### PR TITLE
MAISTRA-411: generated manifests for maistra and servicemesh

### DIFF
--- a/manifests-maistra/1.0.0/maistra.v1.0.0.clusterserviceversion.yaml
+++ b/manifests-maistra/1.0.0/maistra.v1.0.0.clusterserviceversion.yaml
@@ -1,0 +1,397 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: maistra.v1.0.0
+  namespace: placeholder
+  annotations:
+    categories: "OpenShift Optional, Integration & Delivery"
+    capabilities: "Seamless Upgrades"
+    certified: "false"
+    repository: https://github.com/maistra/istio-operator
+    description: |-
+      The Service Mesh Operator provides means for installing, configuring, and managing an instance of Red Hat OpenShift Service Mesh.
+
+    containerImage: maistra/istio-operator-ubi8:1.0.0
+    createdAt: 2019-08-01T12:13:14PDT
+    support: Red Hat, Inc. 
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "maistra.io/v1",
+          "kind": "ServiceMeshControlPlane",
+          "metadata": {
+            "name": "basic-install"
+          },
+          "spec": {
+            "istio": {
+              "global": {
+                "proxy": {
+                  "resources": {
+                    "requests": {
+                      "cpu": "100m",
+                      "memory": "128Mi"
+                    },
+                    "limits": {
+                      "cpu": "500m",
+                      "memory": "128Mi"
+                    }
+                  }
+                }
+              },
+              "gateways": {
+                "istio-egressgateway": {
+                  "autoscaleEnabled": false
+                },
+                "istio-ingressgateway": {
+                  "autoscaleEnabled": false,
+                  "ior_enabled": false
+                }
+              },
+              "mixer": {
+                "policy": {
+                  "autoscaleEnabled": false
+                },
+                "telemetry": {
+                  "autoscaleEnabled": false,
+                  "resources": {
+                    "requests": {
+                      "cpu": "100m",
+                      "memory": "1G"
+                    },
+                    "limits": {
+                      "cpu": "500m",
+                      "memory": "4G"
+                    }
+                  }
+                }
+              },
+              "pilot": {
+                "autoscaleEnabled": false,
+                "traceSampling": 100.0
+              },
+              "kiali": {
+                "enabled": false
+              },
+              "grafana": {
+                "enabled": false
+              },
+              "tracing": {
+                "enabled": true,
+                "jaeger": {
+                  "template": "all-in-one"
+                }
+              }
+            }
+          }
+        }              
+      ]
+spec:
+  version: 1.0.0
+  maturity: alpha
+  displayName: Red Hat OpenShift Service Mesh
+  description: |-
+    Red Hat OpenShift Service Mesh is a platform that provides behavioral insight and operational control over the service mesh, providing a uniform way to connect, secure, and monitor microservice applications. 
+  keywords: [ 'istio', 'maistra', 'servicemesh' ]
+  maintainers:
+  - name: Red Hat, OpenShift Service Mesh
+    email: istio-feedback@redhat.com
+  provider:
+    name: Red Hat, Inc.
+  links:
+  - name: Service Mesh Operator
+    url: https://github.com/Maistra/istio-operator
+  - name: Istio
+    url: https://istio.io/
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAIAAAAiOjnJAAALkklEQVR4nOzdWVMb2dnAcUGru7W2QICENiMBZhmMx4DHC7vBmM32eMD2+5KpVCUfYKryRfI1cjlVuctlUgHG4/IkEotxzGJiWxKLJLOvkpwKmvI4jFh00NFZ+vldpeIp+5mpf8nN6adb2r7vvtcAkG35pAcAfIKwABYQFsACwgJYQFgACwgLYAFhASwgLIAFhAWwgLAAFhAWwALCAlhAWAALCAtgAWEBLCAsgAWEBbCAsAAWEBbAAsICWEBYAAsIC2ABYQEsIKwTCfl5pEdgGIR1otZrLtIjMAzCOtFQVyXpERgGYZ2otMjYfNVBegpWQVinGeq6THoEVkFYp6krL7pSUUR6CiZBWGd42F5BegQmQVhnaG1wuUpMpKdgD4R1hjyNpr/FS3oK9kBYZxts9Rl1WtJTMAbCOptO0t5vKyc9BWMgrHP5uhMu4TMDYZ1LoVl3p8lNegqWQFjnNdJXQ3oElkBY5+Wxm+vKraSnYAaElYGRXvjQOi8IKwNNtfZKj4X0FGyAsDIz2OIjPQIbIKzMdDZ5rIqO9BQMgLAyo5O1w7AAeA4QVsbuXPcYZLjDcwYIK2OFiq7nVhnpKWgHYaEYaPHCEzyng7BQXCpVWq45SU9BNQgL0dAduIQ/DYSFqNZXVOGGw9ITQVjofgN3eE4GYaFr/tLptsM6fHoQ1oUMNsMdnvQgrAvpb/WZDCLpKWgEYV2ILAoD8KGVDoR1UQ/a4TmLNCCsiyou0Hff8JCegjoQVhaM3INzh+MgrCxw2Uz1lfDukP8BYWUHrMMfA2FlR0O1zW2Dw9JfQFhZ8+QuvKXtFxBW1nQ0eooLYB3+ZxBW1siS0HcbXnj0Mwgrm+CFR59AWNlUYNbdg3X4IxBWlg20+PJgHx7Cyjq33dzeAF9pAWFh0NcMl/AQFgbXqmxVlwpIT0EYhIUF3OGBsLC4Ve+wWfWkpyAJwsLlUYeqHzyEsHAZbPUpRon0FMRAWLhIojCg4q+0gLA0R481Y3lr7YP2CtUelkJYGlkUvsHz/QBWRddzU6V3eCAszaPOCotJxvSb329V6cNhag9L1OZ/g/O9MZcvFV6rKsH3+1NL7WE9vVuF7+MqZaS3GuvvTydVhyVq87/uwP7tS1cvl3jsZtx/Cm1UHdbQnUpzTo6anqpvHV69YZkMItarq8+1N7rNKnt3iHrD6m/24r66+kQShZxFTAmVhmUyiMNdOf3raaDFZ9Kr6ENLpWHdu1mWs4+rFItJblXTi5bVGJbJID7uJnA1/eRuVb5qbvGoMazBFl8hiS9acpaYOprUsg6vurD0sjYHZ1cnUc8TraoL62F7OZGPq5Srl0tqvIWk/vRcUldYeln7/6RvsDzpriI7QG6oK6z7bT6dRPgR+KYv7KVFBrIz5ICKwtLL2qc95O8HH61/8X9YqqKw+pu9lBxR9rd4jXRMgo9awpJFYaSPlmf9RK1w79Yl0lPgpZawHnVWUPJxlfL0bnU+12elqghLpu8ecIFZ7uX6TEsVYWHdakc2yPU6PP9h4d5qR1bhLmiqsZGeAhf+w8rBVjuyhx3cfg8P52HlZqsd2Y06R5lDIT0FFpyHlbOtdmS8rsPzHFYut9qRtTW4LHSnj4bnsHK51Y5M1ApDXbTXj4DbsHK/1Y6sv5nDFy1zG1but9qRmY3SAHfvw+UzLFJb7cged1cJfN3i4TMsUlvtyEqLjV99YSc9RTZxGBbZrXZknF3CcxgW2a12ZPWVJXXl/Hz/L29h0bDVjmy4m58PLd7ComGrHVlTjd1RbCQ9RXZwFRYlW+3IJFEYov5WwTlxFRY9W+3I2htdJi5eeMRPWFRttSNTjHIvF1+lyU9YtG21I3vaU53P/mEpJ2FRuNWOTDFKnY1u0lNcFCdh0bnVjuwx+0taPIRF7VY7Mp/TwvodHh7ConmrHdlDBu9KfY75sCjfakd2vdbuczG8Ds98WPRvtSMbaGH4wUO2w2Jiqx1Z7y1vgZnVv+LZDouJrXZkojZ/mNldGobDYmirHVnfbS+jL1pmOCyGttqRmQwSo694YDUs5rbakQ2z+a/JaljMbbUjs1sN12vZe3cIk2ExutWOjMWdWCbDYnSrHVldefGVCsbW4dkLi+mtdmSDrYy98Ii9sJjeakfW8qXDZTORniIDjIXF+lY7MlHL2Do8Y2FxsNWOrK3BxdD3/7IUFh9b7cjMBqmfnXeHsBQWN1vtyPpbfILAxh0eZsLiaasdWWmR8U6Th/QU58JMWJxttSNj5UYWG2Hxt9WOrMyh1LNwWMpGWFxutSNj4icYBsLidasdWUO1rcJtIT3FGRgIi+OtdmSD1K/D0x4W31vtyHpulRUqVF8b0B4W31vtyLRC/n26b0tTfTcX31Z7MqmZD36Yf7++FNmeXoiuxHZ//c/84Y9/NepFq6LzORWb1SBLQlmp4ik1y6KAY6RMPWgv/9NfXiWSH0kPkh7VYWVrqz2RTM6+XXsTWg+ubL98E42s7a5+SFPSMeHIdup/PJ9e+vz/z9NobFaD2ShZTJLXYXEUGyRR8NjNZQ5FL+fuv6fZIN1vK//z3+Zz9idmhN6wkLfa44nkq8XY26XN0Op2bGN3cjYSWd/L4mAfNZrl2M5ybEej0fw0s3LsV4ssOp/TUlyo10uCo9gkS4KzxOh1KCZD9n/+GO6qhLAyds6t9sN44uVCLLi69X55M7qxNzkb+bC5n5MB04uu70VP6LjALHsdir3IIIuCy2aStIKj2FjmVApQP5VLCg03r5T+OLV0sZGxoDSsk7ba9w8S75Y3gytbM4uxyNru5FxkY/uAxIAo1jb3/ZuraX/JbBDLnIqz2JRqzutUDLLWatEVWfSn/57/11MNYWUgtdW+s3cYXNl6t/zfjKJruxNzke3dQ9KjYbG5czg1F52ai/76l/Sy1utU3DaTJArOo084xSApJtluNWg0mlqftdxlWQiuk5j6NHl9331PeoY06iuL596t7e7HSQ9CNUkUykrNh/HkYniD9CzHUfqJNTkXIT0CAw4OE7Pv1khPkR7tB6SAURAWwALCAlhAWAALSi/ea71Wr5PhN3DmzP5hYiwQ2j9IkB7kOErDmlmM2az6x91VlZ4C0rPQKBTZGvOHpuejP07TeDpK7znWJ+0Nrt8O1LrtZtKDkJdMambffRgLBMcCodDqNulxzkB7WCnNVx2/e1DnUWVeW7uHE7Or44HQWCC0R99feSeh9K/CY8YnwuMT4Rt1pb9/8IXXSfu6d1aEI9tjgeCLlyuB2fS3FynHRlgpz6eXXswsN191fNtXw2Ve8XhyZjE2FghNzUfm31N3+y8jLIV1dJ3xcdQfGp8Idza6h7oqK9w8XNqvbe5Pz0eeTy/99GrlpJUb5rBxjZVWfn5e6zXnE2Z/cny7tBF4vToWCE8vROOJJOlxsozhsD5pa3B921dT5mDj3GvmTez59NKoP/h+ZYv0LBjxEFZKW4NrpLfaR+W112E8MeoP/TAZnni9us7OZuJF8BNWStdXnsfdlynJazm2PfrP0PRC9NlU+COlT9PgwltYKR2NLlKn9h81Gv+rFf/s6rOJ8NvlzdwPQAk+w0rJ5an9zt7h5Fxk7OgYc2cPFl+5DisF66n9cmxnPBB6MbP8j1fHnwNTOcbOsRBk/dQ+nkj+698fxgKhUX/wPA++qhP/YaVc/NR+fWvf/3p1PBCaWYxBT2dSS1jIp/bvlzcn5iKj/uD0fPQgztsxJj78X2Oldfqp/f5hYmYhOjUf/bs/+HZJvT/ZXYRKw/rk81P7eDw5NhF6Nhn2v15dI/qcPgfUHlbK7XrHxvbBzJsorS8FYo+KrrFO8cNkmPQIvIGndAAWEBbAAsICWEBYAAsIC2ABYQEsICyABYQFsICwABYQFsACwgJYQFgACwgLYAFhASwgLIAFhAWwgLAAFhAWwALCAlhAWAALCAtgAWEBLCAsgMV/AgAA//956aWpNSdLJgAAAABJRU5ErkJggg== 
+    mediatype: image/png
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+      - serviceAccountName: istio-operator
+        rules:
+
+        - apiGroups:
+          - ''
+          resources:
+          - configmaps
+          - endpoints
+          - namespaces
+          - persistentvolumeclaims
+          - pods
+          - replicationcontrollers
+          - secrets
+          - serviceaccounts
+          - services
+          - events
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          - extensions
+          resources:
+          - daemonsets
+          - deployments
+          - deployments/finalizers
+          - ingresses
+          - ingresses/status
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - '*'
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - '*'
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          - validatingwebhookconfigurations
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - '*'
+        - apiGroups:
+          - certmanager.k8s.io
+          resources:
+          - clusterissuers
+          verbs:
+          - '*'
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - '*'
+        - apiGroups:
+          - authentication.istio.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - config.istio.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - networking.istio.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.istio.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - jaegertracing.io
+          resources:
+          - jaegers
+          verbs:
+          - '*'
+        - apiGroups:
+          - kiali.io
+          resources:
+          - kialis
+          verbs:
+          - '*'
+        - apiGroups:
+          - maistra.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          - routes/custom-host
+          verbs:
+          - '*'
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - network.openshift.io
+          resources:
+          - clusternetworks
+          verbs:
+          - get
+        - apiGroups:
+          - network.openshift.io
+          resources:
+          - netnamespaces
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+        - apiGroups:
+          - k8s.cni.cncf.io
+          resources:
+          - network-attachment-definitions
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          resourceNames:
+          - privileged
+          verbs:
+          - use
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          resourceNames:
+          - anyuid
+          verbs:
+          - use
+        - apiGroups:
+          - ''
+          resources:
+          - nodes
+          - nodes/proxy
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - nonResourceURLs:
+          - /metrics
+          verbs:
+          - get
+      deployments:
+      - name: istio-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: istio-operator
+          template:
+            metadata:
+              labels:
+                name: istio-operator
+            spec:
+              serviceAccountName: istio-operator
+              volumes:
+              - name: discovery-cache
+                emptyDir:
+                  medium: Memory
+              containers:
+                - name: istio-operator
+                  image: maistra/istio-operator-ubi8:1.0.0
+                  ports:
+                  - containerPort: 60000
+                    name: metrics
+                  command:
+                  - istio-operator
+                  - --discoveryCacheDir
+                  - /home/istio-operator/.kube/cache/discovery
+                  imagePullPolicy: Always
+                  env:
+                    - name: WATCH_NAMESPACE
+                      value: ""
+                    - name: POD_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+                    - name: OPERATOR_NAME
+                      value: "istio-operator"
+                  volumeMounts:
+                  - name: discovery-cache
+                    mountPath: /home/istio-operator/.kube/cache/discovery
+  customresourcedefinitions:
+    required:
+    - name: kialis.kiali.io
+      version: v1alpha1
+      kind: Kiali
+      displayName: Kiali
+      description:  A configuration file for a Kiali installation.
+    - name: jaegers.jaegertracing.io
+      version: v1
+      kind: Jaeger
+      displayName: Jaeger
+      description: A configuration file for a Jaeger installation.  
+    owned:
+    - name: servicemeshmemberrolls.maistra.io
+      version: v1
+      kind: ServiceMeshMemberRoll
+      displayName: Istio Service Mesh Member Roll
+      description: A list of namespaces in Service Mesh
+    - name: servicemeshcontrolplanes.maistra.io
+      version: v1
+      kind: ServiceMeshControlPlane
+      displayName: Istio Service Mesh Control Plane
+      description: An Istio control plane installation
+      specDescriptors:
+      - description: Set to true to install Kiali
+        displayName: Install Kiali
+        path: kiali.enabled
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: Set to false to disable tracing
+        displayName: Enable tracing
+        path: tracing.enabled
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: Set to true to install the Istio 3Scale adapter
+        displayName: Install 3Scale Adapter
+        path: threeScale.enabled
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+        displayName: Default Resource Requirements
+        path: istio.defaultResources
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'

