### PR TITLE
MAISTRA-726 Handle SMCP disappearing from cache during removal of finalizer

### DIFF
--- a/pkg/controller/servicemesh/controlplane/controller.go
+++ b/pkg/controller/servicemesh/controlplane/controller.go
@@ -174,7 +174,7 @@ func (r *ReconcileControlPlane) Reconcile(request reconcile.Request) (reconcile.
 			return reconcile.Result{}, nil
 		}
 		reqLogger.Info("Deleting ServiceMeshControlPlane")
-		result, err := reconciler.Delete()
+		err := reconciler.Delete()
 		// XXX: for now, nuke the resources, regardless of errors
 		finalizers = append(finalizers[:finalizerIndex], finalizers[finalizerIndex+1:]...)
 		instance.SetFinalizers(finalizers)
@@ -197,9 +197,9 @@ func (r *ReconcileControlPlane) Reconcile(request reconcile.Request) (reconcile.
 		}
 		if err != nil {
 			// return original error, since it's more important than finalizerError
-			return result, err
+			return reconcile.Result{}, err
 		}
-		return result, errors2.Wrapf(finalizerError, "Error removing finalizer from ServiceMeshControlPlane %s/%s", instance.Namespace, instance.Name)
+		return reconcile.Result{}, errors2.Wrapf(finalizerError, "Error removing finalizer from ServiceMeshControlPlane %s/%s", instance.Namespace, instance.Name)
 	} else if finalizerIndex < 0 {
 		reqLogger.V(1).Info("Adding finalizer", "finalizer", finalizer)
 		finalizers = append(finalizers, finalizer)

--- a/pkg/controller/servicemesh/controlplane/deleter.go
+++ b/pkg/controller/servicemesh/controlplane/deleter.go
@@ -2,11 +2,9 @@ package controlplane
 
 import (
 	"fmt"
-
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func (r *ControlPlaneReconciler) Delete() (reconcile.Result, error) {
+func (r *ControlPlaneReconciler) Delete() error {
 	r.Manager.GetRecorder(controllerName).Event(r.Instance, "Normal", "ServiceMeshDeleting", "Deleting service mesh")
 	err := r.prune(-1)
 	defer func() {
@@ -16,5 +14,5 @@ func (r *ControlPlaneReconciler) Delete() (reconcile.Result, error) {
 			r.Manager.GetRecorder(controllerName).Event(r.Instance, "Warning", "ServiceMeshDeleted", fmt.Sprintf("Error occurred during service mesh deletion: %s", err))
 		}
 	}()
-	return reconcile.Result{}, err
+	return err
 }


### PR DESCRIPTION
If the SMCP is deleted, the reconciler deletes resources owned by the
SMCP. This requeues the same SMCP, causing the reconcile to be invoked
again immediately after it has completely deleted the SMCP (i.e. removed
its finalizer). Because the watch event caused by the deletion may
arrive during the invocation of reconcile(), the SMCP object may
disappear from the cache mid-way through. The update will fail with a
conflict, and the get() on the cache will then fail with a NotFound
error. If that happens, reconcile() can safely return without any errors.

If there's any other error during get(), there's no sense in calling
get() again immediately, as that will most likely result in the same
error. This will just result in a flood of errors in the log. Instead,
reconcile() now returns an error, properly requeueing the SMCP with
backoff.