### PR TITLE
MAISTRA-739 Fix bad invocation of Log.Error()

### DIFF
--- a/pkg/controller/servicemesh/controlplane/reconciler.go
+++ b/pkg/controller/servicemesh/controlplane/reconciler.go
@@ -326,7 +326,7 @@ func (r *ControlPlaneReconciler) renderCharts() error {
 
 	spec, err := r.applyTemplates(r.Status.LastAppliedConfiguration)
 	if err != nil {
-		r.Log.Error(err, "warning: failed to apply ServiceMeshControlPlane templates: %s", err)
+		r.Log.Error(err, "warning: failed to apply ServiceMeshControlPlane templates")
 
 		return err
 	}


### PR DESCRIPTION
The code panicked with: "odd number of arguments passed as key-value
pairs for logging"