### PR TITLE
MAISTRA-2418: Enable WASM Extensions by default

### DIFF
--- a/resources/helm/overlays/wasm-extensions/values.yaml
+++ b/resources/helm/overlays/wasm-extensions/values.yaml
@@ -1,5 +1,5 @@
 wasmExtensions:
-  enabled: false
+  enabled: true
 
   cacher:
     image: pilot

--- a/resources/helm/v2.1/wasm-extensions/values.yaml
+++ b/resources/helm/v2.1/wasm-extensions/values.yaml
@@ -1,5 +1,5 @@
 wasmExtensions:
-  enabled: false
+  enabled: true
 
   cacher:
     image: pilot


### PR DESCRIPTION
We are not completely removing the ability of disabling it now. Instead,
let's enable it by default and hide this ability from the docs.

In a future release, we can completely remove
`techPreview.wasmExtensions`.