### PR TITLE
MAISTRA-2460 Only log "ignoring control plane namespace" when it's in SMMR.spec.members

### DIFF
--- a/pkg/controller/servicemesh/memberroll/controller.go
+++ b/pkg/controller/servicemesh/memberroll/controller.go
@@ -489,12 +489,16 @@ func (r *MemberRollReconciler) reconcileNamespaces(ctx context.Context, namespac
 		"namespacesToRemove", namespacesToRemove.List())
 	startTime := time.Now()
 
-	namespacesToProcess := namespacesToReconcile.Union(namespacesToRemove)
-	if namespacesToProcess.Has(smmr.Namespace) {
+	if namespacesToRemove.Has(smmr.Namespace) {
+		namespacesToRemove.Delete(smmr.Namespace)
+	}
+	if namespacesToReconcile.Has(smmr.Namespace) {
 		// we never operate on the control plane namespace
 		reqLogger.Info("ignoring control plane namespace in members list of ServiceMeshMemberRoll")
-		namespacesToProcess.Delete(smmr.Namespace)
+		namespacesToReconcile.Delete(smmr.Namespace)
 	}
+
+	namespacesToProcess := namespacesToReconcile.Union(namespacesToRemove)
 
 	// use scatter-gather pattern to process namespaces concurrently
 	type result struct {


### PR DESCRIPTION
namespacesToReconcile is always sourced from SMMR.spec.members, whereas namespacesToRemove is determined by listing namespaces with the member-of label. The control plane namespace contains this label and is therefore always in the namespacesToRemove list. We thus shouldn't log the warning "ignoring control plane namespace in members list of ServiceMeshMemberRoll" in that case.