### PR TITLE
[MAISTRA-521] Add 'members' on the output of `oc get smmr`

### DIFF
--- a/deploy/maistra-operator.yaml
+++ b/deploy/maistra-operator.yaml
@@ -53,6 +53,11 @@ spec:
   subresources:
     status: {}
   version: v1
+  additionalPrinterColumns:
+  - JSONPath: .spec.members
+    description: Namespaces that are members of this Control Plane
+    name: Members
+    type: string
 
 ---
 

--- a/deploy/servicemesh-operator.yaml
+++ b/deploy/servicemesh-operator.yaml
@@ -53,6 +53,11 @@ spec:
   subresources:
     status: {}
   version: v1
+  additionalPrinterColumns:
+  - JSONPath: .spec.members
+    description: Namespaces membros of this Control Plane
+    name: Members
+    type: string
 
 ---
 


### PR DESCRIPTION
Before:
```
$ oc get smmr --all-namespaces
NAMESPACE   NAME      AGE
i1          default   17m
i2          default   17m
```

After:
```
$ oc get smmr --all-namespaces
NAMESPACE   NAME      MEMBERS
i1          default   [b1]
i2          default   [b2 b3]
```