### PR TITLE
MAISTRA-2026 Add default DestinationRule for wasm-cacher

### DIFF
--- a/resources/helm/overlays/wasm-extensions/templates/destinationrule.yaml
+++ b/resources/helm/overlays/wasm-extensions/templates/destinationrule.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: wasm-cacher-{{ .Values.revision | default "default" }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: wasm-cacher
+    istio.io/rev: {{ .Values.revision | default "default" }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  host: wasm-cacher-{{ .Values.revision | default "default" }}.{{ .Release.Namespace }}.svc.{{ .Values.global.proxy.clusterDomain }}
+  {{- if .Values.global.defaultConfigVisibilitySettings }}
+  exportTo:
+  - '*'
+  {{- end }}
+  trafficPolicy:
+    tls:
+      mode: DISABLE

--- a/resources/helm/v2.0/wasm-extensions/templates/destinationrule.yaml
+++ b/resources/helm/v2.0/wasm-extensions/templates/destinationrule.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: wasm-cacher-{{ .Values.revision | default "default" }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    maistra-version: "2.0.0.2"
+    app: wasm-cacher
+    istio.io/rev: {{ .Values.revision | default "default" }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  host: wasm-cacher-{{ .Values.revision | default "default" }}.{{ .Release.Namespace }}.svc.{{ .Values.global.proxy.clusterDomain }}
+  {{- if .Values.global.defaultConfigVisibilitySettings }}
+  exportTo:
+  - '*'
+  {{- end }}
+  trafficPolicy:
+    tls:
+      mode: DISABLE


### PR DESCRIPTION
This came up in Google Chat. The default DestinationRule we're creating (when security.dataplane.mtls == true) forces all traffic to be mTLS-encrypted - however, our cache is not running a sidecar and only supports plaintext traffic at the moment. The solution is to add a DestinationRule for the cache that sets the tls.mode to DISABLE