### PR TITLE
MAISTRA-1750 Make sure configuredMembers is never omitted in JSON marshalling

### DIFF
--- a/pkg/apis/maistra/v1/servicemeshmemberroll_types.go
+++ b/pkg/apis/maistra/v1/servicemeshmemberroll_types.go
@@ -83,7 +83,7 @@ type ServiceMeshMemberRollStatus struct {
 	// List of namespaces that are configured as members of the service mesh.
 	// +optional
 	// +nullable
-	ConfiguredMembers []string `json:"configuredMembers,omitempty"`
+	ConfiguredMembers []string `json:"configuredMembers"`
 
 	// Represents the latest available observations of this ServiceMeshMemberRoll's
 	// current state.


### PR DESCRIPTION
This led to bugs when setting smmr.spec.members to `[]` which never resulted in the status.configuredMembers to be set to `[]` because it was omitted from the patch generated by the controller