### PR TITLE
[MAISTRA-877] Jaeger templates: removed agent/collector host:port and UI configurat…

### DIFF
--- a/helm/istio/charts/tracing/templates/jaeger-all-in-one.yaml
+++ b/helm/istio/charts/tracing/templates/jaeger-all-in-one.yaml
@@ -25,22 +25,13 @@ spec:
       {{- end }}
 
   agent:
-    options:
-      collector:
-        host-port: jaeger-collector:14267
-
-  ui:
-    options:
-      dependencies:
-        menuEnabled: false
-      menu:
-        - label: "About Jaeger"
-          items:
-            - label: "Documentation"
-              url: "https://www.jaegertracing.io/docs/latest"
-            - label: "Log Out"
-              url: "/oauth/sign_in"
-              anchorTarget: "_self"
+    {{- if and .Values.jaeger.hub .Values.jaeger.tag .Values.jaeger.agentImage }}
+    image: {{ .Values.jaeger.hub }}/{{ .Values.jaeger.agentImage }}:{{ .Values.jaeger.tag }}
+    {{- end }}
+    annotations:
+      {{- range $key, $value := .Values.jaeger.annotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
 
   storage:
     options:

--- a/helm/istio/charts/tracing/templates/jaeger-production-elasticsearch.yaml
+++ b/helm/istio/charts/tracing/templates/jaeger-production-elasticsearch.yaml
@@ -33,26 +33,13 @@ spec:
       {{- end }}
 
   agent:
-    options:
-      collector:
-        host-port: jaeger-collector:14267
+    {{- if and .Values.jaeger.hub .Values.jaeger.tag .Values.jaeger.agentImage }}
+    image: {{ .Values.jaeger.hub }}/{{ .Values.jaeger.agentImage }}:{{ .Values.jaeger.tag }}
+    {{- end }}
     annotations:
       {{- range $key, $value := .Values.jaeger.annotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
-
-  ui:
-    options:
-      dependencies:
-        menuEnabled: false
-      menu:
-        - label: "About Jaeger"
-          items:
-            - label: "Documentation"
-              url: "https://www.jaegertracing.io/docs/latest"
-            - label: "Log Out"
-              url: "/oauth/sign_in"
-              anchorTarget: "_self"
 
   storage:
     type: elasticsearch


### PR DESCRIPTION
…ion, as the defaults provided by the operator should be used

This PR builds upon https://github.com/Maistra/istio-operator/pull/245 (patch for 1.0) to:
* Remove the collector's agent host:port - so the operator will by default use load balanced gRPC
* Remove the UI configuration, as this default configuration is provided by the operator, and in the next release we will want to override the docs URL with the productised docs.
* Enable the agent image to be overridden as with other images
* Enable annotations to be specified on the agent (consistency issue between two templates)

cc @pavolloffay @jpkrohling