### PR TITLE
WIP: MAISTRA-2004 do not pause when resources are installed outside cp namespace

### DIFF
--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -158,6 +158,8 @@ func GetMeshNamespaces(controlPlaneNamespace string, smmr *v1.ServiceMeshMemberR
 	}
 	meshNamespaces := sets.NewString(controlPlaneNamespace)
 	if smmr != nil {
+		// XXX: I don't think this can work, since ConfiguredMembers won't be set
+		// until after the initial install succeeds
 		meshNamespaces.Insert(smmr.Status.ConfiguredMembers...)
 	}
 	return meshNamespaces

--- a/pkg/controller/servicemesh/controlplane/manifestprocessing.go
+++ b/pkg/controller/servicemesh/controlplane/manifestprocessing.go
@@ -38,6 +38,8 @@ func (r *controlPlaneInstanceReconciler) processComponentManifests(ctx context.C
 	delete(r.renderings, chartName)
 
 	for _, rendering := range renderings {
+		// we need to check the target namespace, as we can only verify readiness
+		// for objects in the control plane's namespace at this time
 		if r.hasReadiness(rendering.Head.Kind) {
 			return true, nil
 		}


### PR DESCRIPTION
Signed-off-by: rcernich <rcernich@redhat.com>

This PR simply modifies the pause logic to ignore waiting when the components it is waiting on have no unready deployments.  This will fix the case where gateways are deployed outside the control plane namespace, but I think there is also an issue with allowing cluster ingress and egress gateways to be installed in a namespace other than the control plane namespace.  That could probably be split out into another issue.  Marking this as WIP to let folks weigh in with their opinions.