### PR TITLE
Code refactoring: MAISTRA-1119, MAISTRA-1120, MAISTRA-1123, MAISTRA-1125

### DIFF
--- a/pkg/bootstrap/cni.go
+++ b/pkg/bootstrap/cni.go
@@ -40,14 +40,14 @@ func internalInstallCNI(cl client.Client) error {
 		return err
 	}
 
-	resourceManager := common.ResourceManager{
+	controllerResources := common.ControllerResources{
 		Client:            cl,
 		PatchFactory:      common.NewPatchFactory(cl),
 		Log:               log,
 		OperatorNamespace: operatorNamespace,
 	}
 
-	mp := common.NewManifestProcessor(resourceManager, "istio_cni", "TODO", "maistra-istio-operator", preProcessObject, postProcessObject)
+	mp := common.NewManifestProcessor(controllerResources, "istio_cni", "TODO", "maistra-istio-operator", preProcessObject, postProcessObject)
 	if err = mp.ProcessManifests(renderings["istio_cni"], "istio_cni"); err != nil {
 		return err
 	}

--- a/pkg/bootstrap/cni.go
+++ b/pkg/bootstrap/cni.go
@@ -4,7 +4,7 @@ import (
 	"path"
 	"sync"
 
-	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/maistra/istio-operator/pkg/controller/common"
 
@@ -15,12 +15,12 @@ var installCNITask sync.Once
 
 // InstallCNI makes sure all Istio CNI resources have been created.  CRDs are located from
 // files in controller.HelmDir/istio-init/files
-func InstallCNI(mgr manager.Manager) error {
+func InstallCNI(cl client.Client) error {
 	// we should run through this each reconcile to make sure it's there
-	return internalInstallCNI(mgr)
+	return internalInstallCNI(cl)
 }
 
-func internalInstallCNI(mgr manager.Manager) error {
+func internalInstallCNI(cl client.Client) error {
 	log.Info("ensuring Istio CNI has been installed")
 
 	operatorNamespace := common.GetOperatorNamespace()
@@ -41,8 +41,8 @@ func internalInstallCNI(mgr manager.Manager) error {
 	}
 
 	resourceManager := common.ResourceManager{
-		Client:            mgr.GetClient(),
-		PatchFactory:      common.NewPatchFactory(mgr.GetClient()),
+		Client:            cl,
+		PatchFactory:      common.NewPatchFactory(cl),
 		Log:               log,
 		OperatorNamespace: operatorNamespace,
 	}

--- a/pkg/bootstrap/crds.go
+++ b/pkg/bootstrap/crds.go
@@ -22,22 +22,21 @@ import (
 	"k8s.io/helm/pkg/releaseutil"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 var installCRDsTask sync.Once
 
 // InstallCRDs makes sure all CRDs have been installed.  CRDs are located from
 // files in controller.HelmDir/istio-init/files
-func InstallCRDs(mgr manager.Manager) error {
+func InstallCRDs(cl client.Client) error {
 	// we only try to install them once.  if there's an error, we should probably
 	// panic, as there's no way to recover.  for now, we just pass the error along.
 	var err error
-	installCRDsTask.Do(func() { internalInstallCRDs(mgr, &err) })
+	installCRDsTask.Do(func() { internalInstallCRDs(cl, &err) })
 	return err
 }
 
-func internalInstallCRDs(mgr manager.Manager, err *error) {
+func internalInstallCRDs(cl client.Client, err *error) {
 	log.Info("ensuring CRDs have been installed")
 	// Always install the latest set of CRDs
 	crdPath := path.Join(common.GetHelmDir(common.DefaultMaistraVersion), "istio-init/files")
@@ -51,14 +50,14 @@ func internalInstallCRDs(mgr manager.Manager, err *error) {
 		if err != nil || info.IsDir() {
 			return err
 		}
-		return processCRDFile(mgr, path)
+		return processCRDFile(cl, path)
 	})
 	if *err == nil {
-		*err = installCRDRole(mgr)
+		*err = installCRDRole(cl)
 	}
 }
 
-func installCRDRole(mgr manager.Manager) error {
+func installCRDRole(cl client.Client) error {
 	crdRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "istio-admin",
@@ -67,7 +66,7 @@ func installCRDRole(mgr manager.Manager) error {
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
-			rbacv1.PolicyRule{
+			{
 				APIGroups: []string{
 					"config.istio.io",
 					"networking.istio.io",
@@ -81,16 +80,16 @@ func installCRDRole(mgr manager.Manager) error {
 			},
 		},
 	}
-	if err := mgr.GetClient().Get(context.TODO(), client.ObjectKey{Name: crdRole.Name}, crdRole); err == nil {
+	if err := cl.Get(context.TODO(), client.ObjectKey{Name: crdRole.Name}, crdRole); err == nil {
 		return nil
 	} else if errors.IsNotFound(err) {
-		return mgr.GetClient().Create(context.TODO(), crdRole)
+		return cl.Create(context.TODO(), crdRole)
 	} else {
 		return err
 	}
 }
 
-func processCRDFile(mgr manager.Manager, fileName string) error {
+func processCRDFile(cl client.Client, fileName string) error {
 	allErrors := []error{}
 	buf := &bytes.Buffer{}
 	file, err := os.Open(fileName)
@@ -102,7 +101,6 @@ func processCRDFile(mgr manager.Manager, fileName string) error {
 	if err != nil {
 		return err
 	}
-	k8sClient := mgr.GetClient()
 	for index, raw := range releaseutil.SplitManifests(string(buf.Bytes())) {
 		rawJSON, err := yaml.YAMLToJSON([]byte(raw))
 		if err != nil {
@@ -124,11 +122,11 @@ func processCRDFile(mgr manager.Manager, fileName string) error {
 		receiver := &unstructured.Unstructured{}
 		receiver.SetGroupVersionKind(obj.GroupVersionKind())
 		receiver.SetName(obj.GetName())
-		err = k8sClient.Get(context.TODO(), client.ObjectKey{Name: obj.GetName()}, receiver)
+		err = cl.Get(context.TODO(), client.ObjectKey{Name: obj.GetName()}, receiver)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				log.Info("creating CRD", "file", fileName, "index", index, "CRD", obj.GetName())
-				err = k8sClient.Create(context.TODO(), obj)
+				err = cl.Create(context.TODO(), obj)
 				if err != nil {
 					log.Error(err, "error creating CRD", "file", fileName, "index", index, "CRD", obj.GetName())
 					allErrors = append(allErrors, err)

--- a/pkg/controller/common/manifestprocessing.go
+++ b/pkg/controller/common/manifestprocessing.go
@@ -22,21 +22,21 @@ import (
 )
 
 type ManifestProcessor struct {
-	ResourceManager
+	ControllerResources
 	preprocessObject func(obj *unstructured.Unstructured) error
 	processNewObject func(obj *unstructured.Unstructured) error
 
 	appInstance, appVersion, owner string
 }
 
-func NewManifestProcessor(resourceManager ResourceManager, appInstance, appVersion, owner string, preprocessObjectFunc, postProcessObjectFunc func(obj *unstructured.Unstructured) error) *ManifestProcessor {
+func NewManifestProcessor(controllerResources ControllerResources, appInstance, appVersion, owner string, preprocessObjectFunc, postProcessObjectFunc func(obj *unstructured.Unstructured) error) *ManifestProcessor {
 	return &ManifestProcessor{
-		ResourceManager:  resourceManager,
-		preprocessObject: preprocessObjectFunc,
-		processNewObject: postProcessObjectFunc,
-		appInstance:      appInstance,
-		appVersion:       appVersion,
-		owner:            owner,
+		ControllerResources: controllerResources,
+		preprocessObject:    preprocessObjectFunc,
+		processNewObject:    postProcessObjectFunc,
+		appInstance:         appInstance,
+		appVersion:          appVersion,
+		owner:               owner,
 	}
 }
 

--- a/pkg/controller/common/scc.go
+++ b/pkg/controller/common/scc.go
@@ -5,11 +5,11 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-    "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (r *ResourceManager) AddUsersToSCC(sccName string, users ...string) ([]string, error) {
-    added := make([]string, 0, len(users))
+func (r *ControllerResources) AddUsersToSCC(sccName string, users ...string) ([]string, error) {
+	added := make([]string, 0, len(users))
 	scc := &unstructured.Unstructured{}
 	scc.SetAPIVersion("security.openshift.io/v1")
 	scc.SetKind("SecurityContextConstraints")
@@ -19,17 +19,17 @@ func (r *ResourceManager) AddUsersToSCC(sccName string, users ...string) ([]stri
 		existing, exists, _ := unstructured.NestedStringSlice(scc.UnstructuredContent(), "users")
 		if !exists {
 			existing = []string{}
-        }
-        modified := false
-        for _, user := range users {
-            if IndexOf(existing, user) < 0 {
-                r.Log.Info("Adding ServiceAccount to SecurityContextConstraints", "ServiceAccount", user, "SecurityContextConstraints", sccName)
-                existing = append(existing, user)
-                added = append(added, user)
-                modified = true
-            }    
-        }
-        if modified {
+		}
+		modified := false
+		for _, user := range users {
+			if IndexOf(existing, user) < 0 {
+				r.Log.Info("Adding ServiceAccount to SecurityContextConstraints", "ServiceAccount", user, "SecurityContextConstraints", sccName)
+				existing = append(existing, user)
+				added = append(added, user)
+				modified = true
+			}
+		}
+		if modified {
 			unstructured.SetNestedStringSlice(scc.UnstructuredContent(), existing, "users")
 			err = r.Client.Update(context.TODO(), scc)
 		}
@@ -37,7 +37,7 @@ func (r *ResourceManager) AddUsersToSCC(sccName string, users ...string) ([]stri
 	return added, err
 }
 
-func (r ResourceManager) RemoveUsersFromSCC(sccName string, users ...string) error {
+func (r ControllerResources) RemoveUsersFromSCC(sccName string, users ...string) error {
 	scc := &unstructured.Unstructured{}
 	scc.SetAPIVersion("security.openshift.io/v1")
 	scc.SetKind("SecurityContextConstraints")
@@ -47,16 +47,16 @@ func (r ResourceManager) RemoveUsersFromSCC(sccName string, users ...string) err
 		existing, exists, _ := unstructured.NestedStringSlice(scc.UnstructuredContent(), "users")
 		if !exists {
 			return nil
-        }
-        modified := false
-        for _, user := range users {
-            if index := IndexOf(existing, user); index >= 0 {
-                r.Log.Info("Removing ServiceAccount from SecurityContextConstraints", "ServiceAccount", user, "SecurityContextConstraints", sccName)
-                existing = append(existing[:index], existing[index+1:]...)
-                modified = true
-            }
-        }
-        if modified {
+		}
+		modified := false
+		for _, user := range users {
+			if index := IndexOf(existing, user); index >= 0 {
+				r.Log.Info("Removing ServiceAccount from SecurityContextConstraints", "ServiceAccount", user, "SecurityContextConstraints", sccName)
+				existing = append(existing[:index], existing[index+1:]...)
+				modified = true
+			}
+		}
+		if modified {
 			unstructured.SetNestedStringSlice(scc.UnstructuredContent(), existing, "users")
 			err = r.Client.Update(context.TODO(), scc)
 		}

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -16,8 +18,10 @@ import (
 
 var log = logf.Log.WithName("util")
 
-type ResourceManager struct {
+type ControllerResources struct {
 	Client            client.Client
+	Scheme            *runtime.Scheme
+	EventRecorder     record.EventRecorder
 	PatchFactory      *PatchFactory
 	Log               logr.Logger
 	OperatorNamespace string

--- a/pkg/controller/podlocality/controller.go
+++ b/pkg/controller/podlocality/controller.go
@@ -43,7 +43,7 @@ func Add(mgr manager.Manager) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(cl client.Client, scheme *runtime.Scheme) reconcile.Reconciler {
-	return &PodLocalityReconciler{ResourceManager: common.ResourceManager{Client: cl, PatchFactory: common.NewPatchFactory(cl), Log: log}, scheme: scheme}
+	return &PodLocalityReconciler{ControllerResources: common.ControllerResources{Client: cl, PatchFactory: common.NewPatchFactory(cl), Log: log}, scheme: scheme}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -132,7 +132,7 @@ var _ reconcile.Reconciler = &PodLocalityReconciler{}
 type PodLocalityReconciler struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
-	common.ResourceManager
+	common.ControllerResources
 	scheme *runtime.Scheme
 }
 

--- a/pkg/controller/podlocality/controller.go
+++ b/pkg/controller/podlocality/controller.go
@@ -38,12 +38,12 @@ var log = logf.Log.WithName("controller_podlocality")
 // Add creates a new PodLocality Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
-	return add(mgr, newReconciler(mgr))
+	return add(mgr, newReconciler(mgr.GetClient(), mgr.GetScheme()))
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &PodLocalityReconciler{ResourceManager: common.ResourceManager{Client: mgr.GetClient(), PatchFactory: common.NewPatchFactory(mgr.GetClient()), Log: log}, scheme: mgr.GetScheme()}
+func newReconciler(cl client.Client, scheme *runtime.Scheme) reconcile.Reconciler {
+	return &PodLocalityReconciler{ResourceManager: common.ResourceManager{Client: cl, PatchFactory: common.NewPatchFactory(cl), Log: log}, scheme: scheme}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler

--- a/pkg/controller/servicemesh/controlplane/controller.go
+++ b/pkg/controller/servicemesh/controlplane/controller.go
@@ -8,15 +8,9 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	errors2 "github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	v1 "github.com/maistra/istio-operator/pkg/apis/maistra/v1"
-	"github.com/maistra/istio-operator/pkg/controller/common"
-	"github.com/maistra/istio-operator/pkg/controller/hacks"
-
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -28,6 +22,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	v1 "github.com/maistra/istio-operator/pkg/apis/maistra/v1"
+	"github.com/maistra/istio-operator/pkg/controller/common"
 )
 
 var log = logf.Log.WithName("controller_servicemeshcontrolplane")
@@ -194,71 +191,8 @@ func (r *ControlPlaneReconciler) Reconcile(request reconcile.Request) (reconcile
 			reqLogger.Info("Deletion of ServiceMeshControlPlane complete")
 			return reconcile.Result{}, nil
 		}
-
-		// TODO: move the whole deletion code into reconciler.Delete()
-		reconciledCondition := reconciler.Status.GetCondition(v1.ConditionTypeReconciled)
-		if reconciledCondition.Status != v1.ConditionStatusFalse || reconciledCondition.Reason != v1.ConditionReasonDeleting {
-			reconciler.Status.SetCondition(v1.Condition{
-				Type:    v1.ConditionTypeReconciled,
-				Status:  v1.ConditionStatusFalse,
-				Reason:  v1.ConditionReasonDeleting,
-				Message: "Deleting service mesh",
-			})
-			reconciler.Status.SetCondition(v1.Condition{
-				Type:    v1.ConditionTypeReady,
-				Status:  v1.ConditionStatusFalse,
-				Reason:  v1.ConditionReasonDeleting,
-				Message: "Deleting service mesh",
-			})
-
-			err = reconciler.PostStatus()
-			return reconcile.Result{}, err // return regardless of error; deletion will continue when update event comes back into the operator
-		}
-
-		reqLogger.Info("Deleting ServiceMeshControlPlane")
 		err := reconciler.Delete()
-		if err == nil {
-			// set reconcile status to true to ensure reconciler is deleted from the cache
-			reconciler.Status.SetCondition(v1.Condition{
-				Type:    v1.ConditionTypeReconciled,
-				Status:  v1.ConditionStatusTrue,
-				Reason:  v1.ConditionReasonDeleted,
-				Message: "Service mesh deleted",
-			})
-		} else {
-			reconciler.Status.SetCondition(v1.Condition{
-				Type:    v1.ConditionTypeReconciled,
-				Status:  v1.ConditionStatusFalse,
-				Reason:  v1.ConditionReasonDeletionError,
-				Message: fmt.Sprintf("Error deleting service mesh: %s", err),
-			})
-			statusErr := reconciler.PostStatus()
-			if statusErr != nil {
-				// we must return the original error, thus we can only log the status update error
-				reqLogger.Error(statusErr, "Error updating status")
-			}
-			return reconcile.Result{}, err
-		}
-
-		// get fresh SMCP from cache to minimize the chance of a conflict during update (the SMCP might have been updated during the execution of reconciler.Delete())
-		instance = &v1.ServiceMeshControlPlane{}
-		if err := r.Client.Get(context.TODO(), request.NamespacedName, instance); err == nil {
-			finalizers = sets.NewString(instance.Finalizers...)
-			finalizers.Delete(common.FinalizerName)
-			instance.SetFinalizers(finalizers.List())
-			if err := r.Client.Update(context.TODO(), instance); err == nil {
-				reqLogger.Info("Removed finalizer")
-				hacks.ReduceLikelihoodOfRepeatedReconciliation()
-			} else if !(errors.IsGone(err) || errors.IsNotFound(err)) {
-				r.EventRecorder.Event(instance, corev1.EventTypeWarning, eventReasonFailedRemovingFinalizer, fmt.Sprintf("Error occurred removing finalizer from service mesh: %s", err)) // TODO: this event probably isn't needed at all
-				return reconcile.Result{}, errors2.Wrap(err, "Error removing ServiceMeshControlPlane finalizer")
-			}
-		} else if !(errors.IsGone(err) || errors.IsNotFound(err)) {
-			r.EventRecorder.Event(instance, corev1.EventTypeWarning, eventReasonFailedRemovingFinalizer, fmt.Sprintf("Error occurred removing finalizer from service mesh: %s", err))
-			return reconcile.Result{}, errors2.Wrap(err, "Error getting ServiceMeshControlPlane prior to removing finalizer")
-		}
-
-		return reconcile.Result{}, nil
+		return reconcile.Result{}, err
 	} else if !finalizers.Has(common.FinalizerName) {
 		reqLogger.V(1).Info("Adding finalizer", "finalizer", common.FinalizerName)
 		finalizers.Insert(common.FinalizerName)

--- a/pkg/controller/servicemesh/controlplane/controller_test.go
+++ b/pkg/controller/servicemesh/controlplane/controller_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/maistra/istio-operator/pkg/controller/common"
 )
 
-func newTestReconciler() *ReconcileControlPlane {
+func newTestReconciler() *ControlPlaneReconciler {
 	return newReconciler(nil, scheme.Scheme, nil, "")
 }
 
@@ -73,10 +73,10 @@ var mergeTests = []mergeTestCases{
 }
 
 func TestGetSMCPTemplateWithSlashReturnsError(t *testing.T) {
-	reconcileControlPlane := newTestReconciler()
-	reconciler := reconcileControlPlane.getOrCreateReconciler(&v1.ServiceMeshControlPlane{})
+	reconciler := newTestReconciler()
+	instanceReconciler := reconciler.getOrCreateReconciler(&v1.ServiceMeshControlPlane{})
 
-	_, err := reconciler.getSMCPTemplate("/", common.DefaultMaistraVersion)
+	_, err := instanceReconciler.getSMCPTemplate("/", common.DefaultMaistraVersion)
 	if err == nil {
 		t.Fatalf("Allowed to access path outside of deployment directory")
 	}
@@ -94,10 +94,10 @@ func TestMerge(t *testing.T) {
 }
 
 func TestCyclicTemplate(t *testing.T) {
-	reconcileControlPlane := newTestReconciler()
-	reconciler := reconcileControlPlane.getOrCreateReconciler(&v1.ServiceMeshControlPlane{})
+	reconciler := newTestReconciler()
+	instanceReconciler := reconciler.getOrCreateReconciler(&v1.ServiceMeshControlPlane{})
 
-	_, err := reconciler.recursivelyApplyTemplates(v1.ControlPlaneSpec{Template: "visited"}, "", sets.NewString("visited"))
+	_, err := instanceReconciler.recursivelyApplyTemplates(v1.ControlPlaneSpec{Template: "visited"}, "", sets.NewString("visited"))
 	if err == nil {
 		t.Fatalf("Expected error to not be nil. Cyclic dependencies should not be allowed.")
 	}

--- a/pkg/controller/servicemesh/controlplane/controller_test.go
+++ b/pkg/controller/servicemesh/controlplane/controller_test.go
@@ -5,21 +5,14 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/sets"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/client-go/kubernetes/scheme"
 
 	v1 "github.com/maistra/istio-operator/pkg/apis/maistra/v1"
 	"github.com/maistra/istio-operator/pkg/controller/common"
 )
 
-func newTestReconciler(client client.Client) *ReconcileControlPlane {
-	return &ReconcileControlPlane{
-		ResourceManager: common.ResourceManager{
-			Client:       client,
-			PatchFactory: common.NewPatchFactory(client),
-			Log:          log,
-		},
-		reconcilers: map[string]*ControlPlaneReconciler{},
-	}
+func newTestReconciler() *ReconcileControlPlane {
+	return newReconciler(nil, scheme.Scheme, nil, "")
 }
 
 type mergeTestCases struct {
@@ -80,9 +73,8 @@ var mergeTests = []mergeTestCases{
 }
 
 func TestGetSMCPTemplateWithSlashReturnsError(t *testing.T) {
-	reconcileControlPlane := newTestReconciler(nil)
+	reconcileControlPlane := newTestReconciler()
 	reconciler := reconcileControlPlane.getOrCreateReconciler(&v1.ServiceMeshControlPlane{})
-	reconciler.Log = log.WithValues()
 
 	_, err := reconciler.getSMCPTemplate("/", common.DefaultMaistraVersion)
 	if err == nil {
@@ -102,9 +94,8 @@ func TestMerge(t *testing.T) {
 }
 
 func TestCyclicTemplate(t *testing.T) {
-	reconcileControlPlane := newTestReconciler(nil)
+	reconcileControlPlane := newTestReconciler()
 	reconciler := reconcileControlPlane.getOrCreateReconciler(&v1.ServiceMeshControlPlane{})
-	reconciler.Log = log.WithValues()
 
 	_, err := reconciler.recursivelyApplyTemplates(v1.ControlPlaneSpec{Template: "visited"}, "", sets.NewString("visited"))
 	if err == nil {

--- a/pkg/controller/servicemesh/controlplane/deleter.go
+++ b/pkg/controller/servicemesh/controlplane/deleter.go
@@ -6,7 +6,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func (r *ControlPlaneReconciler) Delete() error {
+func (r *ControlPlaneInstanceReconciler) Delete() error {
 	r.EventRecorder.Event(r.Instance, corev1.EventTypeNormal, eventReasonDeleting, "Deleting service mesh")
 	err := r.prune("")
 	if err == nil {

--- a/pkg/controller/servicemesh/controlplane/deleter.go
+++ b/pkg/controller/servicemesh/controlplane/deleter.go
@@ -7,12 +7,12 @@ import (
 )
 
 func (r *ControlPlaneReconciler) Delete() error {
-	r.Manager.GetRecorder(controllerName).Event(r.Instance, corev1.EventTypeNormal, eventReasonDeleting, "Deleting service mesh")
+	r.EventRecorder.Event(r.Instance, corev1.EventTypeNormal, eventReasonDeleting, "Deleting service mesh")
 	err := r.prune("")
 	if err == nil {
-		r.Manager.GetRecorder(controllerName).Event(r.Instance, corev1.EventTypeNormal, eventReasonDeleted, "Successfully deleted service mesh resources")
+		r.EventRecorder.Event(r.Instance, corev1.EventTypeNormal, eventReasonDeleted, "Successfully deleted service mesh resources")
 	} else {
-		r.Manager.GetRecorder(controllerName).Event(r.Instance, corev1.EventTypeWarning, eventReasonFailedDeletingResources, fmt.Sprintf("Error deleting service mesh resources: %s", err))
+		r.EventRecorder.Event(r.Instance, corev1.EventTypeWarning, eventReasonFailedDeletingResources, fmt.Sprintf("Error deleting service mesh resources: %s", err))
 	}
 	return err
 }

--- a/pkg/controller/servicemesh/controlplane/deleter.go
+++ b/pkg/controller/servicemesh/controlplane/deleter.go
@@ -1,12 +1,41 @@
 package controlplane
 
 import (
+	"context"
 	"fmt"
 
+	errors "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	maistrav1 "github.com/maistra/istio-operator/pkg/apis/maistra/v1"
+	"github.com/maistra/istio-operator/pkg/controller/common"
+	"github.com/maistra/istio-operator/pkg/controller/hacks"
 )
 
 func (r *ControlPlaneInstanceReconciler) Delete() error {
+	reconciledCondition := r.Status.GetCondition(maistrav1.ConditionTypeReconciled)
+	if reconciledCondition.Status != maistrav1.ConditionStatusFalse || reconciledCondition.Reason != maistrav1.ConditionReasonDeleting {
+		r.Status.SetCondition(maistrav1.Condition{
+			Type:    maistrav1.ConditionTypeReconciled,
+			Status:  maistrav1.ConditionStatusFalse,
+			Reason:  maistrav1.ConditionReasonDeleting,
+			Message: "Deleting service mesh",
+		})
+		r.Status.SetCondition(maistrav1.Condition{
+			Type:    maistrav1.ConditionTypeReady,
+			Status:  maistrav1.ConditionStatusFalse,
+			Reason:  maistrav1.ConditionReasonDeleting,
+			Message: "Deleting service mesh",
+		})
+
+		err := r.PostStatus()
+		return err // return regardless of error; deletion will continue when update event comes back into the operator
+	}
+
+	r.Log.Info("Deleting ServiceMeshControlPlane")
+
 	r.EventRecorder.Event(r.Instance, corev1.EventTypeNormal, eventReasonDeleting, "Deleting service mesh")
 	err := r.prune("")
 	if err == nil {
@@ -14,5 +43,47 @@ func (r *ControlPlaneInstanceReconciler) Delete() error {
 	} else {
 		r.EventRecorder.Event(r.Instance, corev1.EventTypeWarning, eventReasonFailedDeletingResources, fmt.Sprintf("Error deleting service mesh resources: %s", err))
 	}
-	return err
+
+	if err == nil {
+		// set reconcile status to true to ensure reconciler is deleted from the cache
+		r.Status.SetCondition(maistrav1.Condition{
+			Type:    maistrav1.ConditionTypeReconciled,
+			Status:  maistrav1.ConditionStatusTrue,
+			Reason:  maistrav1.ConditionReasonDeleted,
+			Message: "Service mesh deleted",
+		})
+	} else {
+		r.Status.SetCondition(maistrav1.Condition{
+			Type:    maistrav1.ConditionTypeReconciled,
+			Status:  maistrav1.ConditionStatusFalse,
+			Reason:  maistrav1.ConditionReasonDeletionError,
+			Message: fmt.Sprintf("Error deleting service mesh: %s", err),
+		})
+		statusErr := r.PostStatus()
+		if statusErr != nil {
+			// we must return the original error, thus we can only log the status update error
+			r.Log.Error(statusErr, "Error updating status")
+		}
+		return err
+	}
+
+	// get fresh SMCP from cache to minimize the chance of a conflict during update (the SMCP might have been updated during the execution of reconciler.Delete())
+	instance := &maistrav1.ServiceMeshControlPlane{}
+	if err := r.Client.Get(context.TODO(), common.ToNamespacedName(r.Instance.ObjectMeta), instance); err == nil {
+		finalizers := sets.NewString(instance.Finalizers...)
+		finalizers.Delete(common.FinalizerName)
+		instance.SetFinalizers(finalizers.List())
+		if err := r.Client.Update(context.TODO(), instance); err == nil {
+			r.Log.Info("Removed finalizer")
+			hacks.ReduceLikelihoodOfRepeatedReconciliation()
+		} else if !(apierrors.IsGone(err) || apierrors.IsNotFound(err)) {
+			r.EventRecorder.Event(instance, corev1.EventTypeWarning, eventReasonFailedRemovingFinalizer, fmt.Sprintf("Error occurred removing finalizer from service mesh: %s", err)) // TODO: this event probably isn't needed at all
+			return errors.Wrap(err, "Error removing ServiceMeshControlPlane finalizer")
+		}
+	} else if !(apierrors.IsGone(err) || apierrors.IsNotFound(err)) {
+		r.EventRecorder.Event(instance, corev1.EventTypeWarning, eventReasonFailedRemovingFinalizer, fmt.Sprintf("Error occurred removing finalizer from service mesh: %s", err))
+		return errors.Wrap(err, "Error getting ServiceMeshControlPlane prior to removing finalizer")
+	}
+
+	return nil
 }

--- a/pkg/controller/servicemesh/controlplane/hooks.go
+++ b/pkg/controller/servicemesh/controlplane/hooks.go
@@ -16,16 +16,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (r *ControlPlaneReconciler) processNewComponent(name string, status *v1.ComponentStatus) error {
+func (r *ControlPlaneInstanceReconciler) processNewComponent(name string, status *v1.ComponentStatus) error {
 	return nil
 }
 
-func (r *ControlPlaneReconciler) processDeletedComponent(name string, status *v1.ComponentStatus) error {
+func (r *ControlPlaneInstanceReconciler) processDeletedComponent(name string, status *v1.ComponentStatus) error {
 	// nop
 	return nil
 }
 
-func (r *ControlPlaneReconciler) preprocessObject(object *unstructured.Unstructured) error {
+func (r *ControlPlaneInstanceReconciler) preprocessObject(object *unstructured.Unstructured) error {
 	// Add owner ref
 	if object.GetNamespace() == r.Instance.GetNamespace() {
 		object.SetOwnerReferences(r.ownerRefs)
@@ -51,15 +51,15 @@ func (r *ControlPlaneReconciler) preprocessObject(object *unstructured.Unstructu
 	return nil
 }
 
-func (r *ControlPlaneReconciler) processNewObject(object *unstructured.Unstructured) error {
+func (r *ControlPlaneInstanceReconciler) processNewObject(object *unstructured.Unstructured) error {
 	return nil
 }
 
-func (r *ControlPlaneReconciler) processDeletedObject(object *unstructured.Unstructured) error {
+func (r *ControlPlaneInstanceReconciler) processDeletedObject(object *unstructured.Unstructured) error {
 	return nil
 }
 
-func (r *ControlPlaneReconciler) patchKialiConfig(object *unstructured.Unstructured) error {
+func (r *ControlPlaneInstanceReconciler) patchKialiConfig(object *unstructured.Unstructured) error {
 	r.Log.Info("patching kiali CR", object.GetKind(), object.GetName())
 
 	// get jaeger URL and enabled flags from Kiali CR
@@ -180,7 +180,7 @@ func (r *ControlPlaneReconciler) patchKialiConfig(object *unstructured.Unstructu
 	return nil
 }
 
-func (r *ControlPlaneReconciler) waitForWebhookCABundleInitialization(object *unstructured.Unstructured) error {
+func (r *ControlPlaneInstanceReconciler) waitForWebhookCABundleInitialization(object *unstructured.Unstructured) error {
 	name := object.GetName()
 	kind := object.GetKind()
 	r.Log.Info("waiting for webhook CABundle initialization", kind, name)

--- a/pkg/controller/servicemesh/controlplane/htpasswd.go
+++ b/pkg/controller/servicemesh/controlplane/htpasswd.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func (r *ControlPlaneReconciler) patchHtpasswdSecret(object *unstructured.Unstructured) error {
+func (r *ControlPlaneInstanceReconciler) patchHtpasswdSecret(object *unstructured.Unstructured) error {
 	var rawPassword, auth string
 
 	htSecret := &corev1.Secret{}
@@ -54,7 +54,7 @@ func (r *ControlPlaneReconciler) patchHtpasswdSecret(object *unstructured.Unstru
 	return nil
 }
 
-func (r *ControlPlaneReconciler) getRawHtPasswd(object *unstructured.Unstructured) (string, error) {
+func (r *ControlPlaneInstanceReconciler) getRawHtPasswd(object *unstructured.Unstructured) (string, error) {
 	htSecret := &corev1.Secret{}
 	err := r.Client.Get(context.TODO(), client.ObjectKey{Namespace: object.GetNamespace(), Name: "htpasswd"}, htSecret)
 	if err != nil {
@@ -65,7 +65,7 @@ func (r *ControlPlaneReconciler) getRawHtPasswd(object *unstructured.Unstructure
 	return string(htSecret.Data["rawPassword"]), nil
 }
 
-func (r *ControlPlaneReconciler) patchGrafanaConfig(object *unstructured.Unstructured) error {
+func (r *ControlPlaneInstanceReconciler) patchGrafanaConfig(object *unstructured.Unstructured) error {
 	dsYaml, found, err := unstructured.NestedString(object.UnstructuredContent(), "data", "datasources.yaml")
 	if err != nil || !found {
 		r.Log.Info("skipping configuration of Grafana-Prometheus link: Could not find/retrieve datasources.yaml from Grafana ConfigMap")

--- a/pkg/controller/servicemesh/controlplane/manifestprocessing.go
+++ b/pkg/controller/servicemesh/controlplane/manifestprocessing.go
@@ -4,7 +4,7 @@ import (
 	"github.com/maistra/istio-operator/pkg/controller/common"
 )
 
-func (r *ControlPlaneReconciler) processComponentManifests(chartName string) (ready bool, err error) {
+func (r *ControlPlaneInstanceReconciler) processComponentManifests(chartName string) (ready bool, err error) {
 	r.lastComponent = ""
 	componentName := componentFromChartName(chartName)
 	origLogger := r.Log

--- a/pkg/controller/servicemesh/controlplane/manifestprocessing.go
+++ b/pkg/controller/servicemesh/controlplane/manifestprocessing.go
@@ -25,7 +25,7 @@ func (r *ControlPlaneInstanceReconciler) processComponentManifests(chartName str
 		r.Log.Info("component reconciliation complete")
 	}()
 
-	mp := common.NewManifestProcessor(r.ResourceManager, r.Instance.GetNamespace(), r.meshGeneration, r.Instance.GetNamespace(), r.preprocessObject, r.processNewObject)
+	mp := common.NewManifestProcessor(r.ControllerResources, r.Instance.GetNamespace(), r.meshGeneration, r.Instance.GetNamespace(), r.preprocessObject, r.processNewObject)
 	if err = mp.ProcessManifests(renderings, status.Resource); err != nil {
 		return
 	}

--- a/pkg/controller/servicemesh/controlplane/pruner.go
+++ b/pkg/controller/servicemesh/controlplane/pruner.go
@@ -70,7 +70,7 @@ var (
 	}
 )
 
-func (r *ControlPlaneReconciler) prune(generation string) error {
+func (r *ControlPlaneInstanceReconciler) prune(generation string) error {
 	allErrors := []error{}
 	err := r.pruneResources(namespacedResources, generation, r.Instance.Namespace)
 	if err != nil {
@@ -87,7 +87,7 @@ func (r *ControlPlaneReconciler) prune(generation string) error {
 	return utilerrors.NewAggregate(allErrors)
 }
 
-func (r *ControlPlaneReconciler) pruneResources(gvks []schema.GroupVersionKind, instanceGeneration string, namespace string) error {
+func (r *ControlPlaneInstanceReconciler) pruneResources(gvks []schema.GroupVersionKind, instanceGeneration string, namespace string) error {
 	allErrors := []error{}
 	labelSelector := map[string]string{common.OwnerKey: r.Instance.Namespace}
 	for _, gvk := range gvks {

--- a/pkg/controller/servicemesh/controlplane/readiness.go
+++ b/pkg/controller/servicemesh/controlplane/readiness.go
@@ -43,7 +43,7 @@ func (r *ControlPlaneReconciler) updateReadinessStatus() (bool, error) {
 			Message: fmt.Sprintf("Error collecting ready state: %s", err),
 		}
 		r.Status.SetCondition(condition)
-		r.Manager.GetRecorder(controllerName).Event(r.Instance, corev1.EventTypeWarning, eventReasonNotReady, condition.Message)
+		r.EventRecorder.Event(r.Instance, corev1.EventTypeWarning, eventReasonNotReady, condition.Message)
 		return true, err
 	}
 	unreadyComponents := make([]string, 0, len(notReadyState))
@@ -64,7 +64,7 @@ func (r *ControlPlaneReconciler) updateReadinessStatus() (bool, error) {
 				Message: "Some components are not fully available",
 			}
 			r.Status.SetCondition(condition)
-			r.Manager.GetRecorder(controllerName).Event(r.Instance, corev1.EventTypeWarning, eventReasonNotReady, fmt.Sprintf("The following components are not fully available: %s", unreadyComponents))
+			r.EventRecorder.Event(r.Instance, corev1.EventTypeWarning, eventReasonNotReady, fmt.Sprintf("The following components are not fully available: %s", unreadyComponents))
 			updateStatus = true
 		}
 	} else {
@@ -76,7 +76,7 @@ func (r *ControlPlaneReconciler) updateReadinessStatus() (bool, error) {
 				Message: "All component deployments are Available",
 			}
 			r.Status.SetCondition(condition)
-			r.Manager.GetRecorder(controllerName).Event(r.Instance, corev1.EventTypeNormal, eventReasonReady, condition.Message)
+			r.EventRecorder.Event(r.Instance, corev1.EventTypeNormal, eventReasonReady, condition.Message)
 			updateStatus = true
 		}
 	}

--- a/pkg/controller/servicemesh/controlplane/readiness.go
+++ b/pkg/controller/servicemesh/controlplane/readiness.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func (r *ControlPlaneReconciler) UpdateReadiness() error {
+func (r *ControlPlaneInstanceReconciler) UpdateReadiness() error {
 	update, err := r.updateReadinessStatus()
 	if update && !r.skipStatusUpdate() {
 		statusErr := r.PostStatus()
@@ -32,7 +32,7 @@ func (r *ControlPlaneReconciler) UpdateReadiness() error {
 	return err
 }
 
-func (r *ControlPlaneReconciler) updateReadinessStatus() (bool, error) {
+func (r *ControlPlaneInstanceReconciler) updateReadinessStatus() (bool, error) {
 	r.Log.Info("Updating ServiceMeshControlPlane readiness state")
 	notReadyState, err := r.calculateNotReadyState()
 	if err != nil {
@@ -84,7 +84,7 @@ func (r *ControlPlaneReconciler) updateReadinessStatus() (bool, error) {
 	return updateStatus, nil
 }
 
-func (r *ControlPlaneReconciler) calculateNotReadyState() (map[string]bool, error) {
+func (r *ControlPlaneInstanceReconciler) calculateNotReadyState() (map[string]bool, error) {
 	var cniNotReady bool
 	notReadyState := map[string]bool{}
 	err := r.calculateNotReadyStateForType(appsv1.SchemeGroupVersion.WithKind("Deployment"), notReadyState, r.deploymentReady)
@@ -104,7 +104,7 @@ func (r *ControlPlaneReconciler) calculateNotReadyState() (map[string]bool, erro
 	return notReadyState, err
 }
 
-func (r *ControlPlaneReconciler) calculateNotReadyStateForCNI() (bool, error) {
+func (r *ControlPlaneInstanceReconciler) calculateNotReadyStateForCNI() (bool, error) {
 	if !common.IsCNIEnabled {
 		return false, nil
 	}
@@ -123,7 +123,7 @@ func (r *ControlPlaneReconciler) calculateNotReadyStateForCNI() (bool, error) {
 	return false, nil
 }
 
-func (r *ControlPlaneReconciler) calculateNotReadyStateForType(gvk schema.GroupVersionKind, notReadyState map[string]bool, isReady func(*unstructured.Unstructured) bool) error {
+func (r *ControlPlaneInstanceReconciler) calculateNotReadyStateForType(gvk schema.GroupVersionKind, notReadyState map[string]bool, isReady func(*unstructured.Unstructured) bool) error {
 	resources, err := common.FetchOwnedResources(r.Client, gvk, r.Instance.GetNamespace(), r.Instance.GetNamespace())
 	if err != nil {
 		return err
@@ -139,7 +139,7 @@ func (r *ControlPlaneReconciler) calculateNotReadyStateForType(gvk schema.GroupV
 	return nil
 }
 
-func (r *ControlPlaneReconciler) deploymentReady(deployment *unstructured.Unstructured) bool {
+func (r *ControlPlaneInstanceReconciler) deploymentReady(deployment *unstructured.Unstructured) bool {
 	conditions, found, err := unstructured.NestedSlice(deployment.UnstructuredContent(), "status", "conditions")
 	if err != nil {
 		r.Log.Error(err, "error reading Deployment.Status", "Deployment", deployment.GetName())
@@ -164,7 +164,7 @@ func (r *ControlPlaneReconciler) deploymentReady(deployment *unstructured.Unstru
 	return false
 }
 
-func (r *ControlPlaneReconciler) statefulSetReady(statefulSet *unstructured.Unstructured) bool {
+func (r *ControlPlaneInstanceReconciler) statefulSetReady(statefulSet *unstructured.Unstructured) bool {
 	replicas, found, err := unstructured.NestedInt64(statefulSet.UnstructuredContent(), "status", "replicas")
 	if err != nil {
 		r.Log.Error(err, "error reading StatefulSet.Status", "StatefulSet", statefulSet.GetName())
@@ -186,7 +186,7 @@ func (r *ControlPlaneReconciler) statefulSetReady(statefulSet *unstructured.Unst
 	return readyReplicas >= replicas
 }
 
-func (r *ControlPlaneReconciler) daemonSetReady(daemonSet *unstructured.Unstructured) bool {
+func (r *ControlPlaneInstanceReconciler) daemonSetReady(daemonSet *unstructured.Unstructured) bool {
 	unavailable, found, err := unstructured.NestedInt64(daemonSet.UnstructuredContent(), "status", "numberUnavailable")
 	if err != nil {
 		r.Log.Error(err, "error reading DaemonSet.Status", "DaemonSet", daemonSet.GetName())

--- a/pkg/controller/servicemesh/controlplane/reconciler.go
+++ b/pkg/controller/servicemesh/controlplane/reconciler.go
@@ -28,7 +28,7 @@ import (
 )
 
 type ControlPlaneInstanceReconciler struct {
-	*ControlPlaneReconciler
+	common.ControllerResources
 	Instance       *v1.ServiceMeshControlPlane
 	Status         *v1.ControlPlaneStatus
 	ownerRefs      []metav1.OwnerReference

--- a/pkg/controller/servicemesh/controlplane/reconciler.go
+++ b/pkg/controller/servicemesh/controlplane/reconciler.go
@@ -180,7 +180,7 @@ func (r *ControlPlaneReconciler) Reconcile() (result reconcile.Result, err error
 		r.meshGeneration = v1.CurrentReconciledVersion(r.Instance.GetGeneration())
 
 		// Ensure CRDs are installed
-		if err = bootstrap.InstallCRDs(r.Manager); err != nil {
+		if err = bootstrap.InstallCRDs(r.Client); err != nil {
 			reconciliationReason = v1.ConditionReasonReconcileError
 			reconciliationMessage = "Failed to install/update Istio CRDs"
 			r.Log.Error(err, reconciliationMessage)
@@ -190,7 +190,7 @@ func (r *ControlPlaneReconciler) Reconcile() (result reconcile.Result, err error
 		// Ensure Istio CNI is installed
 		if common.IsCNIEnabled {
 			r.lastComponent = "cni"
-			if err = bootstrap.InstallCNI(r.Manager); err != nil {
+			if err = bootstrap.InstallCNI(r.Client); err != nil {
 				reconciliationReason = v1.ConditionReasonReconcileError
 				reconciliationMessage = "Failed to install/update Istio CNI"
 				r.Log.Error(err, reconciliationMessage)
@@ -251,7 +251,7 @@ func (r *ControlPlaneReconciler) Reconcile() (result reconcile.Result, err error
 	// it's possible that some resources in the original version may not be present in the new version.
 	// delete unseen components
 	reconciliationMessage = "Pruning obsolete resources"
-	r.Manager.GetRecorder(controllerName).Event(r.Instance, corev1.EventTypeNormal, eventReasonPruning, reconciliationMessage)
+	r.EventRecorder.Event(r.Instance, corev1.EventTypeNormal, eventReasonPruning, reconciliationMessage)
 	r.Log.Info(reconciliationMessage)
 	err = r.prune(r.meshGeneration)
 	if err != nil {
@@ -264,11 +264,11 @@ func (r *ControlPlaneReconciler) Reconcile() (result reconcile.Result, err error
 	if r.isUpdating() {
 		reconciliationReason = v1.ConditionReasonUpdateSuccessful
 		reconciliationMessage = fmt.Sprintf("Successfully updated from version %s to version %s", r.Status.GetReconciledVersion(), r.meshGeneration)
-		r.Manager.GetRecorder(controllerName).Event(r.Instance, corev1.EventTypeNormal, eventReasonUpdated, reconciliationMessage)
+		r.EventRecorder.Event(r.Instance, corev1.EventTypeNormal, eventReasonUpdated, reconciliationMessage)
 	} else {
 		reconciliationReason = v1.ConditionReasonInstallSuccessful
 		reconciliationMessage = fmt.Sprintf("Successfully installed version %s", r.meshGeneration)
-		r.Manager.GetRecorder(controllerName).Event(r.Instance, corev1.EventTypeNormal, eventReasonInstalled, reconciliationMessage)
+		r.EventRecorder.Event(r.Instance, corev1.EventTypeNormal, eventReasonInstalled, reconciliationMessage)
 	}
 	r.Status.ObservedGeneration = r.Instance.GetGeneration()
 	r.Status.ReconciledVersion = r.meshGeneration
@@ -296,7 +296,7 @@ func (r *ControlPlaneReconciler) pauseReconciliation(chartName string, err error
 	componentName := componentFromChartName(chartName)
 	if err == nil {
 		reconciliationMessage = fmt.Sprintf("Paused until %s becomes ready", componentName)
-		r.Manager.GetRecorder(controllerName).Event(r.Instance, corev1.EventTypeNormal, eventReason, reconciliationMessage)
+		r.EventRecorder.Event(r.Instance, corev1.EventTypeNormal, eventReason, reconciliationMessage)
 		r.Log.Info(reconciliationMessage)
 	} else {
 		conditionReason = v1.ConditionReasonReconcileError
@@ -520,7 +520,7 @@ func (r *ControlPlaneReconciler) postReconciliationStatus(reconciliationReason v
 	} else {
 		// grab the cause, as it's likely the error includes the reconciliation message
 		reconciledCondition.Message = fmt.Sprintf("%s: error: %s", reconciliationMessage, errors.Cause(processingErr))
-		r.Manager.GetRecorder(controllerName).Event(r.Instance, corev1.EventTypeWarning, reason, reconciledCondition.Message)
+		r.EventRecorder.Event(r.Instance, corev1.EventTypeWarning, reason, reconciledCondition.Message)
 	}
 	r.Status.SetCondition(reconciledCondition)
 
@@ -567,7 +567,7 @@ func (r *ControlPlaneReconciler) initializeReconcileStatus() {
 			Message: readyMessage,
 		})
 	}
-	r.Manager.GetRecorder(controllerName).Event(r.Instance, corev1.EventTypeNormal, eventReason, readyMessage)
+	r.EventRecorder.Event(r.Instance, corev1.EventTypeNormal, eventReason, readyMessage)
 	r.Status.SetCondition(v1.Condition{
 		Type:    v1.ConditionTypeReconciled,
 		Status:  v1.ConditionStatusFalse,

--- a/pkg/controller/servicemesh/member/controller.go
+++ b/pkg/controller/servicemesh/member/controller.go
@@ -45,19 +45,19 @@ var log = logf.Log.WithName(controllerName)
 // Add creates a new ServiceMeshMember Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
-	return add(mgr, newReconciler(mgr))
+	return add(mgr, newReconciler(mgr.GetClient(), mgr.GetScheme(), mgr.GetRecorder(controllerName)))
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager) *MemberReconciler {
+func newReconciler(cl client.Client, scheme *runtime.Scheme, eventRecorder record.EventRecorder) *MemberReconciler {
 	return &MemberReconciler{
 		ResourceManager: common.ResourceManager{
-			Client:       mgr.GetClient(),
-			PatchFactory: common.NewPatchFactory(mgr.GetClient()),
+			Client:       cl,
+			PatchFactory: common.NewPatchFactory(cl),
 			Log:          log,
 		},
-		scheme:        mgr.GetScheme(),
-		eventRecorder: mgr.GetRecorder(controllerName),
+		scheme:        scheme,
+		eventRecorder: eventRecorder,
 	}
 }
 

--- a/pkg/controller/servicemesh/member/controller_test.go
+++ b/pkg/controller/servicemesh/member/controller_test.go
@@ -357,7 +357,7 @@ func newMemberRoll() *maistra.ServiceMeshMemberRoll {
 func createClientAndReconciler(t *testing.T, clientObjects ...runtime.Object) (client.Client, *test.EnhancedTracker, *MemberReconciler) {
 	cl, enhancedTracker := test.CreateClient(clientObjects...)
 	fakeEventRecorder := &record.FakeRecorder{}
-	r := &MemberReconciler{ResourceManager: common.ResourceManager{Client: cl, PatchFactory: common.NewPatchFactory(cl), Log: log}, scheme: scheme.Scheme, eventRecorder: fakeEventRecorder}
+	r := newReconciler(cl, scheme.Scheme, fakeEventRecorder)
 	return cl, enhancedTracker, r
 }
 

--- a/pkg/controller/servicemesh/memberroll/controller.go
+++ b/pkg/controller/servicemesh/memberroll/controller.go
@@ -45,13 +45,13 @@ func Add(mgr manager.Manager) error {
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(cl client.Client, scheme *runtime.Scheme, eventRecorder record.EventRecorder, namespaceReconcilerFactory NamespaceReconcilerFactory, kialiReconciler KialiReconciler) *MemberRollReconciler {
 	return &MemberRollReconciler{
-		ResourceManager: common.ResourceManager{
-			Client:       cl,
-			PatchFactory: common.NewPatchFactory(cl),
-			Log:          log,
+		ControllerResources: common.ControllerResources{
+			Client:        cl,
+			Scheme:        scheme,
+			EventRecorder: eventRecorder,
+			PatchFactory:  common.NewPatchFactory(cl),
+			Log:           log,
 		},
-		scheme:                     scheme,
-		eventRecorder:              eventRecorder,
 		namespaceReconcilerFactory: namespaceReconcilerFactory,
 		kialiReconciler:            kialiReconciler,
 	}
@@ -159,11 +159,7 @@ type NamespaceReconcilerFactory func(cl client.Client, logger logr.Logger, meshN
 
 // MemberRollReconciler reconciles a ServiceMeshMemberRoll object
 type MemberRollReconciler struct {
-	// This client, initialized using mgr.Client() above, is a split client
-	// that reads objects from the cache and writes to the apiserver
-	common.ResourceManager
-	scheme        *runtime.Scheme
-	eventRecorder record.EventRecorder
+	common.ControllerResources
 
 	namespaceReconcilerFactory NamespaceReconcilerFactory
 	kialiReconciler            KialiReconciler

--- a/pkg/controller/servicemesh/memberroll/controller_test.go
+++ b/pkg/controller/servicemesh/memberroll/controller_test.go
@@ -620,7 +620,7 @@ func TestClientReturnsErrorWhenRemovingFinalizer(t *testing.T) {
 	}
 }
 
-func createClientAndReconciler(t *testing.T, clientObjects ...runtime.Object) (client.Client, *test.EnhancedTracker, *ReconcileMemberList, *fakeNamespaceReconciler, *fakeKialiReconciler) {
+func createClientAndReconciler(t *testing.T, clientObjects ...runtime.Object) (client.Client, *test.EnhancedTracker, *MemberRollReconciler, *fakeNamespaceReconciler, *fakeKialiReconciler) {
 
 	cl, enhancedTracker := test.CreateClient(clientObjects...)
 
@@ -662,7 +662,7 @@ func (r *fakeNamespaceReconciler) removeNamespaceFromMesh(namespace string) erro
 	return r.delegate.removeNamespaceFromMesh(namespace)
 }
 
-func assertReconcileSucceeds(r *ReconcileMemberList, t *testing.T) {
+func assertReconcileSucceeds(r *MemberRollReconciler, t *testing.T) {
 	res, err := r.Reconcile(request)
 	if err != nil {
 		log.Error(err, "Reconcile failed")
@@ -673,7 +673,7 @@ func assertReconcileSucceeds(r *ReconcileMemberList, t *testing.T) {
 	}
 }
 
-func assertReconcileFails(r *ReconcileMemberList, t *testing.T) {
+func assertReconcileFails(r *MemberRollReconciler, t *testing.T) {
 	_, err := r.Reconcile(request)
 	if err == nil {
 		t.Fatal("Expected reconcile to fail, but it didn't")

--- a/pkg/controller/servicemesh/memberroll/ovs_multitenant.go
+++ b/pkg/controller/servicemesh/memberroll/ovs_multitenant.go
@@ -11,11 +11,12 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/maistra/istio-operator/pkg/controller/common"
 )
 
 type multitenantStrategy struct {
-	client        client.Client
-	logger        logr.Logger
+	common.ControllerResources
 	meshNamespace string
 }
 
@@ -27,40 +28,42 @@ var netNamespaceCheckBackOff = wait.Backoff{
 	Factor:   1.1,
 }
 
-func newMultitenantStrategy(client client.Client, baseLogger logr.Logger, meshNamespace string) (*multitenantStrategy, error) {
+func newMultitenantStrategy(cl client.Client, baseLogger logr.Logger, meshNamespace string) (*multitenantStrategy, error) {
 	return &multitenantStrategy{
-		client:        client,
-		logger:        baseLogger.WithValues("NetworkStrategy", "Multitenant"),
+		ControllerResources: common.ControllerResources{
+			Client: cl,
+			Log:    baseLogger.WithValues("NetworkStrategy", "Multitenant"),
+		},
 		meshNamespace: meshNamespace,
 	}, nil
 }
 
 func (s *multitenantStrategy) reconcileNamespaceInMesh(namespace string) error {
-	s.logger.Info("joining network to mesh", "Namespace", namespace)
+	s.Log.Info("joining network to mesh", "Namespace", namespace)
 	return s.updateNetworkNamespace(namespace, networkapihelpers.JoinPodNetwork, s.meshNamespace)
 }
 
 func (s *multitenantStrategy) removeNamespaceFromMesh(namespace string) error {
-	s.logger.Info("isolating network", "Namespace", namespace)
+	s.Log.Info("isolating network", "Namespace", namespace)
 	return s.updateNetworkNamespace(namespace, networkapihelpers.IsolatePodNetwork, "")
 }
 
 // adapted from github.com/openshift/oc/pkg/cli/admin/network/project_options.go#UpdatePodNetwork()
 func (s *multitenantStrategy) updateNetworkNamespace(namespace string, action networkapihelpers.PodNetworkAction, args string) error {
 	netns := &network.NetNamespace{}
-	err := s.client.Get(context.TODO(), client.ObjectKey{Name: namespace}, netns)
+	err := s.Client.Get(context.TODO(), client.ObjectKey{Name: namespace}, netns)
 	if err != nil {
 		return err
 	}
 	networkapihelpers.SetChangePodNetworkAnnotation(netns, action, args)
-	err = s.client.Update(context.TODO(), netns)
+	err = s.Client.Update(context.TODO(), netns)
 	if err != nil {
 		return err
 	}
 	// Validate SDN controller applied or rejected the intent
 	return wait.ExponentialBackoff(netNamespaceCheckBackOff, func() (bool, error) {
 		updatedNetNs := &network.NetNamespace{}
-		err := s.client.Get(context.TODO(), client.ObjectKey{Name: namespace}, updatedNetNs)
+		err := s.Client.Get(context.TODO(), client.ObjectKey{Name: namespace}, updatedNetNs)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/controller/servicemesh/mutatingwebhook/controller.go
+++ b/pkg/controller/servicemesh/mutatingwebhook/controller.go
@@ -39,7 +39,7 @@ func Add(mgr manager.Manager) error {
 }
 
 func newReconciler(cl client.Client, scheme *runtime.Scheme) reconcile.Reconciler {
-	return &reconciler{ResourceManager: common.ResourceManager{Client: cl, Log: log}, scheme: scheme}
+	return &reconciler{ControllerResources: common.ControllerResources{Client: cl, Scheme: scheme, Log: log}}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -105,8 +105,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 // reconciles webhook configurations
 type reconciler struct {
-	common.ResourceManager
-	scheme *runtime.Scheme
+	common.ControllerResources
 }
 
 // Reconcile updates ClientConfigs of MutatingWebhookConfigurations to contain the CABundle

--- a/pkg/controller/servicemesh/mutatingwebhook/controller.go
+++ b/pkg/controller/servicemesh/mutatingwebhook/controller.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"strings"
 
-	"github.com/maistra/istio-operator/pkg/controller/common"
 	"k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/maistra/istio-operator/pkg/controller/common"
 
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -33,11 +35,11 @@ var (
 // Add creates a new Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
-	return add(mgr, newReconciler(mgr))
+	return add(mgr, newReconciler(mgr.GetClient(), mgr.GetScheme()))
 }
 
-func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &reconciler{ResourceManager: common.ResourceManager{Client: mgr.GetClient(), Log: log}, scheme: mgr.GetScheme()}
+func newReconciler(cl client.Client, scheme *runtime.Scheme) reconcile.Reconciler {
+	return &reconciler{ResourceManager: common.ResourceManager{Client: cl, Log: log}, scheme: scheme}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler

--- a/pkg/controller/servicemesh/validatingwebhook/controller.go
+++ b/pkg/controller/servicemesh/validatingwebhook/controller.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"strings"
 
-	"github.com/maistra/istio-operator/pkg/controller/common"
 	"k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/maistra/istio-operator/pkg/controller/common"
 
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -33,11 +35,11 @@ var (
 // Add creates a new Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
-	return add(mgr, newReconciler(mgr))
+	return add(mgr, newReconciler(mgr.GetClient(), mgr.GetScheme()))
 }
 
-func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &reconciler{ResourceManager: common.ResourceManager{Client: mgr.GetClient(), Log: log}, scheme: mgr.GetScheme()}
+func newReconciler(cl client.Client, scheme *runtime.Scheme) reconcile.Reconciler {
+	return &reconciler{ResourceManager: common.ResourceManager{Client: cl, Log: log}, scheme: scheme}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler

--- a/pkg/controller/servicemesh/validatingwebhook/controller.go
+++ b/pkg/controller/servicemesh/validatingwebhook/controller.go
@@ -39,7 +39,7 @@ func Add(mgr manager.Manager) error {
 }
 
 func newReconciler(cl client.Client, scheme *runtime.Scheme) reconcile.Reconciler {
-	return &reconciler{ResourceManager: common.ResourceManager{Client: cl, Log: log}, scheme: scheme}
+	return &reconciler{ControllerResources: common.ControllerResources{Client: cl, Scheme: scheme, Log: log}}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -105,8 +105,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 // reconciles webhook configurations
 type reconciler struct {
-	common.ResourceManager
-	scheme *runtime.Scheme
+	common.ControllerResources
 }
 
 // Reconcile updates ClientConfigs of ValidatingWebhookConfigurations to contain the CABundle


### PR DESCRIPTION
Includes:
- MAISTRA-1119 Remove dependency on Controller Manager from all controllers
- MAISTRA-1120 Rename ReconcileControlPlane/ReconcileMemberList structs
- MAISTRA-1123 Refactor code: move deletion code from controller.go to deleter.go
- MAISTRA-1125 Refactor: Clean up ResourceManager and its usages