### PR TITLE
Remove the explicit configuration of the collector host/port within t…

### DIFF
--- a/helm/istio/charts/tracing/templates/jaeger-all-in-one.yaml
+++ b/helm/istio/charts/tracing/templates/jaeger-all-in-one.yaml
@@ -25,9 +25,6 @@ spec:
       {{- end }}
 
   agent:
-    options:
-      collector:
-        host-port: jaeger-collector:14267
 
   ui:
     options:

--- a/helm/istio/charts/tracing/templates/jaeger-production-elasticsearch.yaml
+++ b/helm/istio/charts/tracing/templates/jaeger-production-elasticsearch.yaml
@@ -33,9 +33,6 @@ spec:
       {{- end }}
 
   agent:
-    options:
-      collector:
-        host-port: jaeger-collector:14267
     annotations:
       {{- range $key, $value := .Values.jaeger.annotations }}
         {{ $key }}: {{ $value | quote }}


### PR DESCRIPTION
…he agent, to enable the jaeger-operator to configure use of load balanced gRPC for reporting spans to the collector

Signed-off-by: Gary Brown <gary@brownuk.com>