### PR TITLE
Update 3scale image references for 2.0

### DIFF
--- a/deploy/maistra-operator.yaml
+++ b/deploy/maistra-operator.yaml
@@ -6975,7 +6975,7 @@ spec:
         olm.relatedImage.v1_1.proxyv2: docker.io/maistra/proxyv2-ubi8:1.1.8
         olm.relatedImage.v1_1.sidecar-injector: docker.io/maistra/sidecar-injector-ubi8:1.1.8
 
-        olm.relatedImage.v2_0.3scale-istio-adapter: quay.io/3scale/3scale-istio-adapter:v1.0.0
+        olm.relatedImage.v2_0.3scale-istio-adapter: quay.io/3scale/3scale-istio-adapter:v2.0.0
         olm.relatedImage.v2_0.cni: docker.io/maistra/istio-cni-ubi8:2.0.0
         olm.relatedImage.v2_0.grafana: docker.io/maistra/grafana-ubi8:2.0.0
         olm.relatedImage.v2_0.mixer: docker.io/maistra/mixer-ubi8:2.0.0

--- a/deploy/servicemesh-operator.yaml
+++ b/deploy/servicemesh-operator.yaml
@@ -6975,7 +6975,7 @@ spec:
         olm.relatedImage.v1_1.proxyv2: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:1.1.8
         olm.relatedImage.v1_1.sidecar-injector: registry.redhat.io/openshift-service-mesh/sidecar-injector-rhel8:1.1.8
 
-        olm.relatedImage.v2_0.3scale-istio-adapter: registry.redhat.io/openshift-service-mesh/3scale-istio-adapter-rhel8:1.0.0
+        olm.relatedImage.v2_0.3scale-istio-adapter: registry.redhat.io/openshift-service-mesh/3scale-istio-adapter-rhel8:2.0.0
         olm.relatedImage.v2_0.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel8:2.0.0
         olm.relatedImage.v2_0.grafana: registry.redhat.io/openshift-service-mesh/grafana-rhel8:2.0.0
         olm.relatedImage.v2_0.mixer: registry.redhat.io/openshift-service-mesh/mixer-rhel8:2.0.0

--- a/resources/smcp-templates/v2.0/maistra
+++ b/resources/smcp-templates/v2.0/maistra
@@ -35,7 +35,7 @@ spec:
         container:
           imageRegistry: quay.io/3scale
           imageName: 3scale-istio-adapter
-          imageTag: v1.0.0
+          imageTag: v2.0.0
       global.oauthproxy:
         container:
           imageRegistry: quay.io/openshift

--- a/resources/smcp-templates/v2.0/servicemesh
+++ b/resources/smcp-templates/v2.0/servicemesh
@@ -35,7 +35,7 @@ spec:
         container:
           imageRegistry: registry.redhat.io/openshift-service-mesh
           imageName: 3scale-istio-adapter-rhel8
-          imageTag: 1.0.0
+          imageTag: 2.0.0
       global.oauthproxy:
         container:
           imageRegistry: image-registry.openshift-image-registry.svc:5000/openshift


### PR DESCRIPTION
Follow up to #522 for updating references to the 3scale Istio Adapter container image as suggested in https://github.com/maistra/istio-operator/pull/522#issuecomment-700129430.

The templates for the adapter and the authorization remain the same, so those do not need updates.