### PR TITLE
Add VMware NSX Container Plugin as CNI option

### DIFF
--- a/pkg/controller/servicemesh/memberroll/namespace_reconciler.go
+++ b/pkg/controller/servicemesh/memberroll/namespace_reconciler.go
@@ -26,6 +26,7 @@ import (
 
 const networkTypeOpenShiftSDN = "OpenShiftSDN"
 const networkTypeCalico = "Calico"
+const networkTypeNsxNcp = "ncp"
 
 type namespaceReconciler struct {
 	common.ControllerResources
@@ -125,6 +126,9 @@ func (r *namespaceReconciler) initializeNetworkingStrategy(ctx context.Context) 
 				}
 			case strings.ToLower(networkTypeCalico):
 				log.Info("Network Strategy Calico:NetworkPolicy")
+				r.networkingStrategy, err = newNetworkPolicyStrategy(ctx, r.Client, r.meshNamespace)
+			case string.ToLower(networkTypeNsxNcp):
+				log.Info("Network Strategy NSX-NCP:NetworkPolicy")
 				r.networkingStrategy, err = newNetworkPolicyStrategy(ctx, r.Client, r.meshNamespace)
 			default:
 				return fmt.Errorf("unsupported network type: %s", networkType)


### PR DESCRIPTION
Hello,

I tried to file an issue but cannot find where, so I am sending PR. 
We are introducing VMware NSX Container Plugin support for Openshift 4. Without this PR service Mesh doesn't work on Openshift cluster when the CNI is NSX NCP.   
Could you please merge it?

Thanks in advance,
Yasen