### PR TITLE
MAISTRA-1996 preserve v1 content on conversion errors; MAISTRA-1991 preserve unused jaeger config for v1 to v2 round tripping

### DIFF
--- a/pkg/apis/maistra/conversion/common.go
+++ b/pkg/apis/maistra/conversion/common.go
@@ -6,10 +6,13 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/yaml"
 
 	v2 "github.com/maistra/istio-operator/pkg/apis/maistra/v2"
 )
+
+var logger = logf.Log.WithName("smcp-converter")
 
 func setMetadataLabels(labels map[string]interface{}, out *v2.MetadataConfig) error {
 	if len(labels) > 0 {

--- a/pkg/apis/maistra/conversion/conversion_test.go
+++ b/pkg/apis/maistra/conversion/conversion_test.go
@@ -874,6 +874,221 @@ var (
 				},
 			}),
 		},
+		{
+			name: "MAISTRA-1983.user.2",
+			smcpv1: v1.ControlPlaneSpec{
+				Version: "v1.1",
+				// specifying both Template and Profiles saves having to duplicate
+				// everything in roundTripped, i.e. this will round trip exactly
+				Template: "default",
+				Profiles: []string{"default"},
+				Istio: v1.NewHelmValues(map[string]interface{}{
+					"gateways": map[string]interface{}{
+						"istio-ingressgateway": map[string]interface{}{
+							"autoscaleEnabled":      false,
+							"externalTrafficPolicy": "Local",
+							"ior_enabled":           false,
+							"ports": []interface{}{
+								map[string]interface{}{
+									"name":       "status-port",
+									"nodePort":   int64(30158),
+									"port":       int64(15020),
+									"protocol":   "TCP",
+									"targetPort": int64(15020),
+								},
+								map[string]interface{}{
+									"name":       "http2",
+									"nodePort":   int64(32520),
+									"port":       int64(80),
+									"protocol":   "TCP",
+									"targetPort": int64(8082),
+								},
+								map[string]interface{}{
+									"name":       "https",
+									"nodePort":   int64(32731),
+									"port":       int64(443),
+									"protocol":   "TCP",
+									"targetPort": int64(8443),
+								},
+								map[string]interface{}{
+									"name":       "tls",
+									"nodePort":   int64(30462),
+									"port":       int64(15443),
+									"protocol":   "TCP",
+									"targetPort": int64(15443),
+								},
+							},
+							"replicaCount": int64(5),
+							"sds": map[string]interface{}{
+								"enabled": true,
+								"image":   "istio/node-agent-k8s:1.5.9",
+							},
+							"type": "NodePort",
+						},
+					},
+					"global": map[string]interface{}{
+						"controlPlaneSecurityEnabled": true,
+						"disablePolicyChecks":         false,
+						"logging": map[string]interface{}{
+							"level": "default:info",
+						},
+						"mtls": map[string]interface{}{
+							"enabled": true,
+						},
+						"outboundTrafficPolicy": map[string]interface{}{
+							"mode": "REGISTRY_ONLY",
+						},
+						"policyCheckFailOpen": false,
+						"proxy": map[string]interface{}{
+							"accessLogFile": "/dev/stdout",
+						},
+						"tls": map[string]interface{}{
+							"minProtocolVersion": "TLSv1_2",
+						},
+					},
+					"grafana": map[string]interface{}{
+						"enabled": true,
+					},
+					"kiali": map[string]interface{}{
+						"enabled": true,
+					},
+					"mixer": map[string]interface{}{
+						"policy": map[string]interface{}{
+							"autoscaleEnabled": false,
+						},
+						"telemetry": map[string]interface{}{
+							"autoscaleEnabled": false,
+						},
+					},
+					"pilot": map[string]interface{}{
+						"autoscaleEnabled": false,
+						"traceSampling":    int64(100),
+					},
+					"tracing": map[string]interface{}{
+						"enabled": true,
+						"jaeger": map[string]interface{}{
+							"elasticsearch": map[string]interface{}{
+								"esIndexCleaner": map[string]interface{}{
+									"enabled":      true,
+									"numberOfDays": int64(60),
+									"schedule":     "55 23 * * *",
+								},
+								"nodeCount":        int64(3),
+								"redundancyPolicy": nil,
+							},
+							"template": "production-bad",
+						},
+					},
+				}),
+			},
+			smcpv2: v2.ControlPlaneSpec{
+				Version:  "v1.1",
+				Profiles: []string{"default"},
+				TechPreview: v1.NewHelmValues(map[string]interface{}{
+					"errored": map[string]interface{}{
+						"istio": map[string]interface{}{
+							"gateways": map[string]interface{}{
+								"istio-ingressgateway": map[string]interface{}{
+									"autoscaleEnabled":      false,
+									"externalTrafficPolicy": "Local",
+									"ior_enabled":           false,
+									"ports": []interface{}{
+										map[string]interface{}{
+											"name":       "status-port",
+											"nodePort":   int64(30158),
+											"port":       int64(15020),
+											"protocol":   "TCP",
+											"targetPort": int64(15020),
+										},
+										map[string]interface{}{
+											"name":       "http2",
+											"nodePort":   int64(32520),
+											"port":       int64(80),
+											"protocol":   "TCP",
+											"targetPort": int64(8082),
+										},
+										map[string]interface{}{
+											"name":       "https",
+											"nodePort":   int64(32731),
+											"port":       int64(443),
+											"protocol":   "TCP",
+											"targetPort": int64(8443),
+										},
+										map[string]interface{}{
+											"name":       "tls",
+											"nodePort":   int64(30462),
+											"port":       int64(15443),
+											"protocol":   "TCP",
+											"targetPort": int64(15443),
+										},
+									},
+									"replicaCount": int64(5),
+									"sds": map[string]interface{}{
+										"enabled": true,
+										"image":   "istio/node-agent-k8s:1.5.9",
+									},
+									"type": "NodePort",
+								},
+							},
+							"global": map[string]interface{}{
+								"controlPlaneSecurityEnabled": true,
+								"disablePolicyChecks":         false,
+								"logging": map[string]interface{}{
+									"level": "default:info",
+								},
+								"mtls": map[string]interface{}{
+									"enabled": true,
+								},
+								"outboundTrafficPolicy": map[string]interface{}{
+									"mode": "REGISTRY_ONLY",
+								},
+								"policyCheckFailOpen": false,
+								"proxy": map[string]interface{}{
+									"accessLogFile": "/dev/stdout",
+								},
+								"tls": map[string]interface{}{
+									"minProtocolVersion": "TLSv1_2",
+								},
+							},
+							"grafana": map[string]interface{}{
+								"enabled": true,
+							},
+							"kiali": map[string]interface{}{
+								"enabled": true,
+							},
+							"mixer": map[string]interface{}{
+								"policy": map[string]interface{}{
+									"autoscaleEnabled": false,
+								},
+								"telemetry": map[string]interface{}{
+									"autoscaleEnabled": false,
+								},
+							},
+							"pilot": map[string]interface{}{
+								"autoscaleEnabled": false,
+								"traceSampling":    int64(100),
+							},
+							"tracing": map[string]interface{}{
+								"enabled": true,
+								"jaeger": map[string]interface{}{
+									"elasticsearch": map[string]interface{}{
+										"esIndexCleaner": map[string]interface{}{
+											"enabled":      true,
+											"numberOfDays": int64(60),
+											"schedule":     "55 23 * * *",
+										},
+										"nodeCount":        int64(3),
+										"redundancyPolicy": nil,
+									},
+									"template": "production-bad",
+								},
+							},
+						},
+						"message": string("unknown jaeger.template: production-bad"),
+					},
+				}),
+			},
+		},
 	}
 )
 

