### PR TITLE
Changes to Jaeger templates to avoid schema validation errors

### DIFF
--- a/resources/helm/overlays/istio/charts/tracing/templates/jaeger-all-in-one.yaml
+++ b/resources/helm/overlays/istio/charts/tracing/templates/jaeger-all-in-one.yaml
@@ -19,19 +19,18 @@ spec:
       log-level: debug
       query:
         base-path: /
-    annotations:
-      {{- range $key, $value := .Values.jaeger.annotations }}
-        {{ $key }}: {{ $value | quote }}
-      {{- end }}
 
+{{- if and .Values.jaeger.hub .Values.jaeger.tag .Values.jaeger.agentImage }}
   agent:
-    {{- if and .Values.jaeger.hub .Values.jaeger.tag .Values.jaeger.agentImage }}
     image: {{ .Values.jaeger.hub }}/{{ .Values.jaeger.agentImage }}:{{ .Values.jaeger.tag }}
+{{- end }}
+
+{{- if .Values.jaeger.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.jaeger.annotations }}
+      {{ $key }}: {{ $value | quote }}
     {{- end }}
-    annotations:
-      {{- range $key, $value := .Values.jaeger.annotations }}
-        {{ $key }}: {{ $value | quote }}
-      {{- end }}
+{{- end }}
 
   storage:
     options:
@@ -46,10 +45,12 @@ spec:
     enabled: {{ .Values.ingress.enabled }}
     # XXX: should this be parameterized?
     security: oauth-proxy
