### PR TITLE
MAISTRA-2411 Create NetworkPolicy for additional ingress gateways

### DIFF
--- a/resources/helm/overlays/gateways/istio-ingress/templates/networkpolicy.yaml
+++ b/resources/helm/overlays/gateways/istio-ingress/templates/networkpolicy.yaml
@@ -2,20 +2,20 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: "istio-ingressgateway"
+  name: {{ $gateway.name }}
 {{- if not $gateway.namespace }}
   namespace: {{ .Release.Namespace }}
 {{- else }}
   namespace: {{ $gateway.namespace }}
 {{- end }}
   labels:
-    app: {{ index .Values "gateways" "istio-ingressgateway" "labels" "istio" }}
+{{ $gateway.labels | toYaml | indent 4 }}
     release: {{ .Release.Name }}
   annotations:
     "maistra.io/internal": "true"
 spec:
   podSelector:
     matchLabels:
-      istio: ingressgateway
+{{ $gateway.labels | toYaml | indent 6 }}
   ingress:
   - {}

--- a/resources/helm/v2.0/gateways/istio-ingress/templates/networkpolicy.yaml
+++ b/resources/helm/v2.0/gateways/istio-ingress/templates/networkpolicy.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: "istio-ingressgateway"
+  name: {{ $gateway.name }}
 {{- if not $gateway.namespace }}
   namespace: {{ $gateway.namespace | default .Release.Namespace }}
 {{- else }}
@@ -10,13 +10,13 @@ metadata:
 {{- end }}
   labels:
     maistra-version: "2.0.6.2"
-    app: {{ index .Values "gateways" "istio-ingressgateway" "labels" "istio" }}
+{{ $gateway.labels | toYaml | indent 4 }}
     release: {{ .Release.Name }}
   annotations:
     "maistra.io/internal": "true"
 spec:
   podSelector:
     matchLabels:
-      istio: ingressgateway
+{{ $gateway.labels | toYaml | indent 6 }}
   ingress:
   - {}


### PR DESCRIPTION
Previously, we only created one (static) NetworkPolicy that matched the cluster ingress gateway. When users create additionalIngressGateways, we should allow ingress traffic to these gateways by default.