### PR TITLE
MAISTRA-1956 Stabilize accessible_namespaces in the Kiali resource

### DIFF
--- a/pkg/controller/servicemesh/memberroll/controller_test.go
+++ b/pkg/controller/servicemesh/memberroll/controller_test.go
@@ -325,7 +325,7 @@ func TestReconcileCreatesMemberWhenAppNamespaceIsCreated(t *testing.T) {
 	assertStatusMembers(updatedRoll, []string{appNamespace}, []string{appNamespace}, []string{}, []string{}, t)
 	assert.Equals(updatedRoll.Status.ServiceMeshGeneration, controlPlane.Status.ObservedGeneration, "Unexpected Status.ServiceMeshGeneration in SMMR", t)
 
-	kialiReconciler.assertInvokedWith(t, /* no namespaces */)
+	kialiReconciler.assertInvokedWith(t, appNamespace)
 }
 
 func TestReconcileDeletesMemberWhenRemovedFromSpecMembers(t *testing.T) {
@@ -422,7 +422,7 @@ func TestReconcileFailsIfMemberRollUpdateFails(t *testing.T) {
 	assertReconcileFails(r, t)
 
 	// assertNamespaceReconcilerInvoked(t, nsReconciler, appNamespace)
-	kialiReconciler.assertInvokedWith(t, /* no namespaces */)
+	kialiReconciler.assertInvokedWith(t, appNamespace)
 }
 
 func TestReconcileFailsIfKialiReconcileFails(t *testing.T) {
@@ -436,7 +436,7 @@ func TestReconcileFailsIfKialiReconcileFails(t *testing.T) {
 
 	assertReconcileFails(r, t)
 
-	kialiReconciler.assertInvokedWith(t, /* no namespaces */)
+	kialiReconciler.assertInvokedWith(t, appNamespace)
 }
 
 func TestReconcileUpdatesMembersInStatusWhenMemberIsDeleted(t *testing.T) {
@@ -456,7 +456,7 @@ func TestReconcileUpdatesMembersInStatusWhenMemberIsDeleted(t *testing.T) {
 	updatedRoll := test.GetUpdatedObject(ctx, cl, roll.ObjectMeta, &maistrav1.ServiceMeshMemberRoll{}).(*maistrav1.ServiceMeshMemberRoll)
 	assertStatusMembers(updatedRoll, []string{appNamespace}, []string{appNamespace}, []string{}, []string{}, t)
 	assert.Equals(updatedRoll.Status.ServiceMeshGeneration, controlPlane.Status.ObservedGeneration, "Unexpected Status.ServiceMeshGeneration in SMMR", t)
-	kialiReconciler.assertInvokedWith(t, /* no namespaces */)
+	kialiReconciler.assertInvokedWith(t, appNamespace)
 }
 
 func TestReconcileRemovesFinalizerFromMemberRoll(t *testing.T) {

--- a/resources/helm/overlays/istio-telemetry/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/overlays/istio-telemetry/kiali/templates/kiali-cr.yaml
@@ -13,8 +13,6 @@ spec:
     strategy: "openshift"
 
   deployment:
-    accessible_namespaces:
-    - "{{ .Release.Namespace }}"
 {{- if and .Values.kiali.hub .Values.kiali.image }}
     image_name: "{{ .Values.kiali.hub }}/{{ .Values.kiali.image }}"
 {{- end }}

--- a/resources/helm/v2.1/istio-telemetry/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/v2.1/istio-telemetry/kiali/templates/kiali-cr.yaml
@@ -15,8 +15,6 @@ spec:
     strategy: "openshift"
 
   deployment:
-    accessible_namespaces:
-    - "{{ .Release.Namespace }}"
 {{- if and .Values.kiali.hub .Values.kiali.image }}
     image_name: "{{ .Values.kiali.hub }}/{{ .Values.kiali.image }}"
 {{- end }}


### PR DESCRIPTION
Previously, the operator reset the accessible_namespaces field in the
Kiali resource to only the control plane namespace every time the SMCP
was updated. Now, the Helm chart for the Kiali resource no longer
contains the accessible_namespaces field. This allows the
ServiceMeshMemberRoll controller to be the only component that updates
this field and ensures that the list of namespaces reflects the list
of member namespaces at all times.

Additionally, the list of namespaces now contains all the member
namespaces (either configured in SMMR.spec.members or those that
contain a ServiceMeshMember object). Previously, it only contained
configured member namespaces, which caused namespaces to be removed
from the list every time the SMCP was updated (until the namespace
was configured according to the new SMCP version).

Kiali does not require the control plane namespace to be listed
in accessible_namespaces, as it adds it automatically. Kiali also
does not need the member namespaces to be configured in any way,
so it's safe to include all member namespaces.