### PR TITLE
MAISTRA-1500 Fix race condition in post-install readiness check

### DIFF
--- a/pkg/controller/servicemesh/controlplane/manifestprocessing_test.go
+++ b/pkg/controller/servicemesh/controlplane/manifestprocessing_test.go
@@ -1,0 +1,80 @@
+package controlplane
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/helm/pkg/manifest"
+	"k8s.io/helm/pkg/releaseutil"
+
+	maistrav1 "github.com/maistra/istio-operator/pkg/apis/maistra/v1"
+	"github.com/maistra/istio-operator/pkg/controller/common"
+	"github.com/maistra/istio-operator/pkg/controller/common/cni"
+	"github.com/maistra/istio-operator/pkg/controller/common/test"
+	"github.com/maistra/istio-operator/pkg/controller/common/test/assert"
+)
+
+func TestReadinessWhenCacheNotSynced(t *testing.T) {
+	controlPlane := newControlPlane()
+	controlPlane.Spec.Istio = maistrav1.HelmValuesType{}
+	controlPlane.Spec.Template = "maistra"
+	controlPlane.Status.ComponentStatus = []*maistrav1.ComponentStatus{
+		{
+			StatusType: maistrav1.StatusType{
+				Resource:           "security",
+				ObservedGeneration: 0,
+				Conditions:         nil,
+			},
+		},
+	}
+
+	operatorNamespace := "istio-operator"
+	InitializeGlobals(operatorNamespace)()
+
+	cl, tracker := test.CreateClient()
+	fakeEventRecorder := &record.FakeRecorder{}
+
+	instanceReconciler := NewControlPlaneInstanceReconciler(
+		common.ControllerResources{
+			Client:            cl,
+			Scheme:            scheme.Scheme,
+			EventRecorder:     fakeEventRecorder,
+			OperatorNamespace: operatorNamespace,
+		},
+		controlPlane,
+		cni.Config{Enabled: true}).(*controlPlaneInstanceReconciler)
+
+	// emulate cache desync (deployment not yet in cache)
+	tracker.AddReactor("list", "deployments", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, &v1.DeploymentList{}, nil
+	})
+
+	instanceReconciler.renderings = map[string][]manifest.Manifest{
+		"security": {
+			{
+				Name: "deployment.yaml",
+				Content: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: cp-namespace
+spec:`,
+				Head: &releaseutil.SimpleHead{
+					Version: "apps/v1",
+					Kind:    "Deployment",
+				},
+			},
+		},
+	}
+
+	ready, err := instanceReconciler.processComponentManifests(ctx, "security")
+	if err != nil {
+		t.Fatalf("Unexpected error in processComponentManifests: %v", err)
+	}
+
+	assert.False(ready, "expected component to not be ready", t)
+}

--- a/pkg/controller/servicemesh/controlplane/readiness.go
+++ b/pkg/controller/servicemesh/controlplane/readiness.go
@@ -100,12 +100,20 @@ func (r *controlPlaneInstanceReconciler) updateReadinessStatus(ctx context.Conte
 
 type isReadyFunc func(runtime.Object) bool
 
+// keep this in sync with kinds in calculateComponentReadiness()
+var kindsWithReadiness = sets.NewString("Deployment", "StatefulSet", "DaemonSet")
+
+func (r *controlPlaneInstanceReconciler) hasReadiness(kind string) bool {
+	return kindsWithReadiness.Has(kind)
+}
+
 func (r *controlPlaneInstanceReconciler) calculateComponentReadiness(ctx context.Context) (map[string]bool, error) {
 	readinessMap := map[string]bool{}
 	typesToCheck := []struct {
 		list  runtime.Object
 		ready isReadyFunc
 	}{
+		// keep this in sync with kindsWithReadiness
 		{
 			list: &appsv1.DeploymentList{},
 			ready: func(obj runtime.Object) bool {


### PR DESCRIPTION
After deploying a component, if the cache isn't updated in time, we never
wait for the component to become ready (its has no entry in the
readinessMap; we consider this to mean that the chart has no resources
with readiness information, so we consider the whole chart as ready).

If the component is missing in readinessMap, we must take that as a signal
that the component is NOT ready. But if we do that, we'll take all components
that have no resources with readiness information as not ready.

So, before checking readiness, we should determine if the chart has any
resources that contain readiness information. If it doesn't we should
count the component as ready.