### PR TITLE
MAISTRA-2130 Make sure to copy all 2.0 templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ collect-2.0-charts:
 collect-2.0-templates:
 	mkdir -p ${TEMPLATES_OUT_DIR}/v2.0
 	cp ${RESOURCES_DIR}/smcp-templates/v2.0/${BUILD_TYPE} ${TEMPLATES_OUT_DIR}/v2.0/default
-	cp ${RESOURCES_DIR}/smcp-templates/v2.0/base ${TEMPLATES_OUT_DIR}/v2.0
+	find ${RESOURCES_DIR}/smcp-templates/v2.0/ -maxdepth 1 -type f ! -name "maistra" ! -name "servicemesh" |xargs cp -t ${TEMPLATES_OUT_DIR}/v2.0
 
 ################################################################################
 # maistra v2.1


### PR DESCRIPTION
This seems to have been a mistake that happened during the 2.1 preparation work - [on the maistra-2.0 branch, it is correct](https://github.com/maistra/istio-operator/blob/0a738cf46160e383d336a7f291bf4c2ebf5442da/Makefile#L170-L173).