### PR TITLE
[   MAISTRA-749] Reverted grafana patch to pick up settings

### DIFF
--- a/pkg/controller/servicemesh/controlplane/controller_test.go
+++ b/pkg/controller/servicemesh/controlplane/controller_test.go
@@ -91,7 +91,7 @@ func TestCyclicTemplate(t *testing.T) {
 	reconciler := reconcileControlPlane.getOrCreateReconciler(&v1.ServiceMeshControlPlane{})
 	reconciler.Log = log.WithValues()
 
-	_, err := reconciler.recursivelyApplyTemplates(v1.ControlPlaneSpec{Template: "visited"}, map[string]struct{}{"visited": {}})
+	_, err := reconciler.renderSMCPTemplates(v1.ControlPlaneSpec{Template: "visited"}, map[string]struct{}{"visited": {}})
 	if err == nil {
 		t.Fatalf("Expected error to not be nil. Cyclic dependencies should not be allowed.")
 	}

--- a/pkg/controller/servicemesh/controlplane/controller_test.go
+++ b/pkg/controller/servicemesh/controlplane/controller_test.go
@@ -91,7 +91,7 @@ func TestCyclicTemplate(t *testing.T) {
 	reconciler := reconcileControlPlane.getOrCreateReconciler(&v1.ServiceMeshControlPlane{})
 	reconciler.Log = log.WithValues()
 
-	_, err := reconciler.renderSMCPTemplates(v1.ControlPlaneSpec{Template: "visited"}, map[string]struct{}{"visited": {}})
+	_, err := reconciler.recursivelyApplyTemplates(v1.ControlPlaneSpec{Template: "visited"}, map[string]struct{}{"visited": {}})
 	if err == nil {
 		t.Fatalf("Expected error to not be nil. Cyclic dependencies should not be allowed.")
 	}

--- a/tmp/build/patch-grafana.sh
+++ b/tmp/build/patch-grafana.sh
@@ -96,10 +96,28 @@ function grafana_patch_misc() {
   sed -i -e '/grafana-default.yaml.tpl/d' -e '/{{.*end.*}}/d' ${HELM_DIR}/istio/charts/grafana/templates/grafana-ports-mtls.yaml
 }
 
+function grafana_patch_values() {
+  # add annotations and enable ingress
+  sed -i \
+    -e 's|  annotations: {}|  annotations:\n    service.alpha.openshift.io/serving-cert-secret-name: grafana-tls|' \
+    -e '/ingress:/,/enabled/ { s/enabled: .*$/enabled: true/ }' \
+    -e 's+http://prometheus:9090+https://prometheus:9090+' \
+    -e '/access: proxy/ a\
+      basicAuth: true\
+      basicAuthPassword: ""\
+      basicAuthUser: internal\
+      version: 1' \
+    -e 's+^\(\( *\)timeInterval.*\)$+\1\
+\2# we should be using the CA cert in /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt\
+\2tlsSkipVerify: true+' \
+    ${HELM_DIR}/istio/charts/grafana/values.yaml
+}
+
 function GrafanaPatch() {
   echo "Patching Grafana"
 
   grafana_patch_deployment
+	grafana_patch_values
   grafana_patch_service
   grafana_patch_misc
 }


### PR DESCRIPTION
This pr adds grafana_patch_values back in. The grafana configmap is parsed as a string and is not easily mergeable. As such, our options are to include this in patch-grafana.sh for now or to include everything in the base SMCP. This also fixes the unit tests for operator.