### PR TITLE
MAISTRA-1129 reconcileNamespaces should return all configuredNamespaces

### DIFF
--- a/pkg/controller/common/test/assert/asserts.go
+++ b/pkg/controller/common/test/assert/asserts.go
@@ -50,3 +50,12 @@ func StringArrayNotEmpty(actual []string, message string, t *testing.T) {
 		t.Fatalf("%s. Actual: %v", message, actual)
 	}
 }
+
+func StringArrayContains(actual []string, containedString, message string, t *testing.T) {
+	for _, str := range actual {
+		if str == containedString {
+			return
+		}
+	}
+	t.Fatalf("%s: %s not found in %v", message, containedString, actual)
+}

--- a/pkg/controller/servicemesh/memberroll/namespace_reconciler_test.go
+++ b/pkg/controller/servicemesh/memberroll/namespace_reconciler_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestReconcileNamespaceInMesh(t *testing.T) {
-	namespace := newAppNamespace()
+	namespace := newNamespace(appNamespace)
 	meshRoleBinding := newMeshRoleBinding()
 	meshRoleBindings := []*rbac.RoleBinding{meshRoleBinding}
 	cl, _ := test.CreateClient(namespace, meshRoleBinding)
@@ -61,7 +61,7 @@ func TestReconcileNamespaceInMesh(t *testing.T) {
 }
 
 func TestReconcileFailsIfNamespaceIsPartOfAnotherMesh(t *testing.T) {
-	namespace := newAppNamespace()
+	namespace := newNamespace(appNamespace)
 	namespace.Labels = map[string]string{
 		common.MemberOfKey: "other-control-plane",
 	}
@@ -71,7 +71,7 @@ func TestReconcileFailsIfNamespaceIsPartOfAnotherMesh(t *testing.T) {
 }
 
 func TestRemoveNamespaceFromMesh(t *testing.T) {
-	namespace := newAppNamespace()
+	namespace := newNamespace(appNamespace)
 	meshRoleBinding := newMeshRoleBinding()
 	cl, _ := test.CreateClient(namespace, meshRoleBinding)
 	setupReconciledNamespace(t, cl, appNamespace)
@@ -101,7 +101,7 @@ func TestRemoveNamespaceFromMesh(t *testing.T) {
 
 func TestReconcileUpdatesModifiedRoleBindings(t *testing.T) {
 	t.Skip("Not implemented yet")
-	namespace := newAppNamespace()
+	namespace := newNamespace(appNamespace)
 	meshRoleBinding := newMeshRoleBinding()
 	cl, _ := test.CreateClient(namespace, meshRoleBinding)
 	setupReconciledNamespace(t, cl, appNamespace)
@@ -140,7 +140,7 @@ func TestReconcileUpdatesModifiedRoleBindings(t *testing.T) {
 }
 
 func TestReconcileDeletesObsoleteRoleBindings(t *testing.T) {
-	namespace := newAppNamespace()
+	namespace := newNamespace(appNamespace)
 	meshRoleBinding := newMeshRoleBinding()
 
 	cl, _ := test.CreateClient(namespace, meshRoleBinding)
@@ -167,7 +167,7 @@ func TestReconcileDeletesObsoleteRoleBindings(t *testing.T) {
 func TestOtherResourcesArePreserved(t *testing.T) {
 	otherLabelName := "other-label"
 	otherLabelValue := "other-label-value"
-	namespace := newAppNamespace()
+	namespace := newNamespace(appNamespace)
 	namespace.Labels[otherLabelName] = otherLabelValue
 	meshRoleBinding := newMeshRoleBinding()
 


### PR DESCRIPTION
The way we're using the return value of reconcileNamespaces, we will have to pass in all to-be-reconciled namespaces, always. Note that this introduces some overhead - it will reconcile all namespaces always, even if some don't have to be reconciled - but we can fix that in a later refactoring.