### PR TITLE
Enable WASM extensions by default

### DIFF
--- a/resources/helm/overlays/global.yaml
+++ b/resources/helm/overlays/global.yaml
@@ -442,3 +442,8 @@ telemetry:
       # To reduce the number of successful logs, default log window duration is
       # set to 12 hours.
       logWindowDuration: "43200s"
+
+wasmExtensions:
+  enabled: true
+  cacher:
+    image: pilot

--- a/resources/helm/v2.1/global.yaml
+++ b/resources/helm/v2.1/global.yaml
@@ -442,3 +442,8 @@ telemetry:
       # To reduce the number of successful logs, default log window duration is
       # set to 12 hours.
       logWindowDuration: "43200s"
+
+wasmExtensions:
+  enabled: true
+  cacher:
+    image: pilot


### PR DESCRIPTION
While working on enabling WASM by default (MAISTRA-2418), an issue was found (MAISTRA-2516).
This PR addresses both issues in separate commits.

Complement of https://github.com/maistra/istio-operator/pull/747