### PR TITLE
[kiali] put all kiali CRs in the kiali-operator namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ oc create -n observability -f https://raw.githubusercontent.com/jaegertracing/ja
 To install the Kiali operator, execute the following command:
 
 ```
-bash <(curl -L https://git.io/getLatestKialiOperator) --operator-image-version v1.0.0 --operator-watch-namespace '**' --accessible-namespaces '**' --operator-install-kiali false
+bash <(curl -L https://git.io/getLatestKialiOperator) --operator-image-version v1.0.0 --accessible-namespaces '**' --operator-install-kiali false
 ```
 
 For more details on installing the Kiali operator, see the [Kiali documentaton](https://www.kiali.io/documentation/getting-started).
@@ -98,7 +98,7 @@ oc delete -n observability -f https://raw.githubusercontent.com/jaegertracing/ja
 To uninstall the Kiali operator, execute the following command:
 
 ```
-bash <(curl -L https://git.io/getLatestKialiOperator) --uninstall-mode true --operator-watch-namespace '**'
+bash <(curl -L https://git.io/getLatestKialiOperator) --uninstall-mode true
 ```
 
 For more details on uninstalling the Kiali operator, see the [Kiali documentaton](https://www.kiali.io/documentation/getting-started/#_uninstall_kiali_operator_and_kiali).

--- a/helm/istio/charts/kiali/templates/kiali-cr.yaml
+++ b/helm/istio/charts/kiali/templates/kiali-cr.yaml
@@ -1,8 +1,8 @@
 apiVersion: kiali.io/v1alpha1
 kind: Kiali
 metadata:
-  name: kiali
-  namespace: {{ .Release.Namespace }}
+  name: "kiali-{{ .Release.Namespace }}"
+  namespace: kiali-operator
 spec:
   installation_tag: "Kiali [{{ .Release.Namespace }}]"
   istio_namespace: "{{ .Release.Namespace }}"


### PR DESCRIPTION
The Kiali CRs are now named `kiail-<control plane namespace>` (e.g. "kiali-istio-system") and all will be stored in the `kiali-operator` namespace.

This now requires the kiali operator to be watching only the namespace named `kiali-operator`. README instructions have been changed to indicate this.

The original code worked fine; this change is solely for security purposes.

Note: We can revert this code back to how it was before once the kiali operator has a validating webhook to prevent regular users from asking kiali to access namespaces that the user has no rights to.

_This is a PoC. Do not merge yet._
