### PR TITLE
MAISTRA-1723: Disable NodePort gateway support

### DIFF
--- a/build/patch-charts.sh
+++ b/build/patch-charts.sh
@@ -163,6 +163,7 @@ function patchGalley() {
   sed_wrap -i -e '/- "discovery"/ a\
           - --memberRollName=default\
           - --cacheCluster=outbound|80||wasm-cacher-{{ .Values.revision | default "default" }}.{{ .Release.Namespace }}.svc.cluster.local\
+          - --enableNodePortGateways=false\
           - --podLocalitySource=pod' ${HELM_DIR}/istio-control/istio-discovery/templates/deployment.yaml
   # disable webhook config updates
   sed_wrap -i -r -e '/INJECTION_WEBHOOK_CONFIG_NAME/,/ISTIOD_ADDR/ {

--- a/resources/helm/v2.0/istio-control/istio-discovery/templates/deployment.yaml
+++ b/resources/helm/v2.0/istio-control/istio-discovery/templates/deployment.yaml
@@ -61,6 +61,7 @@ spec:
           - "discovery"
           - --memberRollName=default
           - --cacheCluster=outbound|80||wasm-cacher-{{ .Values.revision | default "default" }}.{{ .Release.Namespace }}.svc.cluster.local
+          - --enableNodePortGateways=false
           - --podLocalitySource=pod
           - --monitoringAddr=:15014
 {{- if .Values.global.logging.level }}


### PR DESCRIPTION
Istio 1.6 introduced support for gateways exposed as NodePort
services, but it requires cluster-scoped read permissions on nodes.
An option to disable this was added in maistra/istio#180 and this
updates the charts to use it.