### PR TITLE
MAISTRA-1496 Ensure lastTransitionTime isn't updated when no transition occurs

### DIFF
--- a/pkg/apis/maistra/v1/status.go
+++ b/pkg/apis/maistra/v1/status.go
@@ -185,12 +185,12 @@ func (s *StatusType) SetCondition(condition Condition) *StatusType {
 	// match the time in our cached status during a reconcile.  We truncate here
 	// to save any problems down the line.
 	now := metav1.NewTime(time.Now().Truncate(time.Second))
-	for i := range s.Conditions {
-		if s.Conditions[i].Type == condition.Type {
-			if s.Conditions[i].Status != condition.Status {
+	for i, prevCondition := range s.Conditions {
+		if prevCondition.Type == condition.Type {
+			if prevCondition.Status != condition.Status {
 				condition.LastTransitionTime = now
 			} else {
-				condition.LastTransitionTime = s.Conditions[i].LastTransitionTime
+				condition.LastTransitionTime = prevCondition.LastTransitionTime
 			}
 			s.Conditions[i] = condition
 			return s

--- a/pkg/controller/servicemesh/controlplane/reconciler.go
+++ b/pkg/controller/servicemesh/controlplane/reconciler.go
@@ -118,7 +118,6 @@ func (r *controlPlaneInstanceReconciler) Reconcile(ctx context.Context) (result 
 		// error handling
 		defer func() {
 			if err != nil {
-				r.renderings = nil
 				r.lastComponent = ""
 				updateControlPlaneConditions(r.Status, err)
 			}

--- a/pkg/controller/servicemesh/controlplane/reconciler_test.go
+++ b/pkg/controller/servicemesh/controlplane/reconciler_test.go
@@ -3,12 +3,20 @@ package controlplane
 import (
 	"reflect"
 	"testing"
+	"time"
 
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/record"
+
+	"k8s.io/client-go/kubernetes/scheme"
 
 	maistrav1 "github.com/maistra/istio-operator/pkg/apis/maistra/v1"
 	"github.com/maistra/istio-operator/pkg/controller/common"
 	"github.com/maistra/istio-operator/pkg/controller/common/cni"
+	"github.com/maistra/istio-operator/pkg/controller/common/test"
+	"github.com/maistra/istio-operator/pkg/controller/common/test/assert"
 	"github.com/maistra/istio-operator/pkg/controller/versions"
 )
 
@@ -92,6 +100,75 @@ func TestCyclicTemplate(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error to not be nil. Cyclic dependencies should not be allowed.")
 	}
+}
+
+func TestInstallationErrorDoesNotUpdateLastTransitionTimeWhenNoStateTransitionOccurs(t *testing.T) {
+	controlPlane := newControlPlane()
+	controlPlane.Spec.Istio = maistrav1.HelmValuesType{}
+	controlPlane.Spec.Template = "maistra"
+	controlPlane.Status.SetCondition(maistrav1.Condition{
+		Type:               maistrav1.ConditionTypeReconciled,
+		Status:             maistrav1.ConditionStatusFalse,
+		Reason:             "",
+		Message:            "",
+		LastTransitionTime: oneMinuteAgo,
+	})
+
+	namespace := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "cp-namespace"},
+	}
+
+	operatorNamespace := "istio-operator"
+	InitializeGlobals(operatorNamespace)()
+
+	cl, tracker := test.CreateClient(controlPlane, namespace)
+	fakeEventRecorder := &record.FakeRecorder{}
+
+	r := NewControlPlaneInstanceReconciler(
+		common.ControllerResources{
+			Client:            cl,
+			Scheme:            scheme.Scheme,
+			EventRecorder:     fakeEventRecorder,
+			OperatorNamespace: operatorNamespace,
+		},
+		controlPlane,
+		cni.Config{Enabled: true})
+
+	// make installation fail
+	tracker.AddReactor("create", "deployments", test.ClientFails())
+
+	// run initial reconcile to update the SMCP status
+	_, err := r.Reconcile(ctx)
+	if err == nil {
+		t.Fatal("Expected reconcile to fail, but it didn't")
+	}
+
+	// run reconcile again to work around the problem where the condition reason "InstallError" gets changed to "ReconcileError" in 2nd reconcile
+	_, err = r.Reconcile(ctx)
+	if err == nil {
+		t.Fatal("Expected reconcile to fail, but it didn't")
+	}
+
+	// remember the SMCP status at this point
+	updatedControlPlane := &maistrav1.ServiceMeshControlPlane{}
+	test.PanicOnError(cl.Get(ctx, common.ToNamespacedName(controlPlane.ObjectMeta), updatedControlPlane))
+	initialStatus := updatedControlPlane.Status.DeepCopy()
+
+	// the resolution of lastTransitionTime is one second, so we need to wait at least one second before
+	// performing another reconciliation to ensure that if the lastTransitionTime field is reset, the new
+	// value will actually be different from the previous one
+	time.Sleep(1 * time.Second)
+
+	// run reconcile again to check if the status is still the same
+	_, err = r.Reconcile(ctx)
+	if err == nil {
+		t.Fatal("Expected reconcile to fail, but it didn't")
+	}
+
+	test.PanicOnError(cl.Get(ctx, common.ToNamespacedName(controlPlane.ObjectMeta), updatedControlPlane))
+	newStatus := &updatedControlPlane.Status
+
+	assert.DeepEquals(newStatus, initialStatus, "didn't expect SMCP status to be updated", t)
 }
 
 func newTestReconciler() *controlPlaneInstanceReconciler {


### PR DESCRIPTION
Resetting the renderings to nil caused the operator to set all the
component conditions to false in the next reconciliation attempt (due
to the renderings being nil). The operator then changed the conditions
of all the components that are already deployed back to true, resetting
the lastTransitionTime in the process, since the condition went from
false to true. This then caused the SMCP status to be updated, which
then caused the operator to go into a tight loop, as the status update
watch event triggered another reconciliation and by-passed the back-off
mechanism.

There's no need to reset the chart renderings if an error occurs when
we try to deploy them, as the renderings will be identical the next time
we render them. If the error occurs during the rendering itself, the
renderings won't even be set, so we don't have to set the field to nil
in that case either.