--- a/pkg/apis/maistra/conversion/conversion_test.go
+++ b/pkg/apis/maistra/conversion/conversion_test.go
@@ -38,11 +38,12 @@ var (
 	}
 
 	roundTripTestCases = []struct {
-		name   string
-		smcpv1 v1.ControlPlaneSpec
-		smcpv2 v2.ControlPlaneSpec
-		cruft  *v1.HelmValues // these are just the key paths that need to be removed
-		skip   bool
+		name         string
+		smcpv1       v1.ControlPlaneSpec
+		smcpv2       v2.ControlPlaneSpec
+		roundTripped *v1.ControlPlaneSpec
+		cruft        *v1.HelmValues // these are just the key paths that need to be removed
+		skip         bool
 	}{
 		{
 			name: "simple",
@@ -275,6 +276,604 @@ var (
 				},
 			}),
 		},
+		{
+			name: "MAISTRA-1983.1",
+			smcpv1: v1.ControlPlaneSpec{
+				Version: "v1.1",
+				Istio: v1.NewHelmValues(map[string]interface{}{
+					"tracing": map[string]interface{}{
+						"jaeger": map[string]interface{}{
+							"elasticsearch": map[string]interface{}{
+								"nodeCount":        int64(5),
+								"redundancyPolicy": nil,
+								"esIndexCleaner": map[string]interface{}{
+									"enabled":      true,
+									"numberOfDays": int64(60),
+									"schedule":     "55 23 * * *",
+								},
+							},
+						},
+					},
+				}),
+			},
+			smcpv2: v2.ControlPlaneSpec{
+				Version: "v1.1",
+				Addons: &v2.AddonsConfig{
+					Jaeger: &v2.JaegerAddonConfig{
+						Install: &v2.JaegerInstallConfig{
+							Storage: &v2.JaegerStorageConfig{
+								Elasticsearch: &v2.JaegerElasticsearchStorageConfig{
+									NodeCount: &jaegerElasticsearchNodeCount,
+								},
+							},
+						},
+					},
+				},
+				TechPreview: v1.NewHelmValues(map[string]interface{}{
+					"tracing": map[string]interface{}{
+						"jaeger": map[string]interface{}{
+							"elasticsearch": map[string]interface{}{
+								"esIndexCleaner": map[string]interface{}{
+									"enabled":      true,
+									"numberOfDays": int64(60),
+									"schedule":     "55 23 * * *",
+								},
+							},
+						},
+					},
+				}),
+			},
+			roundTripped: &v1.ControlPlaneSpec{
+				Version: "v1.1",
+				Istio: v1.NewHelmValues(map[string]interface{}{
+					"tracing": map[string]interface{}{
+						"jaeger": map[string]interface{}{
+							"elasticsearch": map[string]interface{}{
+								"nodeCount": int64(5),
+								"esIndexCleaner": map[string]interface{}{
+									"enabled":      true,
+									"numberOfDays": int64(60),
+									"schedule":     "55 23 * * *",
+								},
+							},
+						},
+					},
+				}),
+			},
+			cruft: v1.NewHelmValues(map[string]interface{}{
+				"global": map[string]interface{}{
+					// mesh expansion is disabled by default
+					"meshExpansion": globalMeshExpansionDefaults,
+					// multicluster is disabled by default
+					"multiCluster": globalMultiClusterDefaults,
+				},
+			}),
+		},
+		{
+			name: "MAISTRA-1983.2",
+			smcpv1: v1.ControlPlaneSpec{
+				Version: "v1.1",
+				Istio: v1.NewHelmValues(map[string]interface{}{
+					"tracing": map[string]interface{}{
+						"jaeger": map[string]interface{}{
+							"elasticsearch": map[string]interface{}{
+								"nodeCount":        int64(5),
+								"redundancyPolicy": nil,
+							},
+						},
+						"esIndexCleaner": map[string]interface{}{
+							"enabled":      true,
+							"numberOfDays": int64(60),
+							"schedule":     "55 23 * * *",
+						},
+					},
+				}),
+			},
+			smcpv2: v2.ControlPlaneSpec{
+				Version: "v1.1",
+				Addons: &v2.AddonsConfig{
+					Jaeger: &v2.JaegerAddonConfig{
+						Install: &v2.JaegerInstallConfig{
+							Storage: &v2.JaegerStorageConfig{
+								Elasticsearch: &v2.JaegerElasticsearchStorageConfig{
+									NodeCount: &jaegerElasticsearchNodeCount,
+								},
+							},
+						},
+					},
+				},
+				TechPreview: v1.NewHelmValues(map[string]interface{}{
+					"tracing": map[string]interface{}{
+						"esIndexCleaner": map[string]interface{}{
+							"enabled":      true,
+							"numberOfDays": int64(60),
+							"schedule":     "55 23 * * *",
+						},
+					},
+				}),
+			},
+			roundTripped: &v1.ControlPlaneSpec{
+				Version: "v1.1",
+				Istio: v1.NewHelmValues(map[string]interface{}{
+					"tracing": map[string]interface{}{
+						"jaeger": map[string]interface{}{
+							"elasticsearch": map[string]interface{}{
+								"nodeCount": int64(5),
+							},
+						},
+						"esIndexCleaner": map[string]interface{}{
+							"enabled":      true,
+							"numberOfDays": int64(60),
+							"schedule":     "55 23 * * *",
+						},
+					},
+				}),
+			},
+			cruft: v1.NewHelmValues(map[string]interface{}{
+				"global": map[string]interface{}{
+					// mesh expansion is disabled by default
+					"meshExpansion": globalMeshExpansionDefaults,
+					// multicluster is disabled by default
+					"multiCluster": globalMultiClusterDefaults,
+				},
+			}),
+		},
+		{
+			name: "MAISTRA-1983.3",
+			smcpv1: v1.ControlPlaneSpec{
+				Version: "v1.1",
+				Istio: v1.NewHelmValues(map[string]interface{}{
+					"tracing": map[string]interface{}{
+						"jaeger": map[string]interface{}{
+							"elasticsearch": map[string]interface{}{
+								"nodeCount":        int64(5),
+								"redundancyPolicy": nil,
+							},
+							"esIndexCleaner": map[string]interface{}{
+								"enabled":      true,
+								"numberOfDays": int64(60),
+								"schedule":     "55 23 * * *",
+							},
+						},
+					},
+				}),
+			},
+			smcpv2: v2.ControlPlaneSpec{
+				Version: "v1.1",
+				Addons: &v2.AddonsConfig{
+					Jaeger: &v2.JaegerAddonConfig{
+						Install: &v2.JaegerInstallConfig{
+							Storage: &v2.JaegerStorageConfig{
+								Elasticsearch: &v2.JaegerElasticsearchStorageConfig{
+									NodeCount: &jaegerElasticsearchNodeCount,
+									IndexCleaner: v1.NewHelmValues(map[string]interface{}{
+										"enabled":      true,
+										"numberOfDays": int64(60),
+										"schedule":     "55 23 * * *",
+									}),
+								},
+							},
+						},
+					},
+				},
+			},
+			roundTripped: &v1.ControlPlaneSpec{
+				Version: "v1.1",
+				Istio: v1.NewHelmValues(map[string]interface{}{
+					"tracing": map[string]interface{}{
+						"jaeger": map[string]interface{}{
+							"elasticsearch": map[string]interface{}{
+								"nodeCount": int64(5),
+							},
+							"esIndexCleaner": map[string]interface{}{
+								"enabled":      true,
+								"numberOfDays": float64(60),
+								"schedule":     "55 23 * * *",
+							},
+						},
+					},
+				}),
+			},
+			cruft: v1.NewHelmValues(map[string]interface{}{
+				"global": map[string]interface{}{
+					// mesh expansion is disabled by default
+					"meshExpansion": globalMeshExpansionDefaults,
+					// multicluster is disabled by default
+					"multiCluster": globalMultiClusterDefaults,
+				},
+			}),
+		},
+		{
+			name: "MAISTRA-1983.user",
+			smcpv1: v1.ControlPlaneSpec{
+				Version:  "v1.1",
+				Template: "default",
+				Istio: v1.NewHelmValues(map[string]interface{}{
+					"gateways": map[string]interface{}{
+						"istio-ingressgateway": map[string]interface{}{
+							"autoscaleEnabled":      false,
+							"externalTrafficPolicy": "Local",
+							"ior_enabled":           false,
+							"ports": []interface{}{
+								map[string]interface{}{
+									"name":       "status-port",
+									"nodePort":   30158,
+									"port":       15020,
+									"protocol":   "TCP",
+									"targetPort": 15020,
+								},
+								map[string]interface{}{
+									"name":       "http2",
+									"nodePort":   32520,
+									"port":       80,
+									"protocol":   "TCP",
+									"targetPort": 8082,
+								},
+								map[string]interface{}{
+									"name":       "https",
+									"nodePort":   32731,
+									"port":       443,
+									"protocol":   "TCP",
+									"targetPort": 8443,
+								},
+								map[string]interface{}{
+									"name":       "tls",
+									"nodePort":   30462,
+									"port":       15443,
+									"protocol":   "TCP",
+									"targetPort": 15443,
+								},
+							},
+							"replicaCount": 5,
+							"sds": map[string]interface{}{
+								"enabled": true,
+								"image":   "istio/node-agent-k8s:1.5.9",
+							},
+							"type": "NodePort",
+						},
+					},
+					"global": map[string]interface{}{
+						"controlPlaneSecurityEnabled": true,
+						"disablePolicyChecks":         false,
+						"logging": map[string]interface{}{
+							"level": "default:info",
+						},
+						"mtls": map[string]interface{}{
+							"enabled": true,
+						},
+						"outboundTrafficPolicy": map[string]interface{}{
+							"mode": "REGISTRY_ONLY",
+						},
+						"policyCheckFailOpen": false,
+						"proxy": map[string]interface{}{
+							"accessLogFile": "/dev/stdout",
+						},
+						"tls": map[string]interface{}{
+							"minProtocolVersion": "TLSv1_2",
+						},
+					},
+					"grafana": map[string]interface{}{
+						"enabled": true,
+					},
+					"kiali": map[string]interface{}{
+						"enabled": true,
+					},
+					"mixer": map[string]interface{}{
+						"policy": map[string]interface{}{
+							"autoscaleEnabled": false,
+						},
+						"telemetry": map[string]interface{}{
+							"autoscaleEnabled": false,
+						},
+					},
+					"pilot": map[string]interface{}{
+						"autoscaleEnabled": false,
+						"traceSampling":    100,
+					},
+					"tracing": map[string]interface{}{
+						"enabled": true,
+						"jaeger": map[string]interface{}{
+							"elasticsearch": map[string]interface{}{
+								"esIndexCleaner": map[string]interface{}{
+									"enabled":      true,
+									"numberOfDays": 60,
+									"schedule":     "55 23 * * *",
+								},
+								"nodeCount":        3,
+								"redundancyPolicy": nil,
+							},
+							"template": "production-elasticsearch",
+						},
+					},
+				}),
+			},
+			smcpv2: v2.ControlPlaneSpec{
+				Version:  "v1.1",
+				Profiles: []string{"default"},
+				General: &v2.GeneralConfig{
+					Logging: &v2.LoggingConfig{
+						ComponentLevels: v2.ComponentLogLevels{
+							"default": "info",
+						},
+					},
+				},
+				Policy: &v2.PolicyConfig{
+					Mixer: &v2.MixerPolicyConfig{
+						EnableChecks: &featureEnabled,
+						FailOpen:     &featureDisabled,
+					},
+				},
+				Proxy: &v2.ProxyConfig{
+					Networking: &v2.ProxyNetworkingConfig{
+						TrafficControl: &v2.ProxyTrafficControlConfig{
+							Outbound: v2.ProxyOutboundTrafficControlConfig{
+								Policy: v2.ProxyOutboundTrafficPolicyRegistryOnly,
+							},
+						},
+					},
+					AccessLogging: &v2.ProxyAccessLoggingConfig{
+						File: &v2.ProxyFileAccessLogConfig{
+							Name: "/dev/stdout",
+						},
+					},
+				},
+				Security: &v2.SecurityConfig{
+					ControlPlane: &v2.ControlPlaneSecurityConfig{
+						MTLS: &featureEnabled,
+						TLS: &v2.ControlPlaneTLSConfig{
+							MinProtocolVersion: "TLSv1_2",
+						},
+					},
+					DataPlane: &v2.DataPlaneSecurityConfig{
+						MTLS: &featureEnabled,
+					},
+				},
+				Tracing: &v2.TracingConfig{
+					Type:     v2.TracerTypeJaeger,
+					Sampling: &traceSamplingInt10000,
+				},
+				Gateways: &v2.GatewaysConfig{
+					ClusterIngress: &v2.ClusterIngressGatewayConfig{
+						IngressGatewayConfig: v2.IngressGatewayConfig{
+							GatewayConfig: v2.GatewayConfig{
+								Service: v2.GatewayServiceConfig{
+									ServiceSpec: corev1.ServiceSpec{
+										Type:                  "NodePort",
+										ExternalTrafficPolicy: "Local",
+										Ports: []corev1.ServicePort{
+											{
+												Name:       "status-port",
+												Protocol:   "TCP",
+												Port:       15020,
+												TargetPort: intstr.FromInt(15020),
+												NodePort:   30158,
+											},
+											{
+												Name:       "http2",
+												Protocol:   "TCP",
+												Port:       80,
+												TargetPort: intstr.FromInt(8082),
+												NodePort:   32520,
+											},
+											{
+												Name:       "https",
+												Protocol:   "TCP",
+												Port:       443,
+												TargetPort: intstr.FromInt(8443),
+												NodePort:   32731,
+											},
+											{
+												Name:       "tls",
+												Protocol:   "TCP",
+												Port:       15443,
+												TargetPort: intstr.FromInt(15443),
+												NodePort:   30462,
+											},
+										},
+									},
+								},
+								Runtime: &v2.ComponentRuntimeConfig{
+									Deployment: &v2.DeploymentRuntimeConfig{
+										Replicas: &replicaCount5,
+										AutoScaling: &v2.AutoScalerConfig{
+											Enablement: v2.Enablement{Enabled: &featureDisabled},
+										},
+									},
+								},
+							},
+							SDS: &v2.SecretDiscoveryService{
+								Enablement: v2.Enablement{Enabled: &featureEnabled},
+								Runtime: &v2.ContainerConfig{
+									Image: "istio/node-agent-k8s:1.5.9",
+								},
+							},
+						},
+					},
+					OpenShiftRoute: &v2.OpenShiftRouteConfig{
+						Enablement: v2.Enablement{Enabled: &featureDisabled},
+					},
+				},
+				Runtime: &v2.ControlPlaneRuntimeConfig{
+					Components: map[v2.ControlPlaneComponentName]*v2.ComponentRuntimeConfig{
+						v2.ControlPlaneComponentNameMixerPolicy: {
+							Deployment: &v2.DeploymentRuntimeConfig{
+								AutoScaling: &v2.AutoScalerConfig{
+									Enablement: v2.Enablement{Enabled: &featureDisabled},
+								},
+							},
+						},
+						v2.ControlPlaneComponentNameMixerTelemetry: {
+							Deployment: &v2.DeploymentRuntimeConfig{
+								AutoScaling: &v2.AutoScalerConfig{
+									Enablement: v2.Enablement{Enabled: &featureDisabled},
+								},
+							},
+						},
+						v2.ControlPlaneComponentNamePilot: {
+							Deployment: &v2.DeploymentRuntimeConfig{
+								AutoScaling: &v2.AutoScalerConfig{
+									Enablement: v2.Enablement{Enabled: &featureDisabled},
+								},
+							},
+						},
+					},
+				},
+				Addons: &v2.AddonsConfig{
+					Grafana: &v2.GrafanaAddonConfig{
+						Enablement: v2.Enablement{Enabled: &featureEnabled},
+					},
+					Jaeger: &v2.JaegerAddonConfig{
+						Install: &v2.JaegerInstallConfig{
+							Storage: &v2.JaegerStorageConfig{
+								Type: v2.JaegerStorageTypeElasticsearch,
+								Elasticsearch: &v2.JaegerElasticsearchStorageConfig{
+									NodeCount: &jaegerElasticsearchNodeCount3,
+								},
+							},
+						},
+					},
+					Kiali: &v2.KialiAddonConfig{
+						Enablement: v2.Enablement{Enabled: &featureEnabled},
+					},
+				},
+				TechPreview: v1.NewHelmValues(map[string]interface{}{
+					"tracing": map[string]interface{}{
+						"jaeger": map[string]interface{}{
+							"elasticsearch": map[string]interface{}{
+								"esIndexCleaner": map[string]interface{}{
+									"enabled":      true,
+									"numberOfDays": int64(60),
+									"schedule":     "55 23 * * *",
+								},
+							},
+						},
+					},
+				}),
+			},
+			roundTripped: &v1.ControlPlaneSpec{
+				Version:  "v1.1",
+				Template: "default",
+				Profiles: []string{"default"},
+				Istio: v1.NewHelmValues(map[string]interface{}{
+					"gateways": map[string]interface{}{
+						"istio-ingressgateway": map[string]interface{}{
+							"autoscaleEnabled":      false,
+							"externalTrafficPolicy": "Local",
+							"ior_enabled":           false,
+							"ports": []interface{}{
+								map[string]interface{}{
+									"name":       "status-port",
+									"nodePort":   float64(30158),
+									"port":       float64(15020),
+									"protocol":   "TCP",
+									"targetPort": float64(15020),
+								},
+								map[string]interface{}{
+									"name":       "http2",
+									"nodePort":   float64(32520),
+									"port":       float64(80),
+									"protocol":   "TCP",
+									"targetPort": float64(8082),
+								},
+								map[string]interface{}{
+									"name":       "https",
+									"nodePort":   float64(32731),
+									"port":       float64(443),
+									"protocol":   "TCP",
+									"targetPort": float64(8443),
+								},
+								map[string]interface{}{
+									"name":       "tls",
+									"nodePort":   float64(30462),
+									"port":       float64(15443),
+									"protocol":   "TCP",
+									"targetPort": float64(15443),
+								},
+							},
+							"replicaCount": int64(5),
+							"sds": map[string]interface{}{
+								"enabled": true,
+								"image":   "istio/node-agent-k8s:1.5.9",
+							},
+							"type": "NodePort",
+						},
+					},
+					"global": map[string]interface{}{
+						"controlPlaneSecurityEnabled": true,
+						"disablePolicyChecks":         false,
+						"logging": map[string]interface{}{
+							"level": "default:info",
+						},
+						"mtls": map[string]interface{}{
+							"enabled": true,
+						},
+						"outboundTrafficPolicy": map[string]interface{}{
+							"mode": "REGISTRY_ONLY",
+						},
+						"policyCheckFailOpen": false,
+						"proxy": map[string]interface{}{
+							"accessLogFile": "/dev/stdout",
+						},
+						"tls": map[string]interface{}{
+							"minProtocolVersion": "TLSv1_2",
+						},
+					},
+					"grafana": map[string]interface{}{
+						"enabled": true,
+					},
+					"kiali": map[string]interface{}{
+						"enabled": true,
+					},
+					"mixer": map[string]interface{}{
+						"policy": map[string]interface{}{
+							"autoscaleEnabled": false,
+						},
+						"telemetry": map[string]interface{}{
+							"autoscaleEnabled": false,
+						},
+					},
+					"pilot": map[string]interface{}{
+						"autoscaleEnabled": false,
+						"traceSampling":    float64(100),
+					},
+					"tracing": map[string]interface{}{
+						"enabled": true,
+						"jaeger": map[string]interface{}{
+							"elasticsearch": map[string]interface{}{
+								"esIndexCleaner": map[string]interface{}{
+									"enabled":      true,
+									"numberOfDays": int64(60),
+									"schedule":     "55 23 * * *",
+								},
+								"nodeCount": int64(3),
+							},
+							"template": "production-elasticsearch",
+						},
+					},
+				}),
+			},
+			cruft: v1.NewHelmValues(map[string]interface{}{
+				"global": map[string]interface{}{
+					// mesh expansion is disabled by default
+					"meshExpansion": globalMeshExpansionDefaults,
+					// multicluster is disabled by default
+					"multiCluster":  globalMultiClusterDefaults,
+					"enableTracing": true,
+					"proxy": map[string]interface{}{
+						"tracer": "zipkin",
+					},
+				},
+				"gateways": map[string]interface{}{
+					"istio-ingressgateway": map[string]interface{}{
+						"gatewayType": "ingress",
+						"name":        "istio-ingressgateway",
+					},
+				},
+				"tracing": map[string]interface{}{
+					"provider": "jaeger",
+				},
+			}),
+		},
 	}
 )
 
