### PR TITLE
Fix typo in go.mod file for goautoneg

### DIFF
--- a/internal/bitbucket.org/ww/goautoneg/go.mod
+++ b/internal/bitbucket.org/ww/goautoneg/go.mod
@@ -1,3 +1,3 @@
-module github.com/maistra/istio-operator/internal/bitbucket.org/ww/goautonet
+module github.com/maistra/istio-operator/internal/bitbucket.org/ww/goautoneg
 
 go 1.13


### PR DESCRIPTION
Spotted a typo in the Go modules file.

P.S.: if possible, I'd appreciate if the `hacktoberfest-accepted` label was added to this PR :+1: 