### PR TITLE
MAISTRA-2007 Use self-signed cert for webhook caBundle if present

### DIFF
--- a/pkg/controller/common/webhooks.go
+++ b/pkg/controller/common/webhooks.go
@@ -2,14 +2,8 @@ package common
 
 import (
 	"bytes"
-	"context"
-	"fmt"
 
 	v1 "k8s.io/api/admissionregistration/v1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -20,42 +14,6 @@ var (
 	// ServiceCABundleKey name of config map entry service-ca operator uses for the CA bundle
 	ServiceCABundleKey = "service-ca.crt"
 )
-
-// GetCABundleFromSecret retrieves the root certificate from an Istio SA secret
-func GetCABundleFromSecret(ctx context.Context, client client.Client, namespacedName types.NamespacedName, key string) ([]byte, error) {
-	secret := &corev1.Secret{}
-	err := client.Get(ctx, namespacedName, secret)
-	if err != nil {
-		return nil, err
-	}
-	caBundle, ok := secret.Data[key]
-	if !ok {
-		return nil, fmt.Errorf(
-			"secret %s does not contain root certificate under key %s",
-			namespacedName,
-			key,
-		)
-	}
-	return caBundle, nil
-}
-
-// GetCABundleFromConfigMap retrieves the CABundle from a ConfigMap injected via service.beta.openshift.io/inject-cabundle annotation
-func GetCABundleFromConfigMap(ctx context.Context, client client.Client, namespacedName types.NamespacedName, key string) ([]byte, error) {
-	cm := &corev1.ConfigMap{}
-	err := client.Get(ctx, namespacedName, cm)
-	if err != nil {
-		return nil, err
-	}
-	caBundle, ok := cm.Data[key]
-	if !ok {
-		return nil, fmt.Errorf(
-			"config map %s does not contain CA bundle under key %s",
-			namespacedName,
-			key,
-		)
-	}
-	return []byte(caBundle), nil
-}
 
 // InjectCABundle updates the CABundle in a WebhookClientConfig. It returns true
 // if the value has changed, false otherwise

--- a/pkg/controller/servicemesh/webhookca/source.go
+++ b/pkg/controller/servicemesh/webhookca/source.go
@@ -1,0 +1,124 @@
+package webhookca
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ObjectRef struct {
+	Kind      string
+	Namespace string
+	Name      string
+}
+
+type CABundleSource interface {
+	GetCABundle(ctx context.Context, client client.Client) ([]byte, error)
+	GetNamespace() string
+	SetNamespace(string)
+	MatchedObjects() []ObjectRef
+}
+
+type SecretCABundleSource struct {
+	SecretNames []string
+	Namespace   string
+	Key         string
+}
+
+func (s *SecretCABundleSource) GetCABundle(ctx context.Context, client client.Client) ([]byte, error) {
+	var caBundle []byte
+	errList := []error{}
+	for _, secretName := range s.SecretNames {
+		namespacedName := types.NamespacedName{
+			Namespace: s.Namespace,
+			Name:      secretName,
+		}
+		secret := &corev1.Secret{}
+		err := client.Get(ctx, namespacedName, secret)
+		if err != nil {
+			errList = append(errList, err)
+			continue
+		}
+		var ok bool
+		caBundle, ok = secret.Data[s.Key]
+		if !ok {
+			errList = append(errList, fmt.Errorf(
+				"secret %s does not contain root certificate under key %s",
+				namespacedName,
+				s.Key,
+			))
+			continue
+		}
+		break
+	}
+	if caBundle == nil {
+		return nil, errors.NewAggregate(errList)
+	}
+	return caBundle, nil
+}
+
+func (s *SecretCABundleSource) GetNamespace() string {
+	return s.Namespace
+}
+
+func (s *SecretCABundleSource) SetNamespace(namespace string) {
+	s.Namespace = namespace
+}
+
+func (s *SecretCABundleSource) MatchedObjects() []ObjectRef {
+	refs := []ObjectRef{}
+	for _, secretName := range s.SecretNames {
+		refs = append(refs, ObjectRef{
+			Kind:      "Secret",
+			Namespace: s.Namespace,
+			Name:      secretName,
+		})
+	}
+	return refs
+}
+
+type ConfigMapCABundleSource struct {
+	ConfigMapName string
+	Key           string
+	Namespace     string
+}
+
+func (s *ConfigMapCABundleSource) GetCABundle(ctx context.Context, client client.Client) ([]byte, error) {
+	namespacedName := types.NamespacedName{s.Namespace, s.ConfigMapName}
+	cm := &corev1.ConfigMap{}
+	err := client.Get(ctx, namespacedName, cm)
+	if err != nil {
+		return nil, err
+	}
+	caBundle, ok := cm.Data[s.Key]
+	if !ok {
+		return nil, fmt.Errorf(
+			"config map %s does not contain CA bundle under key %s",
+			namespacedName,
+			s.Key,
+		)
+	}
+	return []byte(caBundle), nil
+}
+
+func (s *ConfigMapCABundleSource) GetNamespace() string {
+	return s.Namespace
+}
+
+func (s *ConfigMapCABundleSource) SetNamespace(namespace string) {
+	s.Namespace = namespace
+}
+
+func (s *ConfigMapCABundleSource) MatchedObjects() []ObjectRef {
+	return []ObjectRef{
+		ObjectRef{
+			Kind:      "ConfigMap",
+			Namespace: s.Namespace,
+			Name:      s.ConfigMapName,
+		},
+	}
+}