--- a/manifests-maistra/1.0.0/servicemeshcontrolplanes.crd.yaml
+++ b/manifests-maistra/1.0.0/servicemeshcontrolplanes.crd.yaml
@@ -10,7 +10,7 @@ spec:
     plural: servicemeshcontrolplanes
     singular: servicemeshcontrolplane
     shortNames:
-     - smcp
+    - smcp
   scope: Namespaced
   subresources:
     status: {}
@@ -18,7 +18,8 @@ spec:
   additionalPrinterColumns:
   - JSONPath: .status.conditions[?(@.type=="Ready")].status
     name: Ready
-    description: Whether or not the control plane installation is up to date and ready to handle requests.
+    description: Whether or not the control plane installation is up to date and ready
+      to handle requests.
     type: string
   - JSONPath: .status.conditions[?(@.type=="Ready")].message
     name: Status
@@ -27,11 +28,13 @@ spec:
     priority: 1
   - JSONPath: .status.conditions[?(@.type=="Reconciled")].status
     name: Reconciled
-    description: Whether or not the control plane installation is up to date with the latest version of this resource.
+    description: Whether or not the control plane installation is up to date with
+      the latest version of this resource.
     type: string
     priority: 1
   - JSONPath: .status.conditions[?(@.type=="Reconciled")].message
     name: Reconciliation Status
