### PR TITLE
MAISTRA-2466: Bump Kiali version to v1.36

### DIFF
--- a/resources/helm/overlays/istio-telemetry/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/overlays/istio-telemetry/kiali/templates/kiali-cr.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.kiali.resourceName | default "kiali" }}
   namespace: {{ .Release.Namespace }}
 spec:
-  version: "v1.33"
+  version: "v1.36"
   installation_tag: "Kiali [{{ .Release.Namespace }}]"
   istio_namespace: "{{ .Release.Namespace }}"
 

--- a/resources/helm/v2.1/istio-telemetry/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/v2.1/istio-telemetry/kiali/templates/kiali-cr.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ .Values.kiali.resourceName | default "kiali" }}
   namespace: {{ .Release.Namespace }}
 spec:
-  version: "v1.33"
+  version: "v1.36"
   installation_tag: "Kiali [{{ .Release.Namespace }}]"
   istio_namespace: "{{ .Release.Namespace }}"
 


### PR DESCRIPTION
fixes: https://issues.redhat.com/browse/MAISTRA-2466
This was modeled after https://github.com/maistra/istio-operator/pull/723