### PR TITLE
More OLM metadata updates

### DIFF
--- a/manifests-maistra/1.0.0/maistra.v1.0.0.clusterserviceversion.yaml
+++ b/manifests-maistra/1.0.0/maistra.v1.0.0.clusterserviceversion.yaml
@@ -12,7 +12,7 @@ metadata:
       The OpenShift Service Mesh Operator enables you to install, configure, and manage an instance of Red Hat OpenShift Service Mesh.
 
     containerImage: maistra/istio-operator-ubi8:1.0.0
-    createdAt: 2019-08-06T17:47:41PDT
+    createdAt: 2019-08-07T14:31:29PDT
     support: Red Hat, Inc. 
     alm-examples: |-
       [
@@ -119,7 +119,7 @@ spec:
   - type: OwnNamespace
     supported: true
   - type: SingleNamespace
-    supported: true
+    supported: false
   - type: MultiNamespace
     supported: false
   - type: AllNamespaces
@@ -331,6 +331,7 @@ spec:
       deployments:
       - name: istio-operator
         spec:
+
           replicas: 1
           selector:
             matchLabels:
@@ -346,30 +347,30 @@ spec:
                 emptyDir:
                   medium: Memory
               containers:
-                - name: istio-operator
-                  image: maistra/istio-operator-ubi8:1.0.0
-                  ports:
-                  - containerPort: 60000
-                    name: metrics
-                  command:
-                  - istio-operator
-                  - --discoveryCacheDir
-                  - /home/istio-operator/.kube/cache/discovery
-                  imagePullPolicy: Always
-                  env:
-                    - name: WATCH_NAMESPACE
-                      value: ""
-                    - name: POD_NAME
-                      valueFrom:
-                        fieldRef:
-                          fieldPath: metadata.name
-                    - name: OPERATOR_NAME
-                      value: istio-operator
-                    - name: ISTIO_CNI_IMAGE
-                      value: maistra/istio-cni-ubi8:1.0.0
-                  volumeMounts:
-                  - name: discovery-cache
-                    mountPath: /home/istio-operator/.kube/cache/discovery
+              - name: istio-operator
+                image: maistra/istio-operator-ubi8:1.0.0
+                ports:
+                - containerPort: 60000
+                  name: metrics
+                command:
+                - istio-operator
+                - --discoveryCacheDir
+                - /home/istio-operator/.kube/cache/discovery
+                imagePullPolicy: Always
+                env:
+                - name: WATCH_NAMESPACE
+                  value: ''
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: istio-operator
+                - name: ISTIO_CNI_IMAGE
+                  value: maistra/istio-cni-ubi8:1.0.0
+                volumeMounts:
+                - name: discovery-cache
+                  mountPath: /home/istio-operator/.kube/cache/discovery
   customresourcedefinitions:
     required:
     - name: kialis.kiali.io

--- a/manifests-servicemesh/1.0.0/maistra.v1.0.0.clusterserviceversion.yaml
+++ b/manifests-servicemesh/1.0.0/maistra.v1.0.0.clusterserviceversion.yaml
@@ -12,7 +12,7 @@ metadata:
       The OpenShift Service Mesh Operator enables you to install, configure, and manage an instance of Red Hat OpenShift Service Mesh.
 
     containerImage: registry.redhat.io/openshift-service-mesh/istio-operator-rhel8:1.0.0
-    createdAt: 2019-08-06T17:47:45PDT
+    createdAt: 2019-08-07T14:31:36PDT
     support: Red Hat, Inc. 
     alm-examples: |-
       [
@@ -119,7 +119,7 @@ spec:
   - type: OwnNamespace
     supported: true
   - type: SingleNamespace
-    supported: true
+    supported: false
   - type: MultiNamespace
     supported: false
   - type: AllNamespaces
@@ -331,6 +331,7 @@ spec:
       deployments:
       - name: istio-operator
         spec:
+
           replicas: 1
           selector:
             matchLabels:
@@ -346,30 +347,30 @@ spec:
                 emptyDir:
                   medium: Memory
               containers:
-                - name: istio-operator
-                  image: registry.redhat.io/openshift-service-mesh/istio-operator-rhel8:1.0.0
-                  ports:
-                  - containerPort: 60000
-                    name: metrics
-                  command:
-                  - istio-operator
-                  - --discoveryCacheDir
-                  - /home/istio-operator/.kube/cache/discovery
-                  imagePullPolicy: Always
-                  env:
-                    - name: WATCH_NAMESPACE
-                      value: ""
-                    - name: POD_NAME
-                      valueFrom:
-                        fieldRef:
-                          fieldPath: metadata.name
-                    - name: OPERATOR_NAME
-                      value: istio-operator
-                    - name: ISTIO_CNI_IMAGE
-                      value: registry.redhat.io/openshift-service-mesh/istio-cni-rhel8:1.0.0
-                  volumeMounts:
-                  - name: discovery-cache
-                    mountPath: /home/istio-operator/.kube/cache/discovery
+              - name: istio-operator
+                image: registry.redhat.io/openshift-service-mesh/istio-operator-rhel8:1.0.0
+                ports:
+                - containerPort: 60000
+                  name: metrics
+                command:
+                - istio-operator
+                - --discoveryCacheDir
+                - /home/istio-operator/.kube/cache/discovery
+                imagePullPolicy: Always
+                env:
+                - name: WATCH_NAMESPACE
+                  value: ''
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: istio-operator
+                - name: ISTIO_CNI_IMAGE
+                  value: registry.redhat.io/openshift-service-mesh/istio-cni-rhel8:1.0.0
+                volumeMounts:
+                - name: discovery-cache
+                  mountPath: /home/istio-operator/.kube/cache/discovery
   customresourcedefinitions:
     required:
     - name: kialis.kiali.io

--- a/tmp/build/generate-manifests.sh
+++ b/tmp/build/generate-manifests.sh
@@ -40,6 +40,12 @@ function generateCSV() {
      exit 1
   fi
 
+  DEPLOYMENT_SPEC=$(yq -s -r -y '.[] | select(.kind=="Deployment" and .metadata.name=="istio-operator") | .spec' ${DEPLOYMENT_FILE} | sed 's/^/          /')
+  if [ "$DEPLOYMENT_SPEC" == "" ]; then
+     echo "generateCSV(): Operator deployment spec is empty, please verify source yaml/path to the field."
+     exit 1
+  fi
+
   CLUSTER_ROLE_RULES=$(yq -s -y '.[] | select(.kind=="ClusterRole" and .metadata.name=="istio-operator") | .rules' ${DEPLOYMENT_FILE} | sed 's/^/        /')
   if [ "$CLUSTER_ROLE_RULES" == "null" ]; then
      echo "generateCSV(): istio-operator cluster role source is empty, please verify source yaml/path to the field."
@@ -55,6 +61,10 @@ function generateCSV() {
   sed -i -e '/__CLUSTER_ROLE_RULES__/{
     s/__CLUSTER_ROLE_RULES__//
     r '<(echo "$CLUSTER_ROLE_RULES")'
+  }' ${csv_path}
+  sed -i -e '/__DEPLOYMENT_SPEC__/{
+    s/__DEPLOYMENT_SPEC__//
+    r '<(echo "$DEPLOYMENT_SPEC")'
   }' ${csv_path}
 }
 

--- a/tmp/build/manifest-templates/clusterserviceversion.yaml
+++ b/tmp/build/manifest-templates/clusterserviceversion.yaml
@@ -119,7 +119,7 @@ spec:
   - type: OwnNamespace
     supported: true
   - type: SingleNamespace
-    supported: true
+    supported: false
   - type: MultiNamespace
     supported: false
   - type: AllNamespaces
@@ -137,43 +137,7 @@ __CLUSTER_ROLE_RULES__
       deployments:
       - name: istio-operator
         spec:
-          replicas: 1
-          selector:
-            matchLabels:
-              name: istio-operator
-          template:
-            metadata:
-              labels:
-                name: istio-operator
-            spec:
-              serviceAccountName: istio-operator
-              volumes:
-              - name: discovery-cache
-                emptyDir:
-                  medium: Memory
-              containers:
-                - name: istio-operator
-                  image: __IMAGE_SRC__
-                  ports:
-                  - containerPort: 60000
-                    name: metrics
-                  command:
-                  - istio-operator
-                  - --discoveryCacheDir
-                  - /home/istio-operator/.kube/cache/discovery
-                  imagePullPolicy: Always
-                  env:
-                    - name: WATCH_NAMESPACE
-                      value: ""
-                    - name: POD_NAME
-                      valueFrom:
-                        fieldRef:
-                          fieldPath: metadata.name
-                    - name: OPERATOR_NAME
-                      value: "istio-operator"
-                  volumeMounts:
-                  - name: discovery-cache
-                    mountPath: /home/istio-operator/.kube/cache/discovery
+__DEPLOYMENT_SPEC__
   customresourcedefinitions:
     required:
     - name: kialis.kiali.io


### PR DESCRIPTION
* use deployment files as the source for operator deployment spec -- avoids duplication and limits errors
* set installModes/SingleNamespace to false -- prevents users to accidentally deploying the operator to a single namespace only