### PR TITLE
MAISTRA-1451 Enable injectPodRedirectAnnot flag when enabled in SMCP

### DIFF
--- a/build/patch-charts.sh
+++ b/build/patch-charts.sh
@@ -274,9 +274,13 @@ function patchSidecarInjector() {
 \1  targetPort: webhook/' ${HELM_DIR}/istio/charts/sidecarInjectorWebhook/templates/service.yaml
 
   # - switch webhook ports to 8443
+  # - add injectPodRedirectAnnot flag when enabled
   # - disable management of webhook config
   # - add webhook port
   sed_wrap -i -e 's/^\(.*\)\(volumeMounts:.*\)$/\1  - --port=8443\
+{{- if .Values.injectPodRedirectAnnot }}\
+\1  - --injectPodRedirectAnnot\
+{{- end }}\
 \1ports:\
 \1- name: webhook\
 \1  containerPort: 8443\

--- a/resources/helm/v1.1/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
+++ b/resources/helm/v1.1/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
@@ -56,6 +56,9 @@ spec:
             - --healthCheckFile=/tmp/health
             - --reconcileWebhookConfig=false
             - --port=8443
+{{- if .Values.injectPodRedirectAnnot }}
+            - --injectPodRedirectAnnot
+{{- end }}
           ports:
           - name: webhook
             containerPort: 8443


### PR DESCRIPTION
When SMCP.spec.istio.sidecarInjectorWebhook.injectPodRedirectAnnot is set
to true, the --injectPodRedirectAnnot flag is passed to the sidecar-injector
in order to enable the injection of the annotations specified under
podRedirectAnnot in the injection template.