### PR TITLE
Configure mergify to add "ready to merge" label to PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -14,6 +14,9 @@ pull_request_rules:
       merge:
         method: squash
         strict: smart
+      label:
+        remove:
+        - "ready to merge"
   - name: automatic merge (without squash) with strict when reviewed and not work in progress
     conditions:
       - '#approved-reviews-by>=2'
@@ -29,19 +32,34 @@ pull_request_rules:
       merge:
         method: rebase
         strict: smart
+      label:
+        remove:
+        - "ready to merge"
   - name: label work in progress PRs
     conditions:
       - label != "work in progress"
-      - title ~= '^WIP\b'
+      - title ~=^WIP\b
     actions:
       label:
         add:
-          - "work in progress"
+        - "work in progress"
+        remove:
+        - "ready to merge"
   - name: remove work in progress labels
     conditions:
       - label = "work in progress"
-      - title ~= '^(?!WIP\b)'
+      - title ~=^(?!WIP\b)
     actions:
       label:
         remove:
-          - "work in progress"
+        - "work in progress"
+  - name: label PRs that can be merged
+    conditions:
+    - '#approved-reviews-by>=2'
+    - '#review-requested=0'
+    - '#changes-requested-reviews-by=0'
+    - label != "work in progress"
+    actions:
+      label:
+        add:
+        - "ready to merge"


### PR DESCRIPTION
This is to make it easy for us to see which PRs have been approved
and are only missing the "okay to merge" label.

This should also make it easy to see which PRs still need at least
one additional approval (PRs that aren't marked as WIP and have no
"ready to merge" label).

I experimented with also adding a "needs review" label, but then
the PR discussion would have a bunch of 'added/removed "needs review"'
events, because switching from WIP to nonWIP and approvals & their
revocations would cause the label to be added/removed.