### PR TITLE
Remove README.md reference to controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Maistra Istio Operator
 
-This project is an operator (controller) that can be used to manage the installation of an [Istio](https://istio.io) control plane.
+This project is an operator that can be used to manage the installation of an [Istio](https://istio.io) control plane.
 
 ## Installation
 


### PR DESCRIPTION
This repo is for software which leverages the [operator framework][1] in
a single application focus. While in the most technical sense it _is_ a
controller (insomuch as all operators are controllers, but not all
controllers are operators) as we extend the API through the use of a
custom resource definition it's best to err on the side of brevity
(unlike this commit message).

[1]: https://github.com/operator-framework/getting-started