-    description: The status of the reconciliation process, if the control plane is not up to date with the latest version this resource.
+    description: The status of the reconciliation process, if the control plane is
+      not up to date with the latest version this resource.
     type: string
     priority: 1

--- a/manifests-maistra/1.0.0/servicemeshmemberrolls.crd.yaml
+++ b/manifests-maistra/1.0.0/servicemeshmemberrolls.crd.yaml
@@ -10,7 +10,7 @@ spec:
     plural: servicemeshmemberrolls
     singular: servicemeshmemberroll
     shortNames:
-      - smmr
+    - smmr
   scope: Namespaced
   subresources:
     status: {}

--- a/manifests-maistra/maistra.package.yaml
+++ b/manifests-maistra/maistra.package.yaml
@@ -2,3 +2,4 @@ packageName: maistra
 channels:
 - name: alpha
   currentCSV: maistra.v1.0.0
+

--- a/manifests-servicemesh/1.0.0/maistra.v1.0.0.clusterserviceversion.yaml
+++ b/manifests-servicemesh/1.0.0/maistra.v1.0.0.clusterserviceversion.yaml
@@ -9,12 +9,10 @@ metadata:
     certified: "false"
     repository: https://github.com/maistra/istio-operator
     description: |-
-      The Service Mesh Operator provides means for configuring and managing an instance of Red Hat OpenShift Service Mesh.
-      ## Prerequisites and Requirements
-      ### Maistra Operator Namespace
+      The Service Mesh Operator provides means for installing, configuring, and managing an instance of Red Hat OpenShift Service Mesh.
 
