### PR TITLE
MAISTRA-1160 Add support for external Jaeger instances

### DIFF
--- a/resources/helm/overlays/istio/charts/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/overlays/istio/charts/kiali/templates/kiali-cr.yaml
@@ -67,7 +67,11 @@ spec:
         username: "internal"
         password: ""
       enabled: true
+{{- if .Values.jaegerInClusterURL }}
+      in_cluster_url: "{{ .Values.jaegerInClusterURL }}"
+{{- else }}
       in_cluster_url: "https://jaeger-query.{{ .Release.Namespace }}.svc"
+{{- end }}
       namespace: "{{ .Release.Namespace }}"
       service : ""
 {{- if .Values.dashboard }}

--- a/resources/helm/v1.1/istio/charts/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/v1.1/istio/charts/kiali/templates/kiali-cr.yaml
@@ -67,7 +67,11 @@ spec:
         username: "internal"
         password: ""
       enabled: true
+{{- if .Values.jaegerInClusterURL }}
+      in_cluster_url: "{{ .Values.jaegerInClusterURL }}"
+{{- else }}
       in_cluster_url: "https://jaeger-query.{{ .Release.Namespace }}.svc"
+{{- end }}
       namespace: "{{ .Release.Namespace }}"
       service : ""
 {{- if .Values.dashboard }}


### PR DESCRIPTION
This still requires documentation, will work on that this afternoon.

To use an external Jaeger instance, you need to:
  - set istio.global.tracer.zipkin.address to collector service URI (**must include namespace** because it's used at injection time)
  - set tracing.enabled = false
  - set kiali.jaegerInClusterURL to query service URI