### PR TITLE
MAISTRA-682 - Fixing Kiali CR image_pull_secrets

### DIFF
--- a/helm/istio/charts/kiali/templates/kiali-cr.yaml
+++ b/helm/istio/charts/kiali/templates/kiali-cr.yaml
@@ -22,7 +22,7 @@ spec:
 {{- if .Values.global.imagePullSecrets }}
     image_pull_secrets: 
 {{- range .Values.global.imagePullSecrets }}
-    - name: {{ . }}
+    - {{ . }}
 {{- end }}
 {{- end }}
     image_version: "{{ .Values.tag }}"


### PR DESCRIPTION
On the Kiali CR,

it doesn't need to be used name which is used on helm. Because the kiali-operator does pass the name after receiving the array.

[kiali-kiali-fixed.yaml.log](https://github.com/Maistra/istio-operator/files/3422853/kiali-kiali-fixed.yaml.log)
[kiali-kiali-wrong.yaml.log](https://github.com/Maistra/istio-operator/files/3422854/kiali-kiali-wrong.yaml.log)


