### PR TITLE
MAISTRA-2418: Remove wasmExtensions section from base template

### DIFF
--- a/pkg/controller/servicemesh/controlplane/profiles_test.go
+++ b/pkg/controller/servicemesh/controlplane/profiles_test.go
@@ -122,6 +122,7 @@ func TestProfiles(t *testing.T) {
 				delete(smcp.Spec.Runtime.Components, v2.ControlPlaneComponentNameMixerPolicy)
 				delete(smcp.Spec.Runtime.Components, v2.ControlPlaneComponentNameMixerTelemetry)
 				smcp.Spec.Runtime.Defaults.Container.ImageTag = COMMUNITY_IMAGE_2_1
+				smcp.Spec.TechPreview.RemoveField("wasmExtensions")
 			},
 		},
 		{
@@ -154,6 +155,7 @@ func TestProfiles(t *testing.T) {
 				delete(smcp.Spec.Runtime.Components, v2.ControlPlaneComponentNameMixerPolicy)
 				delete(smcp.Spec.Runtime.Components, v2.ControlPlaneComponentNameMixerTelemetry)
 				smcp.Spec.Runtime.Defaults.Container.ImageTag = PRODUCT_IMAGE_2_1
+				smcp.Spec.TechPreview.RemoveField("wasmExtensions")
 			},
 		},
 	}

--- a/resources/smcp-templates/v2.1/base
+++ b/resources/smcp-templates/v2.1/base
@@ -83,8 +83,6 @@ spec:
           ingress:
             enabled: true
   techPreview:
-    wasmExtensions:
-      enabled: false
     sidecarInjectorWebhook:
       objectSelector:
         enabled: false


### PR DESCRIPTION
In order to have the default value of `true` - from the overlay charts
to have effect. This is not supposed to be exposed to the users in 2.1.

Complement of https://github.com/maistra/istio-operator/pull/747