### PR TITLE
MAISTRA-1005 Set Status.ServiceMeshReconciledVersion after reconciling SMMR

### DIFF
--- a/pkg/controller/servicemesh/memberroll/controller.go
+++ b/pkg/controller/servicemesh/memberroll/controller.go
@@ -351,6 +351,7 @@ func (r *ReconcileMemberList) Reconcile(request reconcile.Request) (reconcile.Re
 			}
 		}
 		instance.Status.ServiceMeshGeneration = mesh.Status.ObservedGeneration
+		instance.Status.ServiceMeshReconciledVersion = mesh.Status.GetReconciledVersion()
 	} else if len(unconfiguredMembers) > 0 { // required namespace that was missing has been created
 		reqLogger.Info("Reconciling newly created namespaces associated with this ServiceMeshMemberRoll")
 
@@ -404,6 +405,7 @@ func (r *ReconcileMemberList) Reconcile(request reconcile.Request) (reconcile.Re
 			}
 		}
 		instance.Status.ServiceMeshGeneration = mesh.Status.ObservedGeneration
+		instance.Status.ServiceMeshReconciledVersion = mesh.Status.GetReconciledVersion()
 	} else if len(deletedMembers) > 0 { // namespace that was configured has been deleted
 		// nothing to do, but we need to update the ConfiguredMembers field
 		reqLogger.Info("Removing deleted namespaces from ConfiguredMembers")


### PR DESCRIPTION
This field was introduced as part of the work enabling operator upgrades, but even though we read it, we never set it, leading the operator to always reconcile the SMMR causing issues downstream.

Note that the endless reconciliation loop was triggered by the changing order of configuredMembers: with every `Status.Update()`, we would trigger `Reconcile()` again. As the if-clause was always true (because we did not set `ServiceMeshReconciledVersion`), this would change the order of configuredMembers, which would then trigger `Reconcile()` again, and so on.