### PR TITLE
Remove ca_file option in Kiali operator CR

### DIFF
--- a/resources/helm/overlays/istio-telemetry/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/overlays/istio-telemetry/kiali/templates/kiali-cr.yaml
@@ -39,7 +39,6 @@ spec:
   external_services:
     grafana:
       auth:
-        ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
         type: "basic"
         use_kiali_token: false
         username: "internal"
@@ -53,7 +52,6 @@ spec:
 {{- end }}
     prometheus:
       auth:
-        ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
         type: "basic"
         use_kiali_token: false
         username: "internal"
@@ -61,7 +59,6 @@ spec:
       url: "https://prometheus.{{ .Release.Namespace }}.svc:9090"
     tracing:
       auth:
-        ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
         type: "basic"
         use_kiali_token: false
         username: "internal"

--- a/resources/helm/v1.0/istio/charts/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/v1.0/istio/charts/kiali/templates/kiali-cr.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   installation_tag: "Kiali [{{ .Release.Namespace }}]"
   istio_namespace: "{{ .Release.Namespace }}"
+  version: "v1.0"
 
   auth:
     strategy: "openshift"

--- a/resources/helm/v1.0/istio/charts/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/v1.0/istio/charts/kiali/templates/kiali-cr.yaml
@@ -42,7 +42,6 @@ spec:
   external_services:
     grafana:
       auth:
-        ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
         type: "basic"
         use_kiali_token: false
         username: "internal"
@@ -56,7 +55,6 @@ spec:
 {{- end }}
     prometheus:
       auth:
-        ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
         type: "basic"
         use_kiali_token: false
         username: "internal"
@@ -64,7 +62,6 @@ spec:
       url: "https://prometheus.{{ .Release.Namespace }}.svc:9090"
     tracing:
       auth:
-        ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
         type: "basic"
         use_kiali_token: false
         username: "internal"

--- a/resources/helm/v1.1/istio/charts/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/v1.1/istio/charts/kiali/templates/kiali-cr.yaml
@@ -39,7 +39,6 @@ spec:
   external_services:
     grafana:
       auth:
-        ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
         type: "basic"
         use_kiali_token: false
         username: "internal"
@@ -53,7 +52,6 @@ spec:
 {{- end }}
     prometheus:
       auth:
-        ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
         type: "basic"
         use_kiali_token: false
         username: "internal"
@@ -61,7 +59,6 @@ spec:
       url: "https://prometheus.{{ .Release.Namespace }}.svc:9090"
     tracing:
       auth:
-        ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
         type: "basic"
         use_kiali_token: false
         username: "internal"

--- a/resources/helm/v2.0/istio-telemetry/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/v2.0/istio-telemetry/kiali/templates/kiali-cr.yaml
@@ -39,7 +39,6 @@ spec:
   external_services:
     grafana:
       auth:
-        ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
         type: "basic"
         use_kiali_token: false
         username: "internal"
@@ -53,7 +52,6 @@ spec:
 {{- end }}
     prometheus:
       auth:
-        ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
         type: "basic"
         use_kiali_token: false
         username: "internal"
@@ -61,7 +59,6 @@ spec:
       url: "https://prometheus.{{ .Release.Namespace }}.svc:9090"
     tracing:
       auth:
-        ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
         type: "basic"
         use_kiali_token: false
         username: "internal"


### PR DESCRIPTION
Kiali has moved away from the deprecated service serving interface. The
Kiali operator is providing good defaults for ca_file in OpenShift, so
it's no longer needed that maistra operator specifies these options.