### PR TITLE
MAISTRA-548 Drop CAP_MKNOD from sidecar container

### DIFF
--- a/tmp/build/patch-charts.sh
+++ b/tmp/build/patch-charts.sh
@@ -106,6 +106,12 @@ function patchTemplates() {
     }
   }' ${HELM_DIR}/istio/templates/sidecar-injector-configmap.yaml
 
+  # drop CAP_MKNOD from sidecar container, so using the anyuid SCC doesn't require the SCC admission controller to mutate the pod
+  sed -i -e 's/^\(.*runAsUser: 1337.*\)$/\1\
+          capabilities:\
+            drop:\
+            - MKNOD/' ${HELM_DIR}/istio/templates/sidecar-injector-configmap.yaml
+
   # - update the namespaceSelector to ignore namespaces with the label maistra.io/ignore-namespace
   # set sidecarInjectorWebhook.enableNamespacesByDefault=true
   sed -i -e '/if \.Values\.enableNamespacesByDefault/,/else/ {


### PR DESCRIPTION
The anyuid SCC requires the MKNOD kernel capability to be dropped. If
the container's spec doesn't drop it, the SCC admission controller tries
to add it, but isn't allowed to, because it tries to do that during the
validation phase (as the sidecar container wasn't injected prior to the
SCC controller running during the mutation phase). Because it can't
mutate the pod, the SCC admission controller rejects it. By dropping the
capability in the sidecar template, the mutation is not required and
thus the pod is marked as valid by the SCC admission controller.