### PR TITLE
MAISTRA-1722: Remove cluster-scoped permissions from istiod

### DIFF
--- a/resources/helm/overlays/istio-control/istio-discovery/templates/meshclusterrole.yaml
+++ b/resources/helm/overlays/istio-control/istio-discovery/templates/meshclusterrole.yaml
@@ -11,13 +11,3 @@ rules:
   - apiGroups: ["authentication.k8s.io"]
     resources: ["tokenreviews"]
     verbs: ["create"]
-  # additional perms required for istiod startup
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["networking.k8s.io"]
-    resources: ["ingresses", "ingressclasses"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["networking.k8s.io"]
-    resources: ["ingresses/status"]
-    verbs: ["*"]

--- a/resources/helm/v2.0/istio-control/istio-discovery/templates/meshclusterrole.yaml
+++ b/resources/helm/v2.0/istio-control/istio-discovery/templates/meshclusterrole.yaml
@@ -12,13 +12,3 @@ rules:
   - apiGroups: ["authentication.k8s.io"]
     resources: ["tokenreviews"]
     verbs: ["create"]
-  # additional perms required for istiod startup
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["networking.k8s.io"]
-    resources: ["ingresses", "ingressclasses"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["networking.k8s.io"]
-    resources: ["ingresses/status"]
-    verbs: ["*"]


### PR DESCRIPTION
This removes the temporary cluster-scoped permissions from the
istiod-internal ClusterRole.  The ability to create TokenReviews is
all that's left here, which is not an issue.