### PR TITLE
MAISTRA-2404: Register SME conversion webhook only when CRD is present

### DIFF
--- a/pkg/bootstrap/crds.go
+++ b/pkg/bootstrap/crds.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/maistra/istio-operator/pkg/controller/common"
 	"github.com/maistra/istio-operator/pkg/controller/hacks"
+	"github.com/maistra/istio-operator/pkg/controller/servicemesh/webhookca"
+	"github.com/maistra/istio-operator/pkg/controller/servicemesh/webhooks"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -61,6 +63,13 @@ func InstallCRDs(ctx context.Context, cl client.Client, chartsDir string) error 
 	if err != nil {
 		return err
 	}
+
+	// Register conversion webhooks for control plane CRD's - currently only ServiceMeshExtension
+	err = webhooks.RegisterConversionWebhook(ctx, cl, log, common.GetOperatorNamespace(), &webhooks.SmeConverterServicePath, webhookca.ServiceMeshExtensionCRDName, false)
+	if err != nil {
+		return err
+	}
+
 	return installCRDRole(ctx, cl)
 }
 

--- a/pkg/bootstrap/crds_test.go
+++ b/pkg/bootstrap/crds_test.go
@@ -25,6 +25,9 @@ import (
 var ctx = context.Background()
 
 func TestMultipleFilesInDir(t *testing.T) {
+	// Play nice with common.GetOperatorNamespace()
+	os.Setenv("POD_NAMESPACE", "istio-operator")
+
 	dir := createTempDirectoryWithCRDFiles(
 		newCRDYAML("test", "1.0.7"),
 		newCRDYAML("test2", "1.0.7"))

--- a/pkg/controller/servicemesh/webhookca/manager.go
+++ b/pkg/controller/servicemesh/webhookca/manager.go
@@ -8,8 +8,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+const managerName = "webhookca-manager"
+
+var logger = logf.Log.WithName(managerName)
 
 // WebhookCABundleManager is the public interface for managing webhook caBundle.
 type WebhookCABundleManager interface {
@@ -66,7 +71,7 @@ func (wm *webhookCABundleManager) ManageWebhookCABundle(obj runtime.Object, sour
 	wm.mu.Lock()
 	defer wm.mu.Unlock()
 	if _, ok := wm.webhooksToBundleSource[webhookName]; ok {
-		return fmt.Errorf("Already watching webhook %s", webhookName)
+		logger.Info(fmt.Sprintf("Already watching webhook %s", webhookName))
 	}
 	wm.webhooksToBundleSource[webhookName] = source
 

--- a/pkg/controller/servicemesh/webhooks/hacks.go
+++ b/pkg/controller/servicemesh/webhooks/hacks.go
@@ -10,13 +10,10 @@ import (
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	apixv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	clientapixv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	pttypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/json"
 	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -122,10 +119,11 @@ func createWebhookResources(ctx context.Context, mgr manager.Manager, log logr.L
 		return err
 	}
 
-	if err := registerConversionWebhook(ctx, mgr, log, operatorNamespace, &smcpConverterServicePath, webhookca.ServiceMeshControlPlaneCRDName); err != nil {
+	if err := RegisterConversionWebhook(ctx, cl, log, operatorNamespace, &smcpConverterServicePath, webhookca.ServiceMeshControlPlaneCRDName, true); err != nil {
 		return err
 	}
-	if err := registerConversionWebhook(ctx, mgr, log, operatorNamespace, &smeConverterServicePath, webhookca.ServiceMeshExtensionCRDName); err != nil {
+
+	if err := RegisterConversionWebhook(ctx, cl, log, operatorNamespace, &SmeConverterServicePath, webhookca.ServiceMeshExtensionCRDName, false); err != nil {
 		return err
 	}
 
@@ -172,60 +170,59 @@ func createWebhookResources(ctx context.Context, mgr manager.Manager, log logr.L
 	return nil
 }
 
-func registerConversionWebhook(
+func RegisterConversionWebhook(
 	ctx context.Context,
-	mgr manager.Manager,
+	cl client.Client,
 	log logr.Logger,
 	operatorNamespace string,
 	path *string,
-	crdName string) error {
+	crdName string,
+	crdMustExist bool) error {
 
 	log.Info(fmt.Sprintf("Adding conversion webhook to %s CRD", crdName))
-	apixclient, err := clientapixv1.NewForConfig(mgr.GetConfig())
-	if err != nil {
+
+	crd := &apixv1.CustomResourceDefinition{}
+	if err := cl.Get(ctx, client.ObjectKey{Name: crdName}, crd); err != nil {
+		if !crdMustExist && errors.IsNotFound(err) {
+			log.Info(fmt.Sprintf("Not registering conversion webhook for CRD %q as it doesn't exist yet.", crdName))
+			return nil
+		}
+
 		return err
 	}
 
-	crdPatchBytes, err := json.Marshal(map[string]interface{}{
-		"spec": map[string]interface{}{
-			"conversion": &apixv1.CustomResourceConversion{
-				Strategy: apixv1.WebhookConverter,
-				Webhook: &apixv1.WebhookConversion{
-					ConversionReviewVersions: []string{"v1beta1"},
-					ClientConfig: &apixv1.WebhookClientConfig{
-						URL: nil,
-						Service: &apixv1.ServiceReference{
-							Name:      webhookServiceName,
-							Namespace: operatorNamespace,
-							Path:      path,
-						},
-					},
+	newCrd := crd.DeepCopy()
+	newCrd.Spec.Conversion = &apixv1.CustomResourceConversion{
+		Strategy: apixv1.WebhookConverter,
+		Webhook: &apixv1.WebhookConversion{
+			ConversionReviewVersions: []string{"v1beta1"},
+			ClientConfig: &apixv1.WebhookClientConfig{
+				URL: nil,
+				Service: &apixv1.ServiceReference{
+					Name:      webhookServiceName,
+					Namespace: operatorNamespace,
+					Path:      path,
 				},
 			},
 		},
-	})
-	if err != nil {
-		return err
-	}
-
-	crd, err := apixclient.CustomResourceDefinitions().Patch(
-		ctx,
-		crdName,
-		pttypes.MergePatchType,
-		crdPatchBytes,
-		metav1.PatchOptions{FieldManager: common.FinalizerName})
-	if err != nil {
-		return err
 	}
 
 	log.Info(fmt.Sprintf("Registering Maistra %s CRD conversion webhook with CABundle reconciler", crdName))
-	return webhookca.WebhookCABundleManagerInstance.ManageWebhookCABundle(
-		crd,
+	if err := webhookca.WebhookCABundleManagerInstance.ManageWebhookCABundle(
+		newCrd,
 		&webhookca.ConfigMapCABundleSource{
 			Namespace:     operatorNamespace,
 			ConfigMapName: webhookConfigMapName,
 			Key:           common.ServiceCABundleKey,
-		})
+		}); err != nil {
+		return fmt.Errorf("error registering %s CRD conversion webhook with CABundle reconciler: %v", crdName, err)
+	}
+
+	if err := cl.Patch(ctx, newCrd, client.MergeFrom(crd), client.FieldOwner(common.FinalizerName)); err != nil {
+		return fmt.Errorf("error patching CRD %s: %v", crdName, err)
+	}
+
+	return nil
 }
 
 func newWebhookService(namespace string) *corev1.Service {

--- a/pkg/controller/servicemesh/webhooks/server.go
+++ b/pkg/controller/servicemesh/webhooks/server.go
@@ -23,7 +23,7 @@ var (
 	smcpValidatorServicePath = "/validate-smcp"
 	smcpMutatorServicePath   = "/mutate-smcp"
 	smcpConverterServicePath = "/convert-smcp"
-	smeConverterServicePath  = "/convert-sme"
+	SmeConverterServicePath  = "/convert-sme"
 	smmrValidatorServicePath = "/validate-smmr"
 	smmrMutatorServicePath   = "/mutate-smmr"
 	smmValidatorServicePath  = "/validate-smm"
@@ -34,8 +34,7 @@ func Add(mgr manager.Manager) error {
 	ctx := common.NewContextWithLog(common.NewContext(), log)
 	log.Info("Configuring Maistra webhooks")
 
-	operatorNamespace := common.GetOperatorNamespace()
-	if err := createWebhookResources(ctx, mgr, log, operatorNamespace); err != nil {
+	if err := createWebhookResources(ctx, mgr, log, common.GetOperatorNamespace()); err != nil {
 		return err
 	}
 
@@ -51,7 +50,7 @@ func Add(mgr manager.Manager) error {
 	hookServer.Register(smcpConverterServicePath, &conversion.Webhook{})
 
 	log.Info("Adding Maistra ServiceMeshExtension conversion handler")
-	hookServer.Register(smeConverterServicePath, &conversion.Webhook{})
+	hookServer.Register(SmeConverterServicePath, &conversion.Webhook{})
 
 	log.Info("Adding Maistra ServiceMeshControlPlane validation handler")
 	hookServer.Register(smcpValidatorServicePath, &webhook.Admission{


### PR DESCRIPTION
Because SME is a control plane CRD, it's only installed after the first
reconcile. We should make sure the conversion webhook is registered only
when the CRD is present, which could be on initialization, or after the
first reconcile.