### PR TITLE
MAISTRA-1903 Revert proxy.global.tracer renaming

### DIFF
--- a/build/patch-charts.sh
+++ b/build/patch-charts.sh
@@ -244,9 +244,6 @@ function patchGateways() {
                 lightstep:\
                   address: {{ .Values.global.tracer.lightstep.address }}\
                   accessToken: {{ .Values.global.tracer.lightstep.accessToken }}\
-              {{- else if eq .Values.global.proxy.tracer "jaeger" }}\
-                zipkin:\
-                  address: {{ .Values.global.tracer.zipkin.address }}\
               {{- else if eq .Values.global.proxy.tracer "zipkin" }}\
                 zipkin:\
                 {{- if .Values.global.tracer.zipkin.address }}\

--- a/build/patch-jaeger.sh
+++ b/build/patch-jaeger.sh
@@ -25,20 +25,10 @@ function jaeger_remove_files() {
   rm -f ${HELM_DIR}/istio-telemetry/tracing/templates/pvc.yaml
 }
 
-function jaeger_istio_config() {
-  sed_wrap -i -e '/else if eq .Values.global.proxy.tracer "zipkin"/ i\
-      {{- else if eq .Values.global.proxy.tracer "jaeger" }}\
-        zipkin:\
-          # Address of the Jaeger collector\
-          address: {{ .Values.global.tracer.zipkin.address }}' \
-      ${HELM_DIR}/istio-control/istio-discovery/templates/configmap.yaml
-}
-
 function JaegerPatch() {
   echo "Patching Jaeger"
 
   jaeger_remove_files
-  jaeger_istio_config
 }
 
 jaeger_patch_values

--- a/pkg/apis/maistra/conversion/jaeger_test.go
+++ b/pkg/apis/maistra/conversion/jaeger_test.go
@@ -72,7 +72,7 @@ var jaegerTestCases = []conversionTestCase{
 				},
 				"enableTracing": true,
 				"proxy": map[string]interface{}{
-					"tracer": "jaeger",
+					"tracer": "zipkin",
 				},
 			},
 			"tracing": map[string]interface{}{
@@ -106,7 +106,7 @@ var jaegerTestCases = []conversionTestCase{
 				},
 				"enableTracing": true,
 				"proxy": map[string]interface{}{
-					"tracer": "jaeger",
+					"tracer": "zipkin",
 				},
 			},
 			"pilot": map[string]interface{}{
@@ -150,7 +150,7 @@ var jaegerTestCases = []conversionTestCase{
 				},
 				"enableTracing": true,
 				"proxy": map[string]interface{}{
-					"tracer": "jaeger",
+					"tracer": "zipkin",
 				},
 			},
 			"tracing": map[string]interface{}{
@@ -192,7 +192,7 @@ var jaegerTestCases = []conversionTestCase{
 				},
 				"enableTracing": true,
 				"proxy": map[string]interface{}{
-					"tracer": "jaeger",
+					"tracer": "zipkin",
 				},
 			},
 			"tracing": map[string]interface{}{
@@ -236,7 +236,7 @@ var jaegerTestCases = []conversionTestCase{
 				},
 				"enableTracing": true,
 				"proxy": map[string]interface{}{
-					"tracer": "jaeger",
+					"tracer": "zipkin",
 				},
 			},
 			"tracing": map[string]interface{}{
@@ -283,7 +283,7 @@ var jaegerTestCases = []conversionTestCase{
 				},
 				"enableTracing": true,
 				"proxy": map[string]interface{}{
-					"tracer": "jaeger",
+					"tracer": "zipkin",
 				},
 			},
 			"tracing": map[string]interface{}{
@@ -331,7 +331,7 @@ var jaegerTestCases = []conversionTestCase{
 				},
 				"enableTracing": true,
 				"proxy": map[string]interface{}{
-					"tracer": "jaeger",
+					"tracer": "zipkin",
 				},
 			},
 			"tracing": map[string]interface{}{
@@ -384,7 +384,7 @@ var jaegerTestCases = []conversionTestCase{
 				},
 				"enableTracing": true,
 				"proxy": map[string]interface{}{
-					"tracer": "jaeger",
+					"tracer": "zipkin",
 				},
 			},
 			"tracing": map[string]interface{}{
@@ -431,7 +431,7 @@ var jaegerTestCases = []conversionTestCase{
 				},
 				"enableTracing": true,
 				"proxy": map[string]interface{}{
-					"tracer": "jaeger",
+					"tracer": "zipkin",
 				},
 			},
 			"tracing": map[string]interface{}{
@@ -479,7 +479,7 @@ var jaegerTestCases = []conversionTestCase{
 				},
 				"enableTracing": true,
 				"proxy": map[string]interface{}{
-					"tracer": "jaeger",
+					"tracer": "zipkin",
 				},
 			},
 			"tracing": map[string]interface{}{
@@ -551,7 +551,7 @@ var jaegerTestCases = []conversionTestCase{
 				},
 				"enableTracing": true,
 				"proxy": map[string]interface{}{
-					"tracer": "jaeger",
+					"tracer": "zipkin",
 				},
 			},
 			"tracing": map[string]interface{}{
@@ -595,7 +595,7 @@ var jaegerTestCases = []conversionTestCase{
 				},
 				"enableTracing": true,
 				"proxy": map[string]interface{}{
-					"tracer": "jaeger",
+					"tracer": "zipkin",
 				},
 			},
 			"tracing": map[string]interface{}{
@@ -660,7 +660,7 @@ var jaegerTestCases = []conversionTestCase{
 				},
 				"enableTracing": true,
 				"proxy": map[string]interface{}{
-					"tracer": "jaeger",
+					"tracer": "zipkin",
 				},
 			},
 			"tracing": map[string]interface{}{

--- a/pkg/apis/maistra/conversion/tracing.go
+++ b/pkg/apis/maistra/conversion/tracing.go
@@ -39,7 +39,7 @@ func populateTracingValues(in *v2.ControlPlaneSpec, values map[string]interface{
 			if err := setHelmBoolValue(values, "global.enableTracing", true); err != nil {
 				return err
 			}
-			if err := setHelmStringValue(values, "global.proxy.tracer", "jaeger"); err != nil {
+			if err := setHelmStringValue(values, "global.proxy.tracer", "zipkin"); err != nil {
 				return err
 			}
 		case v2.TracerTypeStackdriver:
@@ -114,6 +114,8 @@ func populateTracingConfig(in *v1.HelmValues, out *v2.ControlPlaneSpec) error {
 
 func tracerTypeFromString(tracer string) (v2.TracerType, error) {
 	switch strings.ToLower(tracer) {
+	case "zipkin":
+		return v2.TracerTypeJaeger, nil
 	case strings.ToLower(string(v2.TracerTypeJaeger)):
 		return v2.TracerTypeJaeger, nil
 	case strings.ToLower(string(v2.TracerTypeStackdriver)):

--- a/resources/helm/v2.0/gateways/istio-egress/templates/deployment.yaml
+++ b/resources/helm/v2.0/gateways/istio-egress/templates/deployment.yaml
@@ -162,9 +162,6 @@ spec:
                 lightstep:
                   address: {{ .Values.global.tracer.lightstep.address }}
                   accessToken: {{ .Values.global.tracer.lightstep.accessToken }}
-              {{- else if eq .Values.global.proxy.tracer "jaeger" }}
-                zipkin:
-                  address: {{ .Values.global.tracer.zipkin.address }}
               {{- else if eq .Values.global.proxy.tracer "zipkin" }}
                 zipkin:
                 {{- if .Values.global.tracer.zipkin.address }}

--- a/resources/helm/v2.0/gateways/istio-ingress/templates/deployment.yaml
+++ b/resources/helm/v2.0/gateways/istio-ingress/templates/deployment.yaml
@@ -165,9 +165,6 @@ spec:
                 lightstep:
                   address: {{ .Values.global.tracer.lightstep.address }}
                   accessToken: {{ .Values.global.tracer.lightstep.accessToken }}
-              {{- else if eq .Values.global.proxy.tracer "jaeger" }}
-                zipkin:
-                  address: {{ .Values.global.tracer.zipkin.address }}
               {{- else if eq .Values.global.proxy.tracer "zipkin" }}
                 zipkin:
                 {{- if .Values.global.tracer.zipkin.address }}

--- a/resources/helm/v2.0/istio-control/istio-discovery/templates/configmap.yaml
+++ b/resources/helm/v2.0/istio-control/istio-discovery/templates/configmap.yaml
@@ -177,10 +177,6 @@
           address: {{ .Values.global.tracer.lightstep.address }}
           # Access Token used to communicate with the Satellite pool
           accessToken: {{ .Values.global.tracer.lightstep.accessToken }}
-      {{- else if eq .Values.global.proxy.tracer "jaeger" }}
-        zipkin:
-          # Address of the Jaeger collector
-          address: {{ .Values.global.tracer.zipkin.address }}
       {{- else if eq .Values.global.proxy.tracer "zipkin" }}
         zipkin:
           # Address of the Zipkin collector


### PR DESCRIPTION
This changes the default back to 'zipkin' to stay compatible with the 1.1/1.0 charts