### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ oc create -n observability -f https://raw.githubusercontent.com/jaegertracing/ja
 To install the Kiali operator, execute the following command:
 
 ```
-bash <(curl -L https://git.io/getLatestKialiOperator) --operator-image-version v1.0.0 --operator-watch-namespace '**' --accessible-namespaces '**' --operator-install-kiali false
+bash <(curl -L https://kiali.io/getLatestKialiOperator) --operator-image-version v1.0 --operator-watch-namespace '**' --accessible-namespaces '**' --operator-install-kiali false
 ```
 
 For more details on installing the Kiali operator, see the [Kiali documentaton](https://www.kiali.io/documentation/getting-started).
@@ -133,7 +133,7 @@ oc delete -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/
 To uninstall the Kiali operator, execute the following command:
 
 ```
-bash <(curl -L https://git.io/getLatestKialiOperator) --uninstall-mode true --operator-watch-namespace '**'
+bash <(curl -L https://kiali.io/getLatestKialiOperator) --uninstall-mode true --operator-watch-namespace '**'
 ```
 
 For more details on uninstalling the Kiali operator, see the [Kiali documentaton](https://www.kiali.io/documentation/getting-started/#_uninstall_kiali_operator_and_kiali).


### PR DESCRIPTION
The https://git.io/getLatestKialiOperator should change to https://kiali.io/getLatestKialiOperator, and the version should use v1.0 instead of v1.0.0.