### PR TITLE
MAISTRA-830 Add pause at end of successful reconciliation and deletion

### DIFF
--- a/pkg/controller/hacks/hacks.go
+++ b/pkg/controller/hacks/hacks.go
@@ -1,0 +1,21 @@
+package hacks
+
+import (
+	"time"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var log = logf.Log.WithName("hack")
+
+// ReduceLikelihoodOfRepeatedReconciliation simply performs a 2 second delay. Call this function after you post an
+// update to a resource if you want to reduce the likelihood of the reconcile() function being called again before
+// the update comes back into the operator (until it does, any invocation of reconcile() will perform reconciliation on
+// a stale version of the resource). Calling this function prevents the next reconcile() from being invoked immediately,
+// allowing the watch event more time to come back and update the cache.
+//
+// For the complete explanation, see https://issues.jboss.org/projects/MAISTRA/issues/MAISTRA-830
+func ReduceLikelihoodOfRepeatedReconciliation() {
+	log.Info("Waiting 2 seconds to give the cache a chance to sync after updating resource")
+	time.Sleep(2 * time.Second)
+}

--- a/pkg/controller/servicemesh/controlplane/controller.go
+++ b/pkg/controller/servicemesh/controlplane/controller.go
@@ -6,10 +6,11 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	errors2 "github.com/pkg/errors"
+
 	v1 "github.com/maistra/istio-operator/pkg/apis/maistra/v1"
 	"github.com/maistra/istio-operator/pkg/controller/common"
-
-	errors2 "github.com/pkg/errors"
+	"github.com/maistra/istio-operator/pkg/controller/hacks"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -199,6 +200,7 @@ func (r *ReconcileControlPlane) Reconcile(request reconcile.Request) (reconcile.
 			instance.SetFinalizers(finalizers.List())
 			if err := r.Client.Update(context.TODO(), instance); err == nil {
 				reqLogger.Info("Removed finalizer")
+				hacks.ReduceLikelihoodOfRepeatedReconciliation()
 			} else if !(errors.IsGone(err) || errors.IsNotFound(err)) {
 				r.Manager.GetRecorder(controllerName).Event(instance, corev1.EventTypeWarning, eventReasonFailedRemovingFinalizer, fmt.Sprintf("Error occurred removing finalizer from service mesh: %s", err)) // TODO: this event probably isn't needed at all
 				return reconcile.Result{}, errors2.Wrap(err, "Error removing ServiceMeshControlPlane finalizer")


### PR DESCRIPTION
The short pause greatly reduces the chance of the reconciler running twice after updating or deleting the SMCP. 