--- a/pkg/controller/servicemesh/webhooks/hacks.go
+++ b/pkg/controller/servicemesh/webhooks/hacks.go
@@ -84,14 +84,11 @@ func createWebhookResources(ctx context.Context, mgr manager.Manager, log logr.L
 	log.Info("Registering Maistra ValidatingWebhookConfiguration with CABundle reconciler")
 	if err := webhookca.WebhookCABundleManagerInstance.ManageWebhookCABundle(
 		validatingWebhookConfiguration,
-		webhookca.CABundleSource{
-			Kind: webhookca.CABundleSourceKindConfigMap,
-			NamespacedName: types.NamespacedName{
-				Namespace: operatorNamespace,
-				Name:      webhookConfigMapName,
-			},
-		},
-		common.ServiceCABundleKey); err != nil {
+		&webhookca.ConfigMapCABundleSource{
+			Namespace:     operatorNamespace,
+			ConfigMapName: webhookConfigMapName,
+			Key:           common.ServiceCABundleKey,
+		}); err != nil {
 		return err
 	}
 
@@ -117,14 +114,11 @@ func createWebhookResources(ctx context.Context, mgr manager.Manager, log logr.L
 	log.Info("Registering Maistra MutatingWebhookConfiguration with CABundle reconciler")
 	if err := webhookca.WebhookCABundleManagerInstance.ManageWebhookCABundle(
 		mutatingWebhookConfiguration,
-		webhookca.CABundleSource{
-			Kind: webhookca.CABundleSourceKindConfigMap,
-			NamespacedName: types.NamespacedName{
-				Namespace: operatorNamespace,
-				Name:      webhookConfigMapName,
-			},
-		},
-		common.ServiceCABundleKey); err != nil {
+		&webhookca.ConfigMapCABundleSource{
+			Namespace:     operatorNamespace,
+			ConfigMapName: webhookConfigMapName,
+			Key:           common.ServiceCABundleKey,
+		}); err != nil {
 		return err
 	}
 
@@ -153,12 +147,11 @@ func createWebhookResources(ctx context.Context, mgr manager.Manager, log logr.L
 				log.Info("Registering Maistra ServiceMeshControlPlane CRD conversion webhook with CABundle reconciler")
 				if err := webhookca.WebhookCABundleManagerInstance.ManageWebhookCABundle(
 					smcpcrd,
-					webhookca.CABundleSource{
-						Kind: webhookca.CABundleSourceKindConfigMap,
-						NamespacedName: types.NamespacedName{
-							Namespace: operatorNamespace,
-							Name:      webhookConfigMapName,
-						}}, common.ServiceCABundleKey); err != nil {
+					&webhookca.ConfigMapCABundleSource{
+						Namespace:     operatorNamespace,
+						ConfigMapName: webhookConfigMapName,
+						Key:           common.ServiceCABundleKey,
+					}); err != nil {
 					return err
 				}
 			} else {


### PR DESCRIPTION
This changes the `CABundleSource` so that it'll first check whether there's a `cacerts` secret and use that if possible. If it's not present, it will use the `istio-ca-secret` just as before. I verified that this matches the behaviour of `istiod`: it will use `cacerts` if present, and if not it will create the self-signed `istio-ca-secret` secret.

I had to refactor quite a bit of code to make this work, most notably the `WebhookCABundleManager` doesn't know how to retrieve caBundles from a source anymore, but that logic has been moved into the `CaBundleSource` itself. This allows for a more flexible behaviour, we could e.g. implement a dynamic source in the future that fetches a ConfigMap or Secret, depending on SMCP config.