### PR TITLE
MAISTRA-1940 Wait for components when updating control planes

### DIFF
--- a/build/patch-charts.sh
+++ b/build/patch-charts.sh
@@ -245,6 +245,13 @@ base:
     -e 's/{{ .Values.global.disablePolicyChecks | default "true" }}/{{ hasKey .Values.global "disablePolicyChecks" | ternary .Values.global.disablePolicyChecks true }}/' \
     ${HELM_DIR}/istio-control/istio-discovery/templates/configmap.yaml
 
+  # analysis
+  sed_wrap -i -e '/PILOT_ENABLE_ANALYSIS/ i\
+          - name: PILOT_ENABLE_STATUS\
+            value: "{{ .Values.global.istiod.enableAnalysis }}"
+  ' $deployment
+  # connectionTimeout not supported for proxy config
+  sed_wrap -i -e '/defaultConfig:/,/connectTimeout:/s/connectTimeout:/#connectTimeout:/' ${HELM_DIR}/istio-control/istio-discovery/templates/configmap.yaml
 }
 
 function patchGateways() {

--- a/pkg/apis/maistra/conversion/conversion_test.go
+++ b/pkg/apis/maistra/conversion/conversion_test.go
@@ -1089,6 +1089,172 @@ var (
 				}),
 			},
 		},
