### PR TITLE
MAISTRA-1816 Set status.configuredMembers to [] when SMCP is deleted

### DIFF
--- a/pkg/controller/servicemesh/memberroll/controller.go
+++ b/pkg/controller/servicemesh/memberroll/controller.go
@@ -399,6 +399,7 @@ func (r *MemberRollReconciler) getActiveMesh(ctx context.Context, instance *v1.S
 				})
 			} else {
 				reqLogger.Info("Skipping reconciliation of SMMR, because no ServiceMeshControlPlane exists in the project.", "project", instance.Namespace)
+				instance.Status.ConfiguredMembers = make([]string, 0)
 				instance.Status.SetCondition(v1.ServiceMeshMemberRollCondition{
 					Type:    v1.ConditionTypeMemberRollReady,
 					Status:  corev1.ConditionFalse,


### PR DESCRIPTION
When deleting an SMCP and re-creating it with a different version, the control plane requires different RoleBindings in the mesh's member namespaces. Keeping the status.configuredMembers across SMCP deletions can therefore cause problems that can be hard to recover from (only by deleting the SMMR manually), because the new control plane (with a different Istio version) will assume it has access to the mesh's member namespaces while it fact it doesn't, because the RoleBindings are not correct or point to ClusterRoles and Roles that no longer exist.