### PR TITLE
Disabled commented-reviews-by

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,7 +4,7 @@ pull_request_rules:
       - '#approved-reviews-by>=2'
       - '#review-requested=0'
       - '#changes-requested-reviews-by=0'
-      - '#commented-reviews-by=0'
+      #- '#commented-reviews-by=0'
       - label != "work in progress"
       - label = "okay to merge"
       #- status-success=Commit Message Lint


### PR DESCRIPTION
This was disabled in other repos (see: https://github.com/Maistra/rpms/commit/e907bfc0875a8a909bfa3cca141732c9fda02010), but never disabled in istio-operator. Without this change, automatic merging is broken. 