### PR TITLE
OSSM-81 Add 'streaming-elasticsearch' template

### DIFF
--- a/deploy/examples/maistra_v1_servicemeshcontrolplane_cr_auth.yaml
+++ b/deploy/examples/maistra_v1_servicemeshcontrolplane_cr_auth.yaml
@@ -70,6 +70,8 @@ spec:
         template: all-in-one
         # production strategy, utilizing elasticsearch
         #template: production-elasticsearch
+        # streaming strategy, utilizing elasticsearch
+        #template: streaming-elasticsearch
         # if required. only one instance may use agentStrategy=DaemonSet
         #agentStrategy: DaemonSet
 

--- a/deploy/examples/maistra_v1_servicemeshcontrolplane_cr_full.yaml
+++ b/deploy/examples/maistra_v1_servicemeshcontrolplane_cr_full.yaml
@@ -65,6 +65,8 @@ spec:
         template: all-in-one
         # production strategy, utilizing elasticsearch
         #template: production-elasticsearch
+        # streaming strategy, utilizing elasticsearch
+        #template: streaming-elasticsearch
         # if required. only one instance may use agentStrategy=DaemonSet
         #agentStrategy: DaemonSet
 

--- a/deploy/examples/maistra_v1_servicemeshcontrolplane_cr_minimal.yaml
+++ b/deploy/examples/maistra_v1_servicemeshcontrolplane_cr_minimal.yaml
@@ -64,6 +64,8 @@ spec:
         template: all-in-one
         # production strategy, utilizing elasticsearch
         #template: production-elasticsearch
+        # streaming strategy, utilizing elasticsearch
+        #template: streaming-elasticsearch
         # if required. only one instance may use agentStrategy=DaemonSet
         #agentStrategy: DaemonSet
 

--- a/helm/istio/charts/tracing/templates/jaeger-streaming-elasticsearch.yaml
+++ b/helm/istio/charts/tracing/templates/jaeger-streaming-elasticsearch.yaml
@@ -1,0 +1,114 @@
+{{ if and (eq .Values.provider "jaeger") (eq .Values.jaeger.template "streaming-elasticsearch") }}
+apiVersion: jaegertracing.io/v1
+kind: "Jaeger"
+metadata:
+  name: "jaeger"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ template "tracing.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  strategy: streaming
+
+  query:
+    {{- if and .Values.jaeger.hub .Values.jaeger.tag .Values.jaeger.queryImage }}
+    image: {{ .Values.jaeger.hub }}/{{ .Values.jaeger.queryImage }}:{{ .Values.jaeger.tag }}
+    {{- end }}
+    options:
+      query:
+        base-path: /
+    annotations:
+      {{- range $key, $value := .Values.jaeger.annotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+
+  collector:
+    {{- if and .Values.jaeger.hub .Values.jaeger.tag .Values.jaeger.collectorImage }}
+    image: {{ .Values.jaeger.hub }}/{{ .Values.jaeger.collectorImage }}:{{ .Values.jaeger.tag }}
+    {{- end }}
+    annotations:
+      {{- range $key, $value := .Values.jaeger.annotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+
+  ingester:
+    {{- if and .Values.jaeger.hub .Values.jaeger.tag .Values.jaeger.ingesterImage }}
+    image: {{ .Values.jaeger.hub }}/{{ .Values.jaeger.ingesterImage }}:{{ .Values.jaeger.tag }}
+    {{- end }}
+    annotations:
+      {{- range $key, $value := .Values.jaeger.annotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+
+  agent:
+    {{- if and .Values.jaeger.hub .Values.jaeger.tag .Values.jaeger.agentImage }}
+    image: {{ .Values.jaeger.hub }}/{{ .Values.jaeger.agentImage }}:{{ .Values.jaeger.tag }}
+    {{- end }}
+    annotations:
+      {{- range $key, $value := .Values.jaeger.annotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+
+  storage:
+    type: elasticsearch
+    elasticsearch:
+{{- if .Values.jaeger.elasticsearch.image }}
+      image: {{ toYaml .Values.jaeger.elasticsearch.image }}
+{{- end }}
+{{- if .Values.jaeger.elasticsearch.nodeCount }}
+      nodeCount: {{ toYaml .Values.jaeger.elasticsearch.nodeCount }}
+{{- else }}
+      nodeCount: 3
+{{- end }}
+{{- if .Values.jaeger.elasticsearch.storage }}
+      storage:
+{{ toYaml .Values.jaeger.elasticsearch.storage | indent 8 }}
+{{- end }}
+{{- if .Values.jaeger.elasticsearch.redundancyPolicy }}
+      redundancyPolicy: {{ toYaml .Values.jaeger.elasticsearch.redundancyPolicy }}
+{{- end }}
+      nodeSelector:
+        {{- range $key, $value := .Values.jaeger.elasticsearch.nodeSelector }}
+          {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      resources:
+{{- if .Values.jaeger.elasticsearch.resources }}
+{{ toYaml .Values.jaeger.elasticsearch.resources | indent 8 }}
+{{- else }}
+        requests:
+          memory: "16Gi"
+          cpu: "1"
+        limits:
+          memory: "16Gi"
+{{- end }}
+
+  ingress:
+    enabled: {{ .Values.ingress.enabled }}
+    # XXX: should this be parameterized?
+    security: oauth-proxy
+    annotations:
+      {{- range $key, $value := .Values.ingress.annotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+    openshift:
+      sar: '{"namespace": "{{ .Release.Namespace }}", "resource": "pods", "verb": "get"}'
+      htpasswdFile: /etc/proxy/htpasswd/auth
+
+  volumeMounts:
+  - name: secret-htpasswd
+    mountPath: /etc/proxy/htpasswd
+  volumes:
+  - name: secret-htpasswd
+    secret:
+      secretName: htpasswd
+  resources:
+{{- if .Values.jaeger.resources }}
+{{ toYaml .Values.jaeger.resources | indent 4 }}
+{{- else }}
+{{ toYaml .Values.global.defaultResources | indent 4 }}
+{{- end }}
+  affinity:
+  {{- include "nodeaffinity" . | indent 2 }}
+
+{{ end }}


### PR DESCRIPTION
NOTE: This PR should not be merged until Jaeger 1.15 is available.

It is an almost exact copy of the `production-elasticsearch` template - with the strategy set to `streaming` and an extra spec element for `ingester` to enable the image and annotations to be configured.

The current "auto-provisioning" support for Kafka requires the user to install the strimzi/AMQ operator before Jaeger (and therefore Maistra). We need to decide whether the AMQ operator should be treated in a similar way to the Elasticsearch Operator, and be "[required](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md#required-crds)" (i.e. in the CSV)?

On one hand, the AMQ operator is not a "required" dependency - Jaeger could run in a production environment without it being present, by simply using elasticsearch storage.

However at the moment it is a convenient mechanism to reduce the work required by the end user to setup the Service Mesh.
