### PR TITLE
MAISTRA-2475 Fix initialization and update of Kiali.spec.deployment.accessible_namespaces

### DIFF
--- a/pkg/bootstrap/cni.go
+++ b/pkg/bootstrap/cni.go
@@ -2,8 +2,9 @@ package bootstrap
 
 import (
 	"context"
-	"k8s.io/helm/pkg/manifest"
 	"path"
+
+	"k8s.io/helm/pkg/manifest"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -65,7 +66,7 @@ func internalProcessManifests(ctx context.Context, cl client.Client, rendering [
 		OperatorNamespace: operatorNamespace,
 	}
 
-	mp := helm.NewManifestProcessor(controllerResources, helm.NewPatchFactory(cl), "istio_cni", "TODO", "maistra-istio-operator", preProcessObject, postProcessObject)
+	mp := helm.NewManifestProcessor(controllerResources, helm.NewPatchFactory(cl), "istio_cni", "TODO", "maistra-istio-operator", preProcessObject, postProcessObject, preProcessObjectForPatch)
 	if _, err := mp.ProcessManifests(ctx, rendering, "istio_cni"); err != nil {
 		return err
 	}
@@ -79,4 +80,8 @@ func preProcessObject(ctx context.Context, obj *unstructured.Unstructured) error
 
 func postProcessObject(ctx context.Context, obj *unstructured.Unstructured) error {
 	return nil
+}
+
+func preProcessObjectForPatch(ctx context.Context, oldObj, newObj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	return newObj, nil
 }

--- a/pkg/controller/common/helm/manifestprocessing_test.go
+++ b/pkg/controller/common/helm/manifestprocessing_test.go
@@ -24,7 +24,7 @@ func TestEmptyYAMLBlocks(t *testing.T) {
 		Head: &releaseutil.SimpleHead{},
 	}
 
-	processor := NewManifestProcessor(common.ControllerResources{}, &PatchFactory{}, "app", "version", "owner", nil, nil)
+	processor := NewManifestProcessor(common.ControllerResources{}, &PatchFactory{}, "app", "version", "owner", nil, nil, nil)
 
 	_, err := processor.ProcessManifest(context.TODO(), manifest, "bad")
 

--- a/pkg/controller/servicemesh/controlplane/manifestprocessing.go
+++ b/pkg/controller/servicemesh/controlplane/manifestprocessing.go
@@ -25,7 +25,7 @@ func (r *controlPlaneInstanceReconciler) processComponentManifests(ctx context.C
 		log.Info("component reconciliation complete")
 	}()
 
-	mp := helm.NewManifestProcessor(r.ControllerResources, helm.NewPatchFactory(r.Client), r.Instance.GetNamespace(), r.meshGeneration, r.Instance.GetNamespace(), r.preprocessObject, r.processNewObject)
+	mp := helm.NewManifestProcessor(r.ControllerResources, helm.NewPatchFactory(r.Client), r.Instance.GetNamespace(), r.meshGeneration, r.Instance.GetNamespace(), r.preprocessObject, r.processNewObject, r.preprocessObjectForPatch)
 	if madeChanges, err = mp.ProcessManifests(ctx, renderings, status.Resource); err != nil {
 		return madeChanges, err
 	}

--- a/resources/helm/overlays/istio-telemetry/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/overlays/istio-telemetry/kiali/templates/kiali-cr.yaml
@@ -13,6 +13,7 @@ spec:
     strategy: "openshift"
 
   deployment:
+    accessible_namespaces: []
 {{- if and .Values.kiali.hub .Values.kiali.image }}
     image_name: "{{ .Values.kiali.hub }}/{{ .Values.kiali.image }}"
 {{- end }}

--- a/resources/helm/v2.1/istio-telemetry/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/v2.1/istio-telemetry/kiali/templates/kiali-cr.yaml
@@ -15,6 +15,7 @@ spec:
     strategy: "openshift"
 
   deployment:
+    accessible_namespaces: []
 {{- if and .Values.kiali.hub .Values.kiali.image }}
     image_name: "{{ .Values.kiali.hub }}/{{ .Values.kiali.image }}"
 {{- end }}


### PR DESCRIPTION
This ensures that the .spec.deployment.accessible_namespaces field is initialized when the Kiali resource is first deployed (by the smcp controller), but is then updated only by the smmr controller. The smcp controller should never overwrite the value, as this would cause the issue described in MAISTRA-1956. Previously, we simply removed the field from the Helm chart, which resulted in the smcp controller never updating the field (it was thus only ever updated by the smmr controller), but this resulted in a different issue, where Kiali starts logging errors, because it thinks it has access to all namespaces.