### PR TITLE
MAISTRA-1938 Ensure all ports are forwarded to the proxy by default

### DIFF
--- a/build/patch-charts.sh
+++ b/build/patch-charts.sh
@@ -421,6 +421,12 @@ function patchSidecarInjector() {
   # use the correct cni network defintion
   sed_wrap -i -e '/podRedirectAnnot:/,$s/istio-cni/{{ .Values.istio_cni.istio_cni_network }}/' \
       ${HELM_DIR}/istio-control/istio-discovery/files/injection-template.yaml
+
+  # MAISTRA-1938 Ensure all ports are forwarded to the proxy by default
+  sed_wrap -i -e 's/(includeInboundPorts \.Spec\.Containers)/`*`/g' \
+      ${HELM_DIR}/istio-control/istio-discovery/files/injection-template.yaml
+  sed_wrap -i -e 's/(includeInboundPorts \.Spec\.Containers)/`*`/g' \
+      ${HELM_DIR}/istio-control/istio-discovery/files/gen-istio.yaml
 }
 
 function patchMixer() {

--- a/resources/helm/v2.0/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/resources/helm/v2.0/istio-control/istio-discovery/files/gen-istio.yaml
@@ -752,7 +752,7 @@ data:
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         traffic.sidecar.istio.io/includeOutboundIPRanges: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}"
         traffic.sidecar.istio.io/excludeOutboundIPRanges: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundIPRanges` .Values.global.proxy.excludeIPRanges }}"
-        traffic.sidecar.istio.io/includeInboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` (includeInboundPorts .Spec.Containers) }}"
+        traffic.sidecar.istio.io/includeInboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
         traffic.sidecar.istio.io/excludeInboundPorts: "{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
       {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne .Values.global.proxy.excludeOutboundPorts "") }}
         traffic.sidecar.istio.io/excludeOutboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"

--- a/resources/helm/v2.0/istio-control/istio-discovery/files/injection-template.yaml
+++ b/resources/helm/v2.0/istio-control/istio-discovery/files/injection-template.yaml
@@ -435,7 +435,7 @@ template: |
     sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
     traffic.sidecar.istio.io/includeOutboundIPRanges: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}"
     traffic.sidecar.istio.io/excludeOutboundIPRanges: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundIPRanges` .Values.global.proxy.excludeIPRanges }}"
-    traffic.sidecar.istio.io/includeInboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` (includeInboundPorts .Spec.Containers) }}"
+    traffic.sidecar.istio.io/includeInboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
     traffic.sidecar.istio.io/excludeInboundPorts: "{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
   {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne .Values.global.proxy.excludeOutboundPorts "") }}
     traffic.sidecar.istio.io/excludeOutboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"


### PR DESCRIPTION
When using the init container, all ports are forwarded, but the
template for CNI is such that iptables rules are configured to
only forward the ports that are specified in the pod definition,
while all others go straight to the application container.

This causes the AuthorizationPolicy to not have any effect on
these other ports.