### PR TITLE
MAISTRA-579 Increase memory limit for CNI pods

### DIFF
--- a/helm/istio/charts/istio_cni/templates/daemonset.yaml
+++ b/helm/istio/charts/istio_cni/templates/daemonset.yaml
@@ -100,10 +100,10 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 10Mi
+              memory: 50Mi
             limits:
               cpu: 500m
-              memory: 10Mi
+              memory: 50Mi
       volumes:
         # Used to install CNI.
         - name: cni-bin-dir


### PR DESCRIPTION
Based on my experiments, the minimum memory required to run any pod on
OpenShift 4.1 is around 40MiB. Even if the application itself needs
less memory, around 40MiB is required for the mere initialization of
the pod.