### PR TITLE
MAISTRA-1160 Allow ingress traffic to external Jaeger on port 8443

### DIFF
--- a/resources/helm/overlays/istio/templates/networkpolicy.yaml
+++ b/resources/helm/overlays/istio/templates/networkpolicy.yaml
@@ -94,8 +94,6 @@ spec:
       app.kubernetes.io/part-of: jaeger
       app.kubernetes.io/managed-by: jaeger-operator
   ingress:
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          network.openshift.io/policy-group: ingress
+  - ports:
+    port: 8443
 {{ end }}

--- a/resources/helm/v1.1/istio/templates/networkpolicy.yaml
+++ b/resources/helm/v1.1/istio/templates/networkpolicy.yaml
@@ -98,8 +98,6 @@ spec:
       app.kubernetes.io/part-of: jaeger
       app.kubernetes.io/managed-by: jaeger-operator
   ingress:
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          network.openshift.io/policy-group: ingress
+  - ports:
+    port: 8443
 {{ end }}


### PR DESCRIPTION
I'm really sorry for the back-and-forth on this.. Turns out my `crc` cluster does not respect NetworkPolicy. I tested this on @FilipB's cluster now