### PR TITLE
MAISTRA-2254: Fix permissions to wasm-cacher ClusterRole

### DIFF
--- a/resources/helm/overlays/wasm-extensions/templates/clusterrole.yaml
+++ b/resources/helm/overlays/wasm-extensions/templates/clusterrole.yaml
@@ -12,6 +12,7 @@ rules:
   resources:
   - servicemeshextensions
   - servicemeshextensions/status
+  - servicemeshextensions/finalizers
   verbs:
   - get
   - list
@@ -31,8 +32,4 @@ rules:
   - imagestreams
   - imagestreamimports
   verbs:
-  - create
-  - update
-  - get
-  - list
-  - watch
+  - '*'

--- a/resources/helm/v2.1/wasm-extensions/templates/clusterrole.yaml
+++ b/resources/helm/v2.1/wasm-extensions/templates/clusterrole.yaml
@@ -13,6 +13,7 @@ rules:
   resources:
   - servicemeshextensions
   - servicemeshextensions/status
+  - servicemeshextensions/finalizers
   verbs:
   - get
   - list
@@ -32,8 +33,4 @@ rules:
   - imagestreams
   - imagestreamimports
   verbs:
-  - create
-  - update
-  - get
-  - list
-  - watch
+  - '*'


### PR DESCRIPTION
So MEC can proper add ownerReferences to image streams