### PR TITLE
MAISTRA-1094 Create ReconcileControlPlane object in helper function

### DIFF
--- a/pkg/controller/servicemesh/controlplane/controller_test.go
+++ b/pkg/controller/servicemesh/controlplane/controller_test.go
@@ -7,7 +7,19 @@ import (
 	v1 "github.com/maistra/istio-operator/pkg/apis/maistra/v1"
 	"github.com/maistra/istio-operator/pkg/controller/common"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func newTestReconciler(client client.Client) *ReconcileControlPlane {
+	return &ReconcileControlPlane{
+		ResourceManager: common.ResourceManager{
+			Client:       client,
+			PatchFactory: common.NewPatchFactory(client),
+			Log:          log,
+		},
+		reconcilers: map[string]*ControlPlaneReconciler{},
+	}
+}
 
 type mergeTestCases struct {
 	name           string
@@ -67,7 +79,7 @@ var mergeTests = []mergeTestCases{
 }
 
 func TestGetSMCPTemplateWithSlashReturnsError(t *testing.T) {
-	reconcileControlPlane := ReconcileControlPlane{}
+	reconcileControlPlane := newTestReconciler(nil)
 	reconciler := reconcileControlPlane.getOrCreateReconciler(&v1.ServiceMeshControlPlane{})
 	reconciler.Log = log.WithValues()
 
@@ -89,7 +101,7 @@ func TestMerge(t *testing.T) {
 }
 
 func TestCyclicTemplate(t *testing.T) {
-	reconcileControlPlane := ReconcileControlPlane{}
+	reconcileControlPlane := newTestReconciler(nil)
 	reconciler := reconcileControlPlane.getOrCreateReconciler(&v1.ServiceMeshControlPlane{})
 	reconciler.Log = log.WithValues()
 


### PR DESCRIPTION
This avoids a nil pointer dereference error when trying to access the reconcilers map.