### PR TITLE
[Maistra-1215][Maistra-1211] Added collect-olm-manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 
 # Temporary Build Files
-tmp/_output
-tmp/_test
+tmp/
 
 
 # Created by https://www.gitignore.io/api/go,vim,emacs,visualstudiocode

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,12 @@ IMAGE           ?= docker.io/maistra/istio-ubi8-operator:${MAISTRA_VERSION}
 CONTAINER_CLI   ?= docker
 COMMUNITY       ?= true
 
-SOURCE_DIR        := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-RESOURCES_DIR     = ${SOURCE_DIR}/resources
-OUT_DIR           = ${SOURCE_DIR}/tmp/_output
-TEMPLATES_OUT_DIR = ${OUT_DIR}/resources/default-templates
-HELM_OUT_DIR      = ${OUT_DIR}/resources/helm
+SOURCE_DIR          := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+RESOURCES_DIR        = ${SOURCE_DIR}/resources
+OUT_DIR              = ${SOURCE_DIR}/tmp/_output
+TEMPLATES_OUT_DIR    = ${OUT_DIR}/resources/default-templates
+HELM_OUT_DIR         = ${OUT_DIR}/resources/helm
+OLM_MANIFEST_OUT_DIR = ${OUT_DIR}/manifests
 
 OFFLINE_BUILD       ?= false
 GIT_UPSTREAM_REMOTE ?= $(shell git remote -v |grep --color=never ':Maistra/istio-operator\.git.*(fetch)' |grep --color=never -o '^[^[:space:]]*')
@@ -41,6 +42,8 @@ BUILD_TYPE = maistra
 else
 BUILD_TYPE = servicemesh
 endif
+
+$(info   Building $(BUILD_TYPE) operator)
 
 export SOURCE_DIR OUT_DIR MAISTRA_BRANCH MAISTRA_VERSION VERSION COMMUNITY BUILD_TYPE
 
@@ -151,6 +154,12 @@ collect-charts: collect-1.0-charts collect-1.1-charts
 
 .PHONY: collect-templates
 collect-templates: collect-1.0-templates collect-1.1-templates
+
+.PHONY: collect-olm-manifests
+collect-olm-manifests:
+	rm -rf  ${OLM_MANIFEST_OUT_DIR}
+	mkdir -p ${OLM_MANIFEST_OUT_DIR}
+	cp -ra ${SOURCE_DIR}/manifests-${BUILD_TYPE}/* ${OLM_MANIFEST_OUT_DIR}
 
 .PHONY: collect-resources
 collect-resources: collect-templates collect-charts

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ RESOURCES_DIR        = ${SOURCE_DIR}/resources
 OUT_DIR              = ${SOURCE_DIR}/tmp/_output
 TEMPLATES_OUT_DIR    = ${OUT_DIR}/resources/default-templates
 HELM_OUT_DIR         = ${OUT_DIR}/resources/helm
-OLM_MANIFEST_OUT_DIR = ${OUT_DIR}/manifests
+OLM_MANIFEST_OUT_DIR = ${OUT_DIR}/resources/manifests
 
 OFFLINE_BUILD       ?= false
 GIT_UPSTREAM_REMOTE ?= $(shell git remote -v |grep --color=never ':Maistra/istio-operator\.git.*(fetch)' |grep --color=never -o '^[^[:space:]]*')
@@ -120,11 +120,11 @@ collect-1.1-templates:
 # OLM manifest generation
 ################################################################################
 .PHONY: generate-community-manifests
-generate-community-manifests: 
+generate-community-manifests:
 	COMMUNITY=true ${SOURCE_DIR}/build/generate-manifests.sh
 
 .PHONY: generate-product-manifests
-generate-product-manifests: 
+generate-product-manifests:
 	COMMUNITY=false ${SOURCE_DIR}/build/generate-manifests.sh
 
 ################################################################################
@@ -162,7 +162,7 @@ collect-olm-manifests:
 	cp -ra ${SOURCE_DIR}/manifests-${BUILD_TYPE}/* ${OLM_MANIFEST_OUT_DIR}
 
 .PHONY: collect-resources
-collect-resources: collect-templates collect-charts
+collect-resources: collect-templates collect-charts collect-olm-manifests
 
 ################################################################################
 # update-generated-code target regenerates k8s api related code


### PR DESCRIPTION
In https://github.com/Maistra/rpms/commit/bfe95a98d5f923d623b3d3b8b72e65336c4b5e2e, the operator RPM build was updated to use a `BUILD_TYPE` instead of community. These changes were never propagated here. This caused every build to be a community build.

This is part one of three PRs. This PR adds a collect-olm-manifests endpoint which will be used to remove BUILD_TYPE from the RPM build. The other reference to BUILD_TYPE in the RPM build will be reverted to `COMMUNITY=true` or `COMMUNITY=false` to select the build type.