### PR TITLE
MAISTRA-1373 Enable specification of oauth-proxy container resources

### DIFF
--- a/build/patch-grafana.sh
+++ b/build/patch-grafana.sh
@@ -24,7 +24,12 @@ function grafana_patch_deployment() {
               port: https\
               scheme: HTTPS\
             timeoutSeconds: 1\
-          resources: {}\
+          resources:\
+{{- if .Values.global.oauthproxy.resources }}\
+{{ toYaml .Values.global.oauthproxy.resources | indent 12 }}\
+{{- else }}\
+{{ toYaml .Values.global.defaultResources | indent 12 }}\
+{{- end }}\
           terminationMessagePath: /dev/termination-log\
           terminationMessagePolicy: File\
           volumeMounts:\

--- a/build/patch-prometheus.sh
+++ b/build/patch-prometheus.sh
@@ -24,7 +24,12 @@ function prometheus_patch_deployment() {
               port: https\
               scheme: HTTPS\
             timeoutSeconds: 1\
-          resources: {}\
+          resources:\
+{{- if .Values.global.oauthproxy.resources }}\
+{{ toYaml .Values.global.oauthproxy.resources | indent 12 }}\
+{{- else }}\
+{{ toYaml .Values.global.defaultResources | indent 12 }}\
+{{- end }}\
           terminationMessagePath: /dev/termination-log\
           terminationMessagePolicy: File\
           volumeMounts:\

--- a/resources/helm/v1.1/istio/charts/grafana/templates/deployment.yaml
+++ b/resources/helm/v1.1/istio/charts/grafana/templates/deployment.yaml
@@ -62,7 +62,12 @@ spec:
               port: https
               scheme: HTTPS
             timeoutSeconds: 1
-          resources: {}
+          resources:
+{{- if .Values.global.oauthproxy.resources }}
+{{ toYaml .Values.global.oauthproxy.resources | indent 12 }}
+{{- else }}
+{{ toYaml .Values.global.defaultResources | indent 12 }}
+{{- end }}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/resources/helm/v1.1/istio/charts/prometheus/templates/deployment.yaml
+++ b/resources/helm/v1.1/istio/charts/prometheus/templates/deployment.yaml
@@ -57,7 +57,12 @@ spec:
               port: https
               scheme: HTTPS
             timeoutSeconds: 1
-          resources: {}
+          resources:
+{{- if .Values.global.oauthproxy.resources }}
+{{ toYaml .Values.global.oauthproxy.resources | indent 12 }}
+{{- else }}
+{{ toYaml .Values.global.defaultResources | indent 12 }}
+{{- end }}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:


### PR DESCRIPTION
Note that this only adds the resource block for `v1.1` deployments - it would be easy to also add this to `v1.0`, though, if we want that.