### PR TITLE
MAISTRA-2523 Configure tracing address correctly

### DIFF
--- a/pkg/controller/versions/strategy_v2_1.go
+++ b/pkg/controller/versions/strategy_v2_1.go
@@ -243,7 +243,10 @@ func (v *versionStrategyV2_1) Render(ctx context.Context, cr *common.ControllerR
 			}
 
 			// set the correct zipkin address
-			spec.Istio.SetField("global.tracer.zipkin.address", fmt.Sprintf("%s-collector.%s.svc:9411", jaegerResource, smcp.GetNamespace()))
+			err = spec.Istio.SetField("meshConfig.defaultConfig.tracing.zipkin.address", fmt.Sprintf("%s-collector.%s.svc:9411", jaegerResource, smcp.GetNamespace()))
+			if err != nil {
+				return nil, fmt.Errorf("Could not set field istio.meshConfig.defaultConfig.tracing.zipkin.address: %v", err)
+			}
 
 			jaeger := &jaegerv1.Jaeger{}
 			jaeger.SetName(jaegerResource)


### PR DESCRIPTION
In line 218 of this file, we're now setting a meshConfig value for every installation which leads to a faulty merge behaviour: because the `meshConfig.defaultConfig.tracing` field is a pointer, it is initialized as `nil` and will overwrite any existing tracing configuration with `nil`, breaking Jaeger integration.

This solves the problem by writing the Jaeger URL directly into the meshConfig override that is applied last.