-    containerImage: quay.io/maistra/istio-operator-rhel8:latest-qe
-    createdAt: 2019-07-18T08:00:00Z
+    containerImage: registry.redhat.io/openshift-service-mesh/istio-operator-rhel8:1.0.0
+    createdAt: 2019-08-01T12:13:46PDT
     support: Red Hat, Inc. 
     alm-examples: |-
       [
@@ -72,14 +70,16 @@ metadata:
                 "traceSampling": 100.0
               },
               "kiali": {
-                "enabled": true,
-                "dashboard": {
-                  "user": "admin",
-                  "passphrase": "admin"
-                }
+                "enabled": false
+              },
+              "grafana": {
+                "enabled": false
               },
               "tracing": {
-                "enabled": true
+                "enabled": true,
+                "jaeger": {
+                  "template": "all-in-one"
+                }
               }
             }
           }
@@ -120,8 +120,9 @@ spec:
       clusterPermissions:
       - serviceAccountName: istio-operator
         rules:
+
         - apiGroups:
-          - ""
+          - ''
           resources:
           - configmaps
           - endpoints
@@ -132,7 +133,7 @@ spec:
           - secrets
           - serviceaccounts
           - services
-          - events # is this needed?
+          - events
           verbs:
           - '*'
         - apiGroups:
