### PR TITLE
MAISTRA-1974 Set enableClientPolicyCheck if policy.type==Mixer

### DIFF
--- a/build/patch-charts.sh
+++ b/build/patch-charts.sh
@@ -218,6 +218,9 @@ base:
     rootNamespace: {{ .Values.global.configRootNamespace }}\
 {{- else }}\
     rootNamespace: {{ .Release.Namespace }}\
+{{- end }}\
+{{- if and (.Values.mixer.policy.enabled) (not .Values.global.disablePolicyChecks) }}\
+    enableClientSidePolicyCheck: true\
 {{- end }}' \
     -e '/{{- if .Values.global.remotePolicyAddress }}/,/{{- if and .Values.telemetry.v1.enabled .Values.telemetry.enabled }}/ {
         /{{- if .Values.mixer.policy.enabled }}/,/{{- if and .Values.telemetry.v1.enabled .Values.telemetry.enabled }}/ {

--- a/resources/helm/v2.0/istio-control/istio-discovery/templates/configmap.yaml
+++ b/resources/helm/v2.0/istio-control/istio-discovery/templates/configmap.yaml
@@ -144,6 +144,9 @@
 {{- else }}
     rootNamespace: {{ .Release.Namespace }}
 {{- end }}
+{{- if and (.Values.mixer.policy.enabled) (not .Values.global.disablePolicyChecks) }}
+    enableClientSidePolicyCheck: true
+{{- end }}
     defaultConfig:
       #
       # TCP connection timeout between Envoy & the application, and between Envoys.


### PR DESCRIPTION
This makes sure that the mixer filter is always injected into the outbound filter chain if we're using Mixer policy checks