### PR TITLE
feat: sets up up basic CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+version: 2.1
+jobs:
+
+  build:
+    working_directory: /go/src/github.com/maistra/istio-operator
+    docker:
+      - image: circleci/golang:1.13.6
+    steps:
+      - checkout
+      - run: make clean compile test
+
+workflows:
+  version: 2.1
+  circleci_build:
+    jobs:
+      - build

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,9 @@ OFFLINE_BUILD       ?= false
 GIT_UPSTREAM_REMOTE ?= $(shell git remote -v |grep --color=never ':Maistra/istio-operator\.git.*(fetch)' |grep --color=never -o '^[^[:space:]]*')
 
 ifeq "${GIT_UPSTREAM_REMOTE}" ""
-$(error Could not find git remote for Maistra/istio-operator)
+$(warning Could not find git remote for Maistra/istio-operator. Adding default one)
+$(shell git remote add upstream git@github.com:Maistra/istio-operator.git)
+GIT_UPSTREAM_REMOTE = upstream
 endif
 
 ifeq "${COMMUNITY}" "true"


### PR DESCRIPTION
This PR brings setup of a build running tests on every PR and merge to master using CirleCI free tier. Additionally, it fixes a little glitch in `Makefile` which assumes that there's always fork and upstream remote defined for the cloned git repository, which is not the case when running as the CircleCI job.

You can see the build on master in my fork: https://github.com/bartoszmajsak/istio-operator/commits/maistra-1.1

and the PR with the failing tests - https://github.com/bartoszmajsak/istio-operator/pull/1


CircleCI is enabled for Maistra organization on GitHub so after merging this PR, the repository needs to be enabled on CircleCI side (which is one click resulting in webhook config for that repo). Happy to do that.