### PR TITLE
MAISTRA-2556 Default gateway label 'app' to gateway (service) name

### DIFF
--- a/pkg/controller/common/test/verifiers.go
+++ b/pkg/controller/common/test/verifiers.go
@@ -65,12 +65,18 @@ func (f *ActionVerifierFactory) IsSeen() ActionVerifier {
 // VerifierTestFunc is used for testing an action, returning an error if the test failed.
 type VerifierTestFunc func(action clienttesting.Action) error
 
-// Passes returns an ActionVerifier that verifies the specified action has
+// Passes returns an ActionVerifier that verifies the specified actions have
 // occurred and the test passes.
-func (f *ActionVerifierFactory) Passes(test VerifierTestFunc) ActionVerifier {
+func (f *ActionVerifierFactory) Passes(tests ...VerifierTestFunc) ActionVerifier {
 	return NewSimpleActionVerifier(f.Verb, f.Resource, f.Subresource, f.Namespace, f.Name,
 		func(action clienttesting.Action) (bool, error) {
-			return true, test(action)
+			for _, test := range tests {
+				err := test(action)
+				if err != nil {
+					return true, err
+				}
+			}
+			return true, nil
 		})
 }
 
@@ -179,7 +185,7 @@ func VerifyActions(verifiers ...ActionVerifier) ActionVerifier {
 }
 
 type verifyActions struct {
-	mu sync.RWMutex
+	mu        sync.RWMutex
 	verifiers []ActionVerifier
 }
 

--- a/pkg/controller/servicemesh/controlplane/common_test.go
+++ b/pkg/controller/servicemesh/controlplane/common_test.go
@@ -114,6 +114,12 @@ func RunSimpleInstallTest(t *testing.T, testCases []IntegrationTestCase) {
 	}
 }
 
+func New21SMCPResource(name, namespace string, spec *v2.ControlPlaneSpec) *v2.ServiceMeshControlPlane {
+	smcp := NewV2SMCPResource(name, namespace, spec)
+	smcp.Spec.Version = versions.V2_1.String()
+	return smcp
+}
+
 func New20SMCPResource(name, namespace string, spec *v2.ControlPlaneSpec) *v2.ServiceMeshControlPlane {
 	smcp := NewV2SMCPResource(name, namespace, spec)
 	smcp.Spec.Version = versions.V2_0.String()

--- a/pkg/controller/servicemesh/controlplane/gateways_test.go
+++ b/pkg/controller/servicemesh/controlplane/gateways_test.go
@@ -46,8 +46,8 @@ func TestAdditionalIngressGatewayInstall(t *testing.T) {
 			}),
 			create: IntegrationTestValidation{
 				Verifier: VerifyActions(
-					Verify("create").On("deployments").Named("istio-ingressgateway").In(controlPlaneNamespace).Passes(ExpectedDefaultLabelGatewayCreate("istio-ingressgateway."+controlPlaneNamespace)),
-					Verify("create").On("deployments").Named(additionalGatewayName).In(controlPlaneNamespace).Passes(ExpectedDefaultLabelGatewayCreate(additionalGatewayName+"."+controlPlaneNamespace)),
+					Verify("create").On("deployments").Named("istio-ingressgateway").In(controlPlaneNamespace).Passes(ExpectedLabelGatewayCreate("maistra.io/gateway", "istio-ingressgateway."+controlPlaneNamespace)),
+					Verify("create").On("deployments").Named(additionalGatewayName).In(controlPlaneNamespace).Passes(ExpectedLabelGatewayCreate("maistra.io/gateway", additionalGatewayName+"."+controlPlaneNamespace)),
 				),
 				Assertions: ActionAssertions{},
 			},
@@ -75,7 +75,7 @@ func TestAdditionalIngressGatewayInstall(t *testing.T) {
 			}),
 			create: IntegrationTestValidation{
 				Verifier: ActionVerifier(
-					Verify("create").On("deployments").Named(additionalGatewayName).In(controlPlaneNamespace).Passes(ExpectedDefaultLabelGatewayCreate(additionalGatewayName+"."+controlPlaneNamespace)),
+					Verify("create").On("deployments").Named(additionalGatewayName).In(controlPlaneNamespace).Passes(ExpectedLabelGatewayCreate("maistra.io/gateway", additionalGatewayName+"."+controlPlaneNamespace)),
 				),
 				Assertions: ActionAssertions{},
 			},