@@ -142,7 +143,7 @@ spec:
           - daemonsets
           - deployments
           - deployments/finalizers
-          - ingresses # is this needed? should it be converted to a route?
+          - ingresses
           - ingresses/status
           - replicasets
           - statefulsets
@@ -243,7 +244,6 @@ spec:
           - routes/custom-host
           verbs:
           - '*'
-        # required by smmr controller
         - apiGroups:
           - authorization.k8s.io
           resources:
@@ -265,7 +265,7 @@ spec:
           - list
           - watch
           - update
-        - apiGroups: 
+        - apiGroups:
           - k8s.cni.cncf.io
           resources:
           - network-attachment-definitions
@@ -276,8 +276,6 @@ spec:
           - list
           - patch
           - watch
-
-        # required by cni daemonset
         - apiGroups:
           - security.openshift.io
           resources:
@@ -286,8 +284,6 @@ spec:
           - privileged
           verbs:
           - use
-
-        # required by ingress gateway
         - apiGroups:
           - security.openshift.io
           resources:
@@ -296,10 +292,8 @@ spec:
           - anyuid
           verbs:
           - use
-
-        # to be removed
         - apiGroups:
-          - ""
+          - ''
           resources:
           - nodes
           - nodes/proxy
@@ -307,14 +301,14 @@ spec:
           - get
           - list
           - watch