+{{- if .Values.ingress.annotations }}
     annotations:
       {{- range $key, $value := .Values.ingress.annotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
+{{- end }}
     openshift:
       sar: '{"namespace": "{{ .Release.Namespace }}", "resource": "pods", "verb": "get"}'
       htpasswdFile: /etc/proxy/htpasswd/auth

--- a/resources/helm/overlays/istio/charts/tracing/templates/jaeger-production-elasticsearch.yaml
+++ b/resources/helm/overlays/istio/charts/tracing/templates/jaeger-production-elasticsearch.yaml
@@ -18,28 +18,23 @@ spec:
     options:
       query:
         base-path: /
-    annotations:
-      {{- range $key, $value := .Values.jaeger.annotations }}
-        {{ $key }}: {{ $value | quote }}
-      {{- end }}
 
+{{- if and .Values.jaeger.hub .Values.jaeger.tag .Values.jaeger.collectorImage }}
   collector:
-    {{- if and .Values.jaeger.hub .Values.jaeger.tag .Values.jaeger.collectorImage }}
     image: {{ .Values.jaeger.hub }}/{{ .Values.jaeger.collectorImage }}:{{ .Values.jaeger.tag }}
-    {{- end }}
-    annotations:
-      {{- range $key, $value := .Values.jaeger.annotations }}
-        {{ $key }}: {{ $value | quote }}
-      {{- end }}
+{{- end }}
 
+{{- if and .Values.jaeger.hub .Values.jaeger.tag .Values.jaeger.agentImage }}
   agent:
-    {{- if and .Values.jaeger.hub .Values.jaeger.tag .Values.jaeger.agentImage }}
     image: {{ .Values.jaeger.hub }}/{{ .Values.jaeger.agentImage }}:{{ .Values.jaeger.tag }}
+{{- end }}
+
+{{- if .Values.jaeger.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.jaeger.annotations }}
+      {{ $key }}: {{ $value | quote }}
     {{- end }}
-    annotations:
-      {{- range $key, $value := .Values.jaeger.annotations }}
-        {{ $key }}: {{ $value | quote }}
-      {{- end }}
+{{- end }}
 
   storage:
     type: elasticsearch
@@ -59,10 +54,12 @@ spec:
 {{- if .Values.jaeger.elasticsearch.redundancyPolicy }}
       redundancyPolicy: {{ toYaml .Values.jaeger.elasticsearch.redundancyPolicy }}
 {{- end }}
+{{- if .Values.jaeger.elasticsearch.nodeSelector }}
       nodeSelector:
         {{- range $key, $value := .Values.jaeger.elasticsearch.nodeSelector }}
           {{ $key }}: {{ $value | quote }}
         {{- end }}
+{{- end }}
       resources:
 {{- if .Values.jaeger.elasticsearch.resources }}
 {{ toYaml .Values.jaeger.elasticsearch.resources | indent 8 }}
@@ -81,10 +78,12 @@ spec:
     enabled: {{ .Values.ingress.enabled }}
     # XXX: should this be parameterized?
     security: oauth-proxy
+{{- if .Values.ingress.annotations }}
     annotations:
       {{- range $key, $value := .Values.ingress.annotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
+{{- end }}
     openshift:
       sar: '{"namespace": "{{ .Release.Namespace }}", "resource": "pods", "verb": "get"}'
       htpasswdFile: /etc/proxy/htpasswd/auth

--- a/resources/helm/v1.2/istio/charts/tracing/templates/jaeger-all-in-one.yaml
+++ b/resources/helm/v1.2/istio/charts/tracing/templates/jaeger-all-in-one.yaml
@@ -20,19 +20,18 @@ spec:
       log-level: debug
       query:
         base-path: /
-    annotations:
-      {{- range $key, $value := .Values.jaeger.annotations }}
-        {{ $key }}: {{ $value | quote }}
-      {{- end }}
 
+{{- if and .Values.jaeger.hub .Values.jaeger.tag .Values.jaeger.agentImage }}
   agent:
-    {{- if and .Values.jaeger.hub .Values.jaeger.tag .Values.jaeger.agentImage }}
     image: {{ .Values.jaeger.hub }}/{{ .Values.jaeger.agentImage }}:{{ .Values.jaeger.tag }}
+{{- end }}
+
+{{- if .Values.jaeger.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.jaeger.annotations }}
+      {{ $key }}: {{ $value | quote }}
     {{- end }}
-    annotations:
-      {{- range $key, $value := .Values.jaeger.annotations }}
-        {{ $key }}: {{ $value | quote }}
-      {{- end }}
+{{- end }}
 
   storage:
     options:
@@ -47,10 +46,12 @@ spec:
     enabled: {{ .Values.ingress.enabled }}
     # XXX: should this be parameterized?
     security: oauth-proxy
+{{- if .Values.ingress.annotations }}
     annotations:
       {{- range $key, $value := .Values.ingress.annotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
+{{- end }}
     openshift:
       sar: '{"namespace": "{{ .Release.Namespace }}", "resource": "pods", "verb": "get"}'
       htpasswdFile: /etc/proxy/htpasswd/auth

--- a/resources/helm/v1.2/istio/charts/tracing/templates/jaeger-production-elasticsearch.yaml
+++ b/resources/helm/v1.2/istio/charts/tracing/templates/jaeger-production-elasticsearch.yaml
@@ -19,28 +19,23 @@ spec:
     options:
       query:
         base-path: /
-    annotations:
-      {{- range $key, $value := .Values.jaeger.annotations }}
-        {{ $key }}: {{ $value | quote }}
-      {{- end }}
 
+{{- if and .Values.jaeger.hub .Values.jaeger.tag .Values.jaeger.collectorImage }}
   collector:
-    {{- if and .Values.jaeger.hub .Values.jaeger.tag .Values.jaeger.collectorImage }}
     image: {{ .Values.jaeger.hub }}/{{ .Values.jaeger.collectorImage }}:{{ .Values.jaeger.tag }}
-    {{- end }}
-    annotations:
-      {{- range $key, $value := .Values.jaeger.annotations }}
-        {{ $key }}: {{ $value | quote }}
-      {{- end }}
+{{- end }}
 
+{{- if and .Values.jaeger.hub .Values.jaeger.tag .Values.jaeger.agentImage }}
   agent:
-    {{- if and .Values.jaeger.hub .Values.jaeger.tag .Values.jaeger.agentImage }}
     image: {{ .Values.jaeger.hub }}/{{ .Values.jaeger.agentImage }}:{{ .Values.jaeger.tag }}
+{{- end }}
+
+{{- if .Values.jaeger.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.jaeger.annotations }}
+      {{ $key }}: {{ $value | quote }}
     {{- end }}
-    annotations:
-      {{- range $key, $value := .Values.jaeger.annotations }}
-        {{ $key }}: {{ $value | quote }}
-      {{- end }}
+{{- end }}
 
   storage:
     type: elasticsearch
@@ -60,10 +55,12 @@ spec:
 {{- if .Values.jaeger.elasticsearch.redundancyPolicy }}
       redundancyPolicy: {{ toYaml .Values.jaeger.elasticsearch.redundancyPolicy }}
 {{- end }}
+{{- if .Values.jaeger.elasticsearch.nodeSelector }}
       nodeSelector:
         {{- range $key, $value := .Values.jaeger.elasticsearch.nodeSelector }}
           {{ $key }}: {{ $value | quote }}
         {{- end }}
+{{- end }}
       resources:
 {{- if .Values.jaeger.elasticsearch.resources }}
 {{ toYaml .Values.jaeger.elasticsearch.resources | indent 8 }}
@@ -82,10 +79,12 @@ spec:
     enabled: {{ .Values.ingress.enabled }}
     # XXX: should this be parameterized?
     security: oauth-proxy
+{{- if .Values.ingress.annotations }}
     annotations:
       {{- range $key, $value := .Values.ingress.annotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
+{{- end }}
     openshift:
       sar: '{"namespace": "{{ .Release.Namespace }}", "resource": "pods", "verb": "get"}'
       htpasswdFile: /etc/proxy/htpasswd/auth


### PR DESCRIPTION
Should address most of the errors currently listed in https://issues.redhat.com/browse/MAISTRA-1437.

The problem with the resource limits is that there are no values being specified for limits, e.g.:
```
spec:
  resources:
    limits:
    requests:
      cpu: 10m
      memory: 128Mi
```
The resources are obtained either from `.Values.jaeger.resources` (which doesn't currently have a value) or `.Values.global.defaultResources` which I think is defined [here](https://github.com/Maistra/istio-operator/blob/maistra-1.2/resources/helm/v1.1/istio/values.yaml#L445) (within a limit value).

Question to be addressed: the Jaeger operand image/tags should not be specified in the Maistra CR - they are managed by the Jaeger operator. The values are not included (even by example) in the templates - so can they be removed from the templates? It would simplify them.

Signed-off-by: Gary Brown <gary@brownuk.com>