@@ -125,21 +125,60 @@ func TestAdditionalIngressGatewayInstall(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "app-label",
+			smcp: New21SMCPResource(controlPlaneName, controlPlaneNamespace, &v2.ControlPlaneSpec{
+				Gateways: &v2.GatewaysConfig{
+					IngressGateways: map[string]*v2.IngressGatewayConfig{
+						additionalGatewayName: {
+							GatewayConfig: v2.GatewayConfig{
+								Enablement: v2.Enablement{
+									Enabled: &enabled,
+								},
+								Service: v2.GatewayServiceConfig{
+									Metadata: &v2.MetadataConfig{
+										Labels: map[string]string{
+											"test": "test",
+										},
+									},
+								},
+								Namespace: controlPlaneNamespace,
+							},
+						},
+					},
+				},
+			}),
+			create: IntegrationTestValidation{
+				Verifier: VerifyActions(
+					Verify("create").On("deployments").Named(additionalGatewayName).In(controlPlaneNamespace).Passes(
+						ExpectedLabelGatewayCreate("maistra.io/gateway", additionalGatewayName+"."+controlPlaneNamespace),
+						ExpectedLabelGatewayCreate("app", additionalGatewayName),
+						ExpectedLabelGatewayCreate("test", "test"),
+					),
+				),
+				Assertions: ActionAssertions{},
+			},
+			delete: IntegrationTestValidation{
+				Assertions: ActionAssertions{
+					Assert("delete").On("deployments").Named(additionalGatewayName).In(controlPlaneNamespace).IsSeen(),
+				},
+			},
+		},
 	}
 	RunSimpleInstallTest(t, testCases)
 }
 
-func ExpectedDefaultLabelGatewayCreate(expected string) func(action clienttesting.Action) error {
+func ExpectedLabelGatewayCreate(labelName string, expectedValue string) func(action clienttesting.Action) error {
 	return func(action clienttesting.Action) error {
 		createAction := action.(clienttesting.CreateAction)
 		obj := createAction.GetObject()
 		gateway := obj.(*unstructured.Unstructured)
-		if val, ok := common.GetLabel(gateway, "maistra.io/gateway"); ok {
-			if val != expected {
-				return fmt.Errorf("expected maistra.io/gateway label to be %s, got %s", expected, val)
+		if val, ok := common.GetLabel(gateway, labelName); ok {
+			if val != expectedValue {
+				return fmt.Errorf("expected %s label to be %s, got %s", labelName, expectedValue, val)
 			}
 		} else {
-			return fmt.Errorf("gateway should have maistra.io/gateway label defined")
+			return fmt.Errorf("gateway should have %s label defined", labelName)
 		}
 		return nil
 	}

--- a/pkg/controller/versions/strategy_v2_0.go
+++ b/pkg/controller/versions/strategy_v2_0.go
@@ -456,4 +456,3 @@ func (v *versionStrategyV2_0) GetTelemetryType(in *v1.HelmValues, mixerTelemetry
 func (v *versionStrategyV2_0) GetPolicyType(in *v1.HelmValues, mixerPolicyEnabled, mixerPolicyEnabledSet, remoteEnabled bool) v2.PolicyType {
 	return v.conversionImpl.GetPolicyType(in, mixerPolicyEnabled, mixerPolicyEnabledSet, remoteEnabled)
 }
-

--- a/pkg/controller/versions/strategy_v2_1.go
+++ b/pkg/controller/versions/strategy_v2_1.go
@@ -430,6 +430,10 @@ func (v *versionStrategyV2_1) renderEgressGateway(name string, namespace string,
 
 func (v *versionStrategyV2_1) renderGateway(name string, namespace string, chartPath string, typeName string, gateways map[string]interface{}, values *v1.HelmValues) (map[string][]manifest.Manifest, map[string]interface{}, error) {
 	gateway, ok, _ := unstructured.NestedMap(gateways, name)
+	// if 'app' label is not provided, set it to gateway name
+	if _, found, _ := unstructured.NestedString(gateway, "labels", "app"); !found {
+		unstructured.SetNestedField(gateway, name, "labels", "app")
+	}
 	if !ok {
 		// XXX: return an error?
 		return map[string][]manifest.Manifest{}, nil, nil


### PR DESCRIPTION
This is the most elegant solution I could come up with: if the user did not set the `app` label in the SMCP, we set it to the gateway name. For default gateways, this doesn't change anything. But additional gateways with custom names will now have the label `app: <GATEWAY_NAME>`. If users want the old behaviour, they have to set the `app` label to `istio-ingressgateway` or `istio-egressgateway` themselves in the SMCP.

Initially, I had tried removing all the default labels when users supplied custom labels in the SMCP, but that didn't work - turns out you need the `istio` and `app` labels for ingress gateways to work. Not sure why -- I couldn't find a reference anywhere. I'm asking on Istio Slack now.