### PR TITLE
MAISTRA-2402: Remove the default values from CRD's

### DIFF
--- a/build/generate-crds.sh
+++ b/build/generate-crds.sh
@@ -16,6 +16,10 @@ function generateCRDs() {
       crd:maxDescLen=0,preserveUnknownFields=false,crdVersions=v1beta1 \
       output:dir=./deploy/crds
 
+# FIXME: Remove when generating v1 above
+ echo "Removing default values"
+ sed -i '/default: TCP/d' deploy/crds/*
+
   echo "Patching CRDs to add attributes not supported by controller-gen"
    # workaround for https://github.com/kubernetes-sigs/controller-tools/issues/457
   #sed -i -e "s/\( *\)\(description\: The IP protocol for this port\)/\1default: TCP\n\1\2/" \

--- a/deploy/maistra-operator.yaml
+++ b/deploy/maistra-operator.yaml
@@ -1203,7 +1203,6 @@ spec:
                                     format: int32
                                     type: integer
                                   protocol:
-                                    default: TCP
                                     type: string
                                   targetPort:
                                     anyOf:
@@ -1582,7 +1581,6 @@ spec:
                                     format: int32
                                     type: integer
                                   protocol:
-                                    default: TCP
                                     type: string
                                   targetPort:
                                     anyOf:
@@ -4225,7 +4223,6 @@ spec:
                                         format: int32
                                         type: integer
                                       protocol:
-                                        default: TCP
                                         type: string
                                       targetPort:
                                         anyOf:
@@ -4604,7 +4601,6 @@ spec:
                                         format: int32
                                         type: integer
                                       protocol:
-                                        default: TCP
                                         type: string
                                       targetPort:
                                         anyOf:

--- a/deploy/servicemesh-operator.yaml
+++ b/deploy/servicemesh-operator.yaml
@@ -1203,7 +1203,6 @@ spec:
                                     format: int32
                                     type: integer
                                   protocol:
-                                    default: TCP
                                     type: string
                                   targetPort:
                                     anyOf:
@@ -1582,7 +1581,6 @@ spec:
                                     format: int32
                                     type: integer
                                   protocol:
-                                    default: TCP
                                     type: string
                                   targetPort:
                                     anyOf:
@@ -4225,7 +4223,6 @@ spec:
                                         format: int32
                                         type: integer
                                       protocol:
-                                        default: TCP
                                         type: string
                                       targetPort:
                                         anyOf:
@@ -4604,7 +4601,6 @@ spec:
                                         format: int32
                                         type: integer
                                       protocol:
-                                        default: TCP
                                         type: string
                                       targetPort:
                                         anyOf:

--- a/deploy/src/crd.yaml
+++ b/deploy/src/crd.yaml
@@ -1202,7 +1202,6 @@ spec:
                                     format: int32
                                     type: integer
                                   protocol:
-                                    default: TCP
                                     type: string
                                   targetPort:
                                     anyOf:
@@ -1581,7 +1580,6 @@ spec:
                                     format: int32
                                     type: integer
                                   protocol:
-                                    default: TCP
                                     type: string
                                   targetPort:
                                     anyOf:
@@ -4224,7 +4222,6 @@ spec:
                                         format: int32
                                         type: integer
                                       protocol:
-                                        default: TCP
                                         type: string
                                       targetPort:
                                         anyOf:
@@ -4603,7 +4600,6 @@ spec:
                                         format: int32
                                         type: integer
                                       protocol:
-                                        default: TCP
                                         type: string
                                       targetPort:
                                         anyOf:

--- a/manifests-maistra/2.1.0/servicemeshcontrolplanes.crd.yaml
+++ b/manifests-maistra/2.1.0/servicemeshcontrolplanes.crd.yaml
@@ -1202,7 +1202,6 @@ spec:
                                     format: int32
                                     type: integer
                                   protocol:
-                                    default: TCP
                                     type: string
                                   targetPort:
                                     anyOf:
@@ -1581,7 +1580,6 @@ spec:
                                     format: int32
                                     type: integer
                                   protocol:
-                                    default: TCP
                                     type: string
                                   targetPort:
                                     anyOf:
@@ -4224,7 +4222,6 @@ spec:
                                         format: int32
                                         type: integer
                                       protocol:
-                                        default: TCP
                                         type: string
                                       targetPort:
                                         anyOf:
@@ -4603,7 +4600,6 @@ spec:
                                         format: int32
                                         type: integer
                                       protocol:
-                                        default: TCP
                                         type: string
                                       targetPort:
                                         anyOf:

--- a/manifests-servicemesh/2.1.0/servicemeshcontrolplanes.crd.yaml
+++ b/manifests-servicemesh/2.1.0/servicemeshcontrolplanes.crd.yaml
@@ -1202,7 +1202,6 @@ spec:
                                     format: int32
                                     type: integer
                                   protocol:
-                                    default: TCP
                                     type: string
                                   targetPort:
                                     anyOf:
@@ -1581,7 +1580,6 @@ spec:
                                     format: int32
                                     type: integer
                                   protocol:
-                                    default: TCP
                                     type: string
                                   targetPort:
                                     anyOf:
@@ -4224,7 +4222,6 @@ spec:
                                         format: int32
                                         type: integer
                                       protocol:
-                                        default: TCP
                                         type: string
                                       targetPort:
                                         anyOf:
@@ -4603,7 +4600,6 @@ spec:
                                         format: int32
                                         type: integer
                                       protocol:
-                                        default: TCP
                                         type: string
                                       targetPort:
                                         anyOf:


### PR DESCRIPTION
They are not supported in apiextensions v1beta1 and are causing
trouble. This workaround should be removed when we migrate to v1.