### PR TITLE
MAISTRA-1494: Add support for the metadata version

### DIFF
--- a/build/generate-manifests.sh
+++ b/build/generate-manifests.sh
@@ -93,6 +93,10 @@ function generateCSV() {
   local csv_path=${BUNDLE_DIR}/${OPERATOR_NAME}.v${MAISTRA_VERSION}.clusterserviceversion.yaml
   cp ${MY_LOCATION}/manifest-templates/clusterserviceversion.yaml ${csv_path}
 
+  sed -i -e '/__DEPLOYMENT_SPEC__/{
+    s/__DEPLOYMENT_SPEC__//
+    r '<(echo "$DEPLOYMENT_SPEC")'
+  }' ${csv_path}
   sed -i -e 's/__NAME__/'${OPERATOR_NAME}'/g' ${csv_path}
   sed -i -e 's/__VERSION__/'${MAISTRA_VERSION}'/g' ${csv_path}
   sed -i -e 's/__STRIPPED_VERSION__/'${MAISTRA_STRIPPED_VERSION}'/g' ${csv_path}
@@ -112,10 +116,6 @@ function generateCSV() {
   sed -i -e '/__CLUSTER_ROLE_RULES__/{
     s/__CLUSTER_ROLE_RULES__//
     r '<(echo "$CLUSTER_ROLE_RULES")'
-  }' ${csv_path}
-  sed -i -e '/__DEPLOYMENT_SPEC__/{
-    s/__DEPLOYMENT_SPEC__//
-    r '<(echo "$DEPLOYMENT_SPEC")'
   }' ${csv_path}
   if [ -z "$REPLACES_CSV" ]; then
     sed -i '/__REPLACES_CSV__/d' ${csv_path}

--- a/deploy/maistra-operator.yaml
+++ b/deploy/maistra-operator.yaml
@@ -487,6 +487,8 @@ spec:
               value: istio-operator
 #            - name: ISTIO_CNI_IMAGE_PULL_SECRET
 #              value: name-of-secret
+            - name: METADATA_VERSION
+              value: __VERSION__
           volumeMounts:
           - name: operator-olm-config
             mountPath: /etc/operator/olm

--- a/deploy/servicemesh-operator.yaml
+++ b/deploy/servicemesh-operator.yaml
@@ -492,6 +492,8 @@ spec:
               value: istio-operator
 #            - name: ISTIO_CNI_IMAGE_PULL_SECRET
 #              value: name-of-secret
+            - name: METADATA_VERSION
+              value: __VERSION__
           volumeMounts:
           - name: operator-olm-config
             mountPath: /etc/operator/olm

--- a/manifests-servicemesh/1.1.2.2/servicemeshoperator.v1.1.2+2.clusterserviceversion.yaml
+++ b/manifests-servicemesh/1.1.2.2/servicemeshoperator.v1.1.2+2.clusterserviceversion.yaml
@@ -12,7 +12,7 @@ metadata:
       The OpenShift Service Mesh Operator enables you to install, configure, and manage an instance of Red Hat OpenShift Service Mesh. OpenShift Service Mesh is based on the open source Istio project.
 
     containerImage: registry.redhat.io/openshift-service-mesh/istio-rhel8-operator:1.1.2
-    createdAt: 2020-05-22T17:29:22UTC
+    createdAt: 2020-05-26T02:02:15UTC
     support: Red Hat, Inc. 
     olm.skipRange: ">=1.0.2 <1.1.2"
     alm-examples: |-
@@ -544,6 +544,8 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: istio-operator
+                - name: METADATA_VERSION
+                  value: 1.1.2+2
                 volumeMounts:
                 - name: operator-olm-config
                   mountPath: /etc/operator/olm

--- a/pkg/apis/maistra/v1/status.go
+++ b/pkg/apis/maistra/v1/status.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -141,9 +142,15 @@ type Condition struct {
 	LastTransitionTime metav1.Time     `json:"lastTransitionTime,omitempty"`
 }
 
+var metadataVersion string = os.Getenv("METADATA_VERSION");
+
 // CurrentReconciledVersion returns a ReconciledVersion for this release of the operator
 func CurrentReconciledVersion(generation int64) string {
-	return ComposeReconciledVersion(version.Info.Version, generation)
+	if metadataVersion == "" {
+		return ComposeReconciledVersion(version.Info.Version, generation)
+	} else {
+		return ComposeReconciledVersion(metadataVersion, generation)
+	}
 }
 
 // ComposeReconciledVersion returns a string for use in ReconciledVersion fields


### PR DESCRIPTION
I still have to test this PR, will do that tomorrow but wanted to get other eyes on the changes.

This PR adds knowledge of the metadata version into the operator's deployment so we can use this as the basis for making decisions on whether a reconciliation is necessary.  The current code uses the operator build version which, with multiple streams, is no longer guaranteed to change.