### PR TITLE
[MAISTRA-748] Remove TLS error messages from OAuth proxies

### DIFF
--- a/tmp/build/patch-grafana.sh
+++ b/tmp/build/patch-grafana.sh
@@ -14,8 +14,10 @@ function grafana_patch_deployment() {
             failureThreshold: 3\
             periodSeconds: 10\
             successThreshold: 1\
-            tcpSocket:\
+            httpGet:\
+              path: /oauth/healthz\
               port: https\
+              scheme: HTTPS\
             timeoutSeconds: 1\
           resources: {}\
           terminationMessagePath: /dev/termination-log\


### PR DESCRIPTION
Oauth container logs had messages like this:
`2019/08/09 16:20:00 server.go:2753: http: TLS handshake error from 10.128.4.1:59806: EOF`

These were cause by two issues:
1. Readiness probes on oauth container using TCP probe.
   This was fixed by switching to a proper HTTPS probe
2. Prometheus trying to scrape itself using the oauth (https) port.
   This will never work, as to access prometheus via OAuth authentication is necessary, so,
   changing schema to https is not enough. The fix here is to exclude this port from scraping.
   Scraping still happens, using the prometheus port (9090) defined on the main prometheus
   container.