### PR TITLE
MAISTRA-889: switch default jaeger configuration over to all-in-one

### DIFF
--- a/deploy/smcp-templates/servicemesh
+++ b/deploy/smcp-templates/servicemesh
@@ -16,7 +16,7 @@ spec:
       image: grafana-rhel8
     tracing:
       jaeger:
-        template: production-elasticsearch
+        template: all-in-one
     galley:
       image: galley-rhel8
     mixer:

--- a/manifests-servicemesh/1.0.0/servicemeshoperator.v1.0.0.clusterserviceversion.yaml
+++ b/manifests-servicemesh/1.0.0/servicemeshoperator.v1.0.0.clusterserviceversion.yaml
@@ -12,7 +12,7 @@ metadata:
       The OpenShift Service Mesh Operator enables you to install, configure, and manage an instance of Red Hat OpenShift Service Mesh. OpenShift Service Mesh is based on the open source Istio project.
 
     containerImage: registry.redhat.io/openshift-service-mesh/istio-rhel8-operator:1.0.0
-    createdAt: 2019-08-23T16:47:06PDT
+    createdAt: 2019-09-04T13:39:05UTC
     support: Red Hat, Inc. 
     alm-examples: |-
       [
@@ -77,7 +77,7 @@ metadata:
               "tracing": {
                 "enabled": true,
                 "jaeger": {
-                  "template": "production-elasticsearch"
+                  "template": "all-in-one"
                 }
               }
             }

--- a/tmp/build/generate-manifests.sh
+++ b/tmp/build/generate-manifests.sh
@@ -13,7 +13,7 @@ if [[ ${COMMUNITY} == "true" ]]; then
   DESCRIPTION="The Maistra Operator enables you to install, configure, and manage an instance of Maistra service mesh. Maistra is based on the open source Istio project."
 else
   BUILD_TYPE="servicemesh"
-  JAEGER_TEMPLATE="production-elasticsearch"
+  JAEGER_TEMPLATE="all-in-one"
   DESCRIPTION="The OpenShift Service Mesh Operator enables you to install, configure, and manage an instance of Red Hat OpenShift Service Mesh. OpenShift Service Mesh is based on the open source Istio project."
 fi
 : ${DEPLOYMENT_FILE:=deploy/${BUILD_TYPE}-operator.yaml}


### PR DESCRIPTION
This is the PR representing the operator changes, rather than rebuild the RPMs we will be updating the container build to override the files within the container.