### PR TITLE
Don't set the IMAGE variable by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ MAISTRA_BRANCH         ?= maistra-2.1
 REPLACES_PRODUCT_CSV   ?= 2.0.5
 REPLACES_COMMUNITY_CSV ?= 2.0.5
 VERSION                ?= development
-IMAGE                  ?= docker.io/maistra/istio-ubi8-operator:${MAISTRA_VERSION}
 CONTAINER_CLI          ?= docker
 COMMUNITY              ?= true
 TEST_TIMEOUT           ?= 5m
@@ -291,6 +290,7 @@ build: update-generated-code update-charts update-templates compile
 ################################################################################
 .PHONY: image
 image: build collect-resources
+	@if [ -z "${IMAGE}" ]; then echo "Please set the IMAGE variable" && exit 1; fi
 	${CONTAINER_CLI} build --no-cache -t "${IMAGE}" -f ${SOURCE_DIR}/build/Dockerfile --build-arg build_type=${BUILD_TYPE} .
 
 .DEFAULT_GOAL := build


### PR DESCRIPTION
It's better to be explicit than implicit. Developers running
`make image` should run something like `export IMAGE=myimage:mytag`
beforehand.

Motivation for this is yesterday, while playing with images I
accidentally pushed a new image to docker.io/maistra/istio-ubi8-operator:2.1