+		{
+			name: "MAISTRA-2014.name.jaeger",
+			smcpv1: v1.ControlPlaneSpec{
+				Version: "v1.1",
+				Istio: v1.NewHelmValues(map[string]interface{}{
+					"global": map[string]interface{}{
+						"proxy": map[string]interface{}{
+							"tracer": "zipkin",
+						},
+						"tracer": map[string]interface{}{
+							"zipkin": map[string]interface{}{
+								"address": "jaeger-collector.cp-namespace.svc.cluster.local:9411",
+							},
+						},
+					},
+					"tracing": map[string]interface{}{
+						"enabled": false,
+					},
+					"kiali": map[string]interface{}{
+						"jaegerInClusterURL": "jaeger-query.cp-namespace.svc.cluster.local",
+					},
+				}),
+			},
+			smcpv2: v2.ControlPlaneSpec{
+				Version: "v1.1",
+				Tracing: &v2.TracingConfig{
+					Type: v2.TracerTypeJaeger,
+				},
+				Addons: &v2.AddonsConfig{
+					Jaeger: &v2.JaegerAddonConfig{
+						Name: "jaeger",
+					},
+				},
+				TechPreview: v1.NewHelmValues(map[string]interface{}{
+					"global": map[string]interface{}{
+						"tracer": map[string]interface{}{
+							"zipkin": map[string]interface{}{
+								"address": "jaeger-collector.cp-namespace.svc.cluster.local:9411",
+							},
+						},
+					},
+					"kiali": map[string]interface{}{
+						"jaegerInClusterURL": "jaeger-query.cp-namespace.svc.cluster.local",
+					},
+				}),
+			},
+			roundTripped: &v1.ControlPlaneSpec{
+				Version: "v1.1",
+				Istio: v1.NewHelmValues(map[string]interface{}{
+					"global": map[string]interface{}{
+						"enableTracing": true,
+						"proxy": map[string]interface{}{
+							"tracer": "zipkin",
+						},
+						"tracer": map[string]interface{}{
+							"zipkin": map[string]interface{}{
+								"address": "jaeger-collector.cp-namespace.svc.cluster.local:9411",
+							},
+						},
+					},
+					"kiali": map[string]interface{}{
+						"jaegerInClusterURL": "jaeger-query.cp-namespace.svc.cluster.local",
+					},
+					"tracing": map[string]interface{}{
+						"enabled": false,
+					},
+				}),
+			},
+			cruft: v1.NewHelmValues(map[string]interface{}{
+				"global": map[string]interface{}{
+					// mesh expansion is disabled by default
+					"meshExpansion": globalMeshExpansionDefaults,
+					// multicluster is disabled by default
+					"multiCluster": globalMultiClusterDefaults,
+				},
+				"tracing": map[string]interface{}{
+					"jaeger": map[string]interface{}{
+						"resourceName": "jaeger",
+					},
+					"provider": "jaeger",
+				},
+			}),
+		},
+		{
+			name: "MAISTRA-2014.name.custom-jaeger",
+			smcpv1: v1.ControlPlaneSpec{
+				Version: "v1.1",
+				Istio: v1.NewHelmValues(map[string]interface{}{
+					"global": map[string]interface{}{
+						"proxy": map[string]interface{}{
+							"tracer": "zipkin",
+						},
+						"tracer": map[string]interface{}{
+							"zipkin": map[string]interface{}{
+								"address": "custom-jaeger-collector.cp-namespace.svc.cluster.local:9411",
+							},
+						},
+					},
+					"tracing": map[string]interface{}{
+						"enabled": false,
+					},
+					"kiali": map[string]interface{}{
+						"jaegerInClusterURL": "custom-jaeger-query.cp-namespace.svc.cluster.local",
+					},
+				}),
+			},
+			smcpv2: v2.ControlPlaneSpec{
+				Version: "v1.1",
+				Tracing: &v2.TracingConfig{
+					Type: v2.TracerTypeJaeger,
+				},
+				Addons: &v2.AddonsConfig{
+					Jaeger: &v2.JaegerAddonConfig{
+						Name: "custom-jaeger",
+					},
+				},
+				TechPreview: v1.NewHelmValues(map[string]interface{}{
+					"global": map[string]interface{}{
+						"tracer": map[string]interface{}{
+							"zipkin": map[string]interface{}{
+								"address": "custom-jaeger-collector.cp-namespace.svc.cluster.local:9411",
+							},
+						},
+					},
+					"kiali": map[string]interface{}{
+						"jaegerInClusterURL": "custom-jaeger-query.cp-namespace.svc.cluster.local",
+					},
+				}),
+			},
+			roundTripped: &v1.ControlPlaneSpec{
+				Version: "v1.1",
+				Istio: v1.NewHelmValues(map[string]interface{}{
+					"global": map[string]interface{}{
+						"enableTracing": true,
+						"proxy": map[string]interface{}{
+							"tracer": "zipkin",
+						},
+						"tracer": map[string]interface{}{
+							"zipkin": map[string]interface{}{
+								"address": "custom-jaeger-collector.cp-namespace.svc.cluster.local:9411",
+							},
+						},
+					},
+					"kiali": map[string]interface{}{
+						"jaegerInClusterURL": "custom-jaeger-query.cp-namespace.svc.cluster.local",
+					},
+					"tracing": map[string]interface{}{
+						"enabled": false,
+					},
+				}),
+			},
+			cruft: v1.NewHelmValues(map[string]interface{}{
+				"global": map[string]interface{}{
+					// mesh expansion is disabled by default
+					"meshExpansion": globalMeshExpansionDefaults,
+					// multicluster is disabled by default
+					"multiCluster": globalMultiClusterDefaults,
+				},
+				"tracing": map[string]interface{}{
+					"jaeger": map[string]interface{}{
+						"resourceName": "jaeger",
+					},
+					"provider": "jaeger",
+				},
+			}),
+		},
 	}
 )
 