-        - apiGroups: # might be required by citadel
+        - apiGroups:
           - authentication.k8s.io
           resources:
           - tokenreviews
           verbs:
           - create
         - nonResourceURLs:
-          - '/metrics'
+          - /metrics
           verbs:
           - get
       deployments:
@@ -336,7 +330,7 @@ spec:
                   medium: Memory
               containers:
                 - name: istio-operator
-                  image: maistra/istio-operator-ubi8:0.12.0
+                  image: registry.redhat.io/openshift-service-mesh/istio-operator-rhel8:1.0.0
                   ports:
                   - containerPort: 60000
                     name: metrics

--- a/manifests-servicemesh/1.0.0/servicemeshcontrolplanes.crd.yaml
+++ b/manifests-servicemesh/1.0.0/servicemeshcontrolplanes.crd.yaml
@@ -1,0 +1,40 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: servicemeshcontrolplanes.maistra.io
+spec:
+  group: maistra.io
+  names:
+    kind: ServiceMeshControlPlane
+    listKind: ServiceMeshControlPlaneList
+    plural: servicemeshcontrolplanes
+    singular: servicemeshcontrolplane
+    shortNames:
+    - smcp
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: Ready
+    description: Whether or not the control plane installation is up to date and ready
+      to handle requests.
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].message
+    name: Status
+    description: The status of the control plane installation.
+    type: string
+    priority: 1
+  - JSONPath: .status.conditions[?(@.type=="Reconciled")].status
+    name: Reconciled
+    description: Whether or not the control plane installation is up to date with
+      the latest version of this resource.
+    type: string
+    priority: 1
+  - JSONPath: .status.conditions[?(@.type=="Reconciled")].message
+    name: Reconciliation Status
+    description: The status of the reconciliation process, if the control plane is
+      not up to date with the latest version this resource.
+    type: string
+    priority: 1

--- a/manifests-servicemesh/1.0.0/servicemeshmemberrolls.crd.yaml
+++ b/manifests-servicemesh/1.0.0/servicemeshmemberrolls.crd.yaml
@@ -1,0 +1,22 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: servicemeshmemberrolls.maistra.io
+spec:
+  group: maistra.io
+  names:
+    kind: ServiceMeshMemberRoll
+    listKind: ServiceMeshMemberRollList
+    plural: servicemeshmemberrolls
+    singular: servicemeshmemberroll
+    shortNames:
+    - smmr
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1
+  additionalPrinterColumns:
+  - JSONPath: .spec.members
+    description: Namespaces that are members of this Control Plane
+    name: Members
+    type: string

--- a/manifests-servicemesh/maistra.package.yaml
+++ b/manifests-servicemesh/maistra.package.yaml
@@ -1,0 +1,5 @@
+packageName: maistra
+channels:
+- name: alpha
+  currentCSV: maistra.v1.0.0
+


### PR DESCRIPTION
This replaces manifests in ```manifests/``` dir with metadata for maistra and servicemesh versions of the operator. Generated using ```generate-metadata.sh``` script.