@@ -405,10 +1004,14 @@ func TestRoundTripConversion(t *testing.T) {
 			if err != nil {
 				t.Fatalf("error converting smcpv2 to smcpv1: %v", err)
 			}
-			if diff := cmp.Diff(tc.smcpv1, smcpv1, cmp.AllowUnexported(v1.HelmValues{})); diff != "" {
+			expected := &tc.smcpv1
+			if tc.roundTripped != nil {
+				expected = tc.roundTripped
+			}
+			if diff := cmp.Diff(expected, &smcpv1, cmp.AllowUnexported(v1.HelmValues{})); diff != "" {
 				t.Logf("TestRoundTripConversion() case %s v2->v1 mismatch, will try again after removing cruft (-want +got):\n%s", tc.name, diff)
 				removeHelmValues(smcpv1.Istio.GetContent(), tc.cruft.GetContent())
-				if diff := cmp.Diff(tc.smcpv1, smcpv1, cmp.AllowUnexported(v1.HelmValues{})); diff != "" {
+				if diff := cmp.Diff(expected, &smcpv1, cmp.AllowUnexported(v1.HelmValues{})); diff != "" {
 					t.Errorf("TestRoundTripConversion() case %s v2->v1 mismatch (-want +got):\n%s", tc.name, diff)
 				}
 			}

--- a/pkg/apis/maistra/conversion/jaeger_test.go
+++ b/pkg/apis/maistra/conversion/jaeger_test.go
@@ -10,10 +10,12 @@ import (
 )
 
 var (
-	jaegerMaxTraces              = int64(15000)
-	jaegerElasticsearchNodeCount = int32(5)
-	traceSampling                = int32(1)
-	traceSamplingInt             = int32(100)
+	jaegerMaxTraces               = int64(15000)
+	jaegerElasticsearchNodeCount  = int32(5)
+	jaegerElasticsearchNodeCount3 = int32(3)
+	traceSampling                 = int32(1)
+	traceSamplingInt              = int32(100)
+	traceSamplingInt10000         = int32(10000)
 )
 
 var jaegerTestCases = []conversionTestCase{


### PR DESCRIPTION
Signed-off-by: rcernich <rcernich@redhat.com>