### PR TITLE
Added missing CRD file error handling for the CRD tool

### DIFF
--- a/resources/helm/v2.1/istio-init/files/federationstatuses.maistra.io.crd.yaml
+++ b/resources/helm/v2.1/istio-init/files/federationstatuses.maistra.io.crd.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     maistra-version: "2.1.0"
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: federationstatuses.maistra.io
 spec:

--- a/resources/helm/v2.1/istio-init/files/meshfederations.maistra.io.crd.yaml
+++ b/resources/helm/v2.1/istio-init/files/meshfederations.maistra.io.crd.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     maistra-version: "2.1.0"
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: meshfederations.maistra.io
 spec:
@@ -52,14 +52,41 @@ spec:
                       type: string
                   type: object
               type: object
-            networkAddress:
-              description: 'NetworkAddress is the address used to communicate with the external mesh. Port 15443 will be used for service traffic and port 8188 will be used for service discovery. XXX: should this be an array?'
-              type: string
+            remote:
+              description: Remote configures details related to the remote mesh with which this mesh is federating.
+              properties:
+                addresses:
+                  description: Addresses are the addresses to which discovery and service requests should be sent (i.e. the addresses of ingress gateways on the remote mesh).  These may be specified as resolveable DNS names or IP addresses.
+                  items:
+                    type: string
+                  type: array
+                discoveryPort:
+                  description: DiscoveryPort is the port on which the addresses are handling discovery requests.  Defaults to 8188, if unspecified.
+                  format: int32
+                  type: integer
+                servicePort:
+                  description: ServicePort is the port on which the addresses are handling service requests.  Defaults to 15443, if unspecified.
+                  format: int32
+                  type: integer
+              type: object
             security:
               properties:
                 certificateChain:
-                  description: 'Name of secret containing certificate chain to be used to validate the remote.  This is also used to validate certificates used by the remote services (both client and server certificates). XXX: maybe this is only used to initiate a connection, with the actual certs stored in the status field, as retrieved from the remote mesh, or maybe this identifies an endpoint used to retrieve a cert chain, a la jwks'
-                  type: string
+                  description: Name of ConfigMap containing certificate chain to be used to validate the remote.  This is also used to validate certificates used by the remote services (both client and server certificates).  The name of the entry should be root-cert.pem.  If unspecified, it will look for a ConfigMap named <meshfederation-name>-ca-root-cert, e.g. if this resource is named mesh1, it will look for a ConfigMap named mesh1-ca-root-cert.
+                  properties:
+                    apiGroup:
+                      description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                      type: string
+                    kind:
+                      description: Kind is the type of resource being referenced
+                      type: string
+                    name:
+                      description: Name is the name of resource being referenced
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
                 clientID:
                   description: ClientID of the remote mesh.  This is used to authenticate incoming requrests from the remote mesh's discovery client.
                   type: string

--- a/resources/helm/v2.1/istio-init/files/serviceexports.maistra.io.crd.yaml
+++ b/resources/helm/v2.1/istio-init/files/serviceexports.maistra.io.crd.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     maistra-version: "2.1.0"
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: serviceexports.maistra.io
 spec:

--- a/resources/helm/v2.1/istio-init/files/serviceimports.maistra.io.crd.yaml
+++ b/resources/helm/v2.1/istio-init/files/serviceimports.maistra.io.crd.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     maistra-version: "2.1.0"
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: serviceimports.maistra.io
 spec:

--- a/resources/helm/v2.1/istio-init/files/servicemeshextensions.maistra.io.crd.yaml
+++ b/resources/helm/v2.1/istio-init/files/servicemeshextensions.maistra.io.crd.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     maistra-version: "2.1.0"
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: servicemeshextensions.maistra.io
 spec:

--- a/tools/crd/main.go
+++ b/tools/crd/main.go
@@ -101,6 +101,8 @@ func processFile(fileName string, written sets.String) {
 				}
 			}
 		}
+	} else {
+		panic(err)
 	}
 }
 


### PR DESCRIPTION
I noticed that the CRD tool build can be completed even if the files are missing. This fix makes sure that the CRD tool will fail if the files are not accessible.