### PR TITLE
Download charts from maistra-2.1 branch again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 -include Makefile.overrides
 
 MAISTRA_VERSION        ?= 2.1.0
-MAISTRA_BRANCH         ?= maistra-2.1-istio-1.9
+MAISTRA_BRANCH         ?= maistra-2.1
 REPLACES_PRODUCT_CSV   ?= 2.0.5
 REPLACES_COMMUNITY_CSV ?= 2.0.5
 VERSION                ?= development

--- a/build/download-charts.sh
+++ b/build/download-charts.sh
@@ -7,7 +7,7 @@ source $(dirname ${BASH_SOURCE})/sed-wrapper.sh
 
 : ${MAISTRA_VERSION:=2.1.0}
 : ${MAISTRA_REPO:=https://github.com/Maistra/istio}
-: ${MAISTRA_BRANCH:=maistra-2.1-istio-1.9}
+: ${MAISTRA_BRANCH:=maistra-2.1}
 
 : ${SOURCE_DIR:=$(pwd)}
 : ${OUT_DIR:=${SOURCE_DIR}/tmp/_output}


### PR DESCRIPTION
The branch was recently renamed from maistra-2.1-istio-1.9 back to maistra-2.1.