--- a/pkg/apis/maistra/conversion/conversion_v2_to_v1.go
+++ b/pkg/apis/maistra/conversion/conversion_v2_to_v1.go
@@ -8,6 +8,7 @@ import (
 	"github.com/maistra/istio-operator/pkg/apis/maistra/status"
 	v1 "github.com/maistra/istio-operator/pkg/apis/maistra/v1"
 	v2 "github.com/maistra/istio-operator/pkg/apis/maistra/v2"
+	"github.com/maistra/istio-operator/pkg/controller/versions"
 )
 
 func v2ToV1Hacks(values map[string]interface{}, out *v1.ControlPlaneSpec) error {
@@ -73,6 +74,17 @@ func v2ToV1Hacks(values map[string]interface{}, out *v1.ControlPlaneSpec) error 
 		delete(jaegerValues, "query")
 	} else if err != nil {
 		return err
+	}
+
+	if out.Version == versions.V1_1.String() {
+		// external jaeger for v1.1
+		if zipkinAddress, ok, err := hv.GetString("global.tracer.zipkin.address"); ok && zipkinAddress != "" {
+			if err := setHelmBoolValue(values, "tracing.enabled", false); err != nil {
+				return err
+			}
+		} else if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/apis/maistra/conversion/gateways.go
+++ b/pkg/apis/maistra/conversion/gateways.go
@@ -199,7 +199,7 @@ func gatewayConfigToValues(in *v2.GatewayConfig) (map[string]interface{}, error)
 			}
 		}
 		if len(in.Service.Metadata.Annotations) > 0 {
-			if err := setHelmStringMapValue(gatewayValues, "annotations", in.Service.Metadata.Annotations); err != nil {
+			if err := setHelmStringMapValue(gatewayValues, "serviceAnnotations", in.Service.Metadata.Annotations); err != nil {
 				return nil, err
 			}
 		}
@@ -487,7 +487,7 @@ func gatewayValuesToConfig(in *v1.HelmValues, out *v2.GatewayConfig) error {
 		return err
 	}
 	in.RemoveField("labels")
-	if rawAnnotations, ok, err := in.GetMap("annotations"); ok && len(rawAnnotations) > 0 {
+	if rawAnnotations, ok, err := in.GetMap("serviceAnnotations"); ok && len(rawAnnotations) > 0 {
 		setMetadata = true
 		if err := setMetadataAnnotations(rawAnnotations, metadata); err != nil {
 			return err
@@ -495,7 +495,7 @@ func gatewayValuesToConfig(in *v1.HelmValues, out *v2.GatewayConfig) error {
 	} else if err != nil {
 		return err
 	}
-	in.RemoveField("annotations")
+	in.RemoveField("serviceAnnotations")
 	if setMetadata {
 		out.Service.Metadata = metadata
 	}

--- a/pkg/apis/maistra/conversion/gateways_test.go
+++ b/pkg/apis/maistra/conversion/gateways_test.go
@@ -233,7 +233,7 @@ var gatewaysTestCases = []conversionTestCase{
 					"labels": map[string]interface{}{
 						"extra-label": "label-value",
 					},
-					"annotations": map[string]interface{}{
+					"serviceAnnotations": map[string]interface{}{
 						"some-annotation": "not-used-in-charts",
 					},
 					"ports": []interface{}{
@@ -327,7 +327,7 @@ var gatewaysTestCases = []conversionTestCase{
 					"labels": map[string]interface{}{
 						"extra-label": "label-value",
 					},
-					"annotations": map[string]interface{}{
+					"serviceAnnotations": map[string]interface{}{
 						"some-annotation": "not-used-in-charts",
 					},
 					"ports": []interface{}{
@@ -422,7 +422,7 @@ var gatewaysTestCases = []conversionTestCase{
 					"labels": map[string]interface{}{
 						"extra-label": "label-value",
 					},
-					"annotations": map[string]interface{}{
+					"serviceAnnotations": map[string]interface{}{
 						"some-annotation": "not-used-in-charts",
 					},
 					"ports": []interface{}{

--- a/pkg/apis/maistra/conversion/kiali.go
+++ b/pkg/apis/maistra/conversion/kiali.go
@@ -99,17 +99,20 @@ func populateKialiAddonConfig(in *v1.HelmValues, out *v2.KialiAddonConfig) (bool
 	}
 	// we want to use the original, now that we're checking to see if there is actual kiali config
 	kialiValues = v1.NewHelmValues(rawKialiValues)
+	setKiali := false
 
 	kiali := out
 
 	if name, ok, err := kialiValues.GetAndRemoveString("resourceName"); ok {
 		kiali.Name = name
+		setKiali = true
 	} else if err != nil {
 		return false, err
 	}
 
 	if enabled, ok, err := kialiValues.GetAndRemoveBool("enabled"); ok {
 		kiali.Enabled = &enabled
+		setKiali = true
 	} else if err != nil {
 		return false, err
 	}
@@ -170,6 +173,7 @@ func populateKialiAddonConfig(in *v1.HelmValues, out *v2.KialiAddonConfig) (bool
 
 	if setInstall {
 		kiali.Install = install
+		setKiali = true
 	}
 	// update the kiali settings
 	if len(kialiValues.GetContent()) == 0 {
@@ -178,5 +182,5 @@ func populateKialiAddonConfig(in *v1.HelmValues, out *v2.KialiAddonConfig) (bool
 		return false, err
 	}
 
-	return true, nil
+	return setKiali, nil
 }

--- a/pkg/apis/maistra/conversion/tracing.go
+++ b/pkg/apis/maistra/conversion/tracing.go
@@ -85,8 +85,13 @@ func populateTracingConfig(in *v1.HelmValues, out *v2.ControlPlaneSpec) error {
 		if traceEnabled {
 			// default to jaeger if enabled and no proxy.tracer specified
 			tracing.Type = v2.TracerTypeJaeger
-		} else {
+		} else if zipkinAddress, ok, err := in.GetString("global.tracer.zipkin.address"); ok && zipkinAddress != "" {
+			// configuration for external jaeger cr
+			tracing.Type = v2.TracerTypeJaeger
+		} else if err == nil {
 			tracing.Type = v2.TracerTypeNone
+		} else {
+			return err
 		}
 		setTracing = true
 	} else if err != nil {

--- a/pkg/controller/common/test/controller-test-utils.go
+++ b/pkg/controller/common/test/controller-test-utils.go
@@ -17,6 +17,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/maistra/istio-operator/pkg/apis"
+	v1 "github.com/maistra/istio-operator/pkg/apis/maistra/v1"
+	"github.com/maistra/istio-operator/pkg/apis/maistra/v1alpha1"
 	v2 "github.com/maistra/istio-operator/pkg/apis/maistra/v2"
 	"github.com/maistra/istio-operator/pkg/controller/common"
 	"github.com/maistra/istio-operator/pkg/controller/common/test/assert"
@@ -40,6 +42,7 @@ func GetScheme() *runtime.Scheme {
 		Version: "v1",
 		Kind:    "NetworkAttachmentDefinitionList",
 	}, &unstructured.UnstructuredList{})
+	s.SetVersionPriority(v2.SchemeGroupVersion, v1.SchemeGroupVersion, v1alpha1.GroupVersion)
 	return s
 }
 

--- a/pkg/controller/servicemesh/controlplane/common_test.go
+++ b/pkg/controller/servicemesh/controlplane/common_test.go
@@ -87,7 +87,7 @@ func RunSimpleInstallTest(t *testing.T, testCases []IntegrationTestCase) {
 						// create jaeger routes and services
 						test.ReactTo("create").On("jaegers").In(controlPlaneNamespace).With(SimulateJaegerInstall(domain, nil)),
 					},
-					Timeout: 10 * time.Second,
+					Timeout: 20 * time.Second,
 				},
 				{
 					Name: "delete-smcp",

--- a/pkg/controller/servicemesh/controlplane/common_test.go
+++ b/pkg/controller/servicemesh/controlplane/common_test.go
@@ -40,7 +40,7 @@ type IntegrationTestValidation struct {
 
 type IntegrationTestCase struct {
 	name      string
-	smcp      *v2.ServiceMeshControlPlane
+	smcp      runtime.Object
 	resources []runtime.Object
 	create    IntegrationTestValidation
 	delete    IntegrationTestValidation
@@ -110,11 +110,16 @@ func RunSimpleInstallTest(t *testing.T, testCases []IntegrationTestCase) {
 }
 
 func New20SMCPResource(name, namespace string, spec *v2.ControlPlaneSpec) *v2.ServiceMeshControlPlane {
+	smcp := NewV2SMCPResource(name, namespace, spec)
+	smcp.Spec.Version = versions.V2_0.String()
+	return smcp
+}
+
+func NewV2SMCPResource(name, namespace string, spec *v2.ControlPlaneSpec) *v2.ServiceMeshControlPlane {
 	smcp := &maistrav2.ServiceMeshControlPlane{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 	}
 	spec.DeepCopyInto(&smcp.Spec)
-	smcp.Spec.Version = versions.V2_0.String()
 	smcp.Spec.Profiles = []string{"maistra"}
 	return smcp
 }

--- a/pkg/controller/servicemesh/controlplane/readiness.go
+++ b/pkg/controller/servicemesh/controlplane/readiness.go
@@ -105,8 +105,8 @@ func (r *controlPlaneInstanceReconciler) updateReadinessStatus(ctx context.Conte
 		allComponents.Insert(comp.Resource)
 	}
 
-	r.Status.Readiness.Components = map[string][]string {
-		"ready": readyComponents.List(),
+	r.Status.Readiness.Components = map[string][]string{
+		"ready":   readyComponents.List(),
 		"unready": unreadyComponents.List(),
 		"pending": allComponents.Difference(readyComponents).Difference(unreadyComponents).List(),
 	}
@@ -152,6 +152,9 @@ func (r *controlPlaneInstanceReconciler) calculateComponentReadinessMap(ctx cont
 			list: &appsv1.DeploymentList{},
 			ready: func(obj runtime.Object) bool {
 				deployment := obj.(*appsv1.Deployment)
+				if deployment.Status.ReadyReplicas < deployment.Status.Replicas || deployment.Status.ObservedGeneration < deployment.Generation {
+					return false
+				}
 				for _, condition := range deployment.Status.Conditions {
 					if condition.Type == appsv1.DeploymentAvailable {
 						return condition.Status == corev1.ConditionTrue

--- a/pkg/controller/versions/rendering_strategy_v1_x.go
+++ b/pkg/controller/versions/rendering_strategy_v1_x.go
@@ -5,13 +5,19 @@ import (
 	"fmt"
 	"path"
 
+	jaegerv1 "github.com/maistra/istio-operator/pkg/apis/external/jaeger/v1"
 	v1 "github.com/maistra/istio-operator/pkg/apis/maistra/v1"
 	v2 "github.com/maistra/istio-operator/pkg/apis/maistra/v2"
 	"github.com/maistra/istio-operator/pkg/controller/common"
 	"github.com/maistra/istio-operator/pkg/controller/common/cni"
 	"github.com/maistra/istio-operator/pkg/controller/common/helm"
+	pkgerrors "github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/helm/pkg/manifest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type v1xRenderingStrategy struct{}
@@ -61,6 +67,52 @@ func (rs *v1xRenderingStrategy) render(ctx context.Context, v version, cr *commo
 	err = spec.Istio.SetField("global.istioNamespace", smcp.GetNamespace())
 	if err != nil {
 		return nil, fmt.Errorf("Could not set field status.lastAppliedConfiguration.istio.global.istioNamespace: %v", err)
+	}
+
+	// MAISTRA-2014 - external jaeger with v2 resource
+	// note, if converted from v1 resource that was already specifying zipkin address and in-cluster url,
+	// tracing will already be disabled, so none of this is necessary
+	if isComponentEnabled(spec.Istio, "tracing") {
+		if provider, _, _ := spec.Istio.GetString("tracing.provider"); provider == "jaeger" {
+			// if we're not installing the jaeger resource, we need to determine what has been installed,
+			// so control plane rules are created correctly
+			jaegerResource, _, _ := spec.Istio.GetString("tracing.jaeger.resourceName")
+			if jaegerResource == "" {
+				jaegerResource = "jaeger"
+			}
+
+			// set the correct zipkin address
+			spec.Istio.SetField("global.tracer.zipkin.address", fmt.Sprintf("%s-collector.%s.svc:9411", jaegerResource, smcp.GetNamespace()))
+
+			jaeger := &jaegerv1.Jaeger{}
+			jaeger.SetName(jaegerResource)
+			jaeger.SetNamespace(smcp.GetNamespace())
+			if err := cr.Client.Get(ctx, client.ObjectKey{Name: jaeger.GetName(), Namespace: jaeger.GetNamespace()}, jaeger); err == nil {
+				if !metav1.IsControlledBy(jaeger, smcp) {
+					// if the resource exists, we never overwrite it
+					if err := spec.Istio.SetField("tracing.enabled", false); err != nil {
+						return nil, fmt.Errorf("error disabling jaeger install")
+					}
+					if jaegerInClusterURL, _, _ := spec.Istio.GetString("kiali.jaegerInClusterURL"); jaegerInClusterURL == "" {
+						// we won't override any user value
+						spec.Istio.SetField("kiali.jaegerInClusterURL", fmt.Sprintf("https://%s-query.%s.svc", jaegerResource, smcp.GetNamespace()))
+					}
+					if strategy, _, _ := jaeger.Spec.GetString("strategy"); strategy == "" || strategy == "allInOne" {
+						spec.Istio.SetField("tracing.jaeger.template", "all-in-one")
+					} else {
+						// we just want it to not be all-in-one.  see the charts
+						spec.Istio.SetField("tracing.jaeger.template", "production-elasticsearch")
+					}
+				}
+			} else if !(errors.IsNotFound(err) || errors.IsGone(err)) {
+				if meta.IsNoMatchError(err) {
+					return nil, NewDependencyMissingError("Jaeger CRD", err)
+				}
+				return nil, pkgerrors.Wrapf(err, "error retrieving jaeger resource \"%s/%s\"", smcp.GetNamespace(), jaegerResource)
+			} else if err := spec.Istio.SetField("tracing.jaeger.install", true); err != nil {
+				return nil, pkgerrors.Wrapf(err, "error enabling jaeger install")
+			}
+		}
 	}
 
 	// convert back to the v2 type

--- a/resources/helm/v2.0/istio-control/istio-discovery/templates/configmap.yaml
+++ b/resources/helm/v2.0/istio-control/istio-discovery/templates/configmap.yaml
@@ -150,7 +150,7 @@
     defaultConfig:
       #
       # TCP connection timeout between Envoy & the application, and between Envoys.
-      connectTimeout: 10s
+      #connectTimeout: 10s
       #
       ### ADVANCED SETTINGS #############
       # Where should envoy's configuration be stored in the istio-proxy container

--- a/resources/helm/v2.0/istio-control/istio-discovery/templates/deployment.yaml
+++ b/resources/helm/v2.0/istio-control/istio-discovery/templates/deployment.yaml
@@ -150,6 +150,8 @@ spec:
             value: ""
           - name: ISTIOD_ADDR
             value: istiod-{{ .Values.revision | default "default" }}.{{ .Release.Namespace }}.svc:15012
+          - name: PILOT_ENABLE_STATUS
+            value: "{{ .Values.global.istiod.enableAnalysis }}"
           - name: PILOT_ENABLE_ANALYSIS
             value: "{{ .Values.global.istiod.enableAnalysis }}"
           - name: CLUSTER_ID


### PR DESCRIPTION
We're already waiting for individual components to be ready in order when deploying the first time, but when updating a control plane we just apply everything instantly. This PR uses the same waiting mechanism when updating an existing control plane.

Note the ugly use of `hacks.ReduceLikelihoodOfRepeatedReconciliation`- but I couldn't find another way to make sure the cache is updated before we calculate readiness. This is because we're using `unstructured` to apply the resources, so the cache has no chance of updating. @luksa I'd be especially interested in our opinion here, maybe you know of a better solution.