### PR TITLE
MAISTRA-2617: Tell istiod to not watch all namespaces

### DIFF
--- a/resources/helm/overlays/global.yaml
+++ b/resources/helm/overlays/global.yaml
@@ -180,7 +180,7 @@ global:
 
   # Whether to restrict the applications namespace the controller manages;
   # If not set, controller watches all namespaces
-  oneNamespace: false
+  oneNamespace: true
 
   # Default node selector to be applied to all deployments so that all pods can be
   # constrained to run a particular nodes. Each component can overwrite these default

--- a/resources/helm/v2.1/global.yaml
+++ b/resources/helm/v2.1/global.yaml
@@ -180,7 +180,7 @@ global:
 
   # Whether to restrict the applications namespace the controller manages;
   # If not set, controller watches all namespaces
-  oneNamespace: false
+  oneNamespace: true
 
   # Default node selector to be applied to all deployments so that all pods can be
   # constrained to run a particular nodes. Each component can overwrite these default


### PR DESCRIPTION
By setting `global.oneNamespace` to `true`.

By default, this is `false`, which leads to istiod trying to watch
all namespaces on startup, here: https://github.com/maistra/istio/blob/149e082318f4992db24cd9b23b140443b828f2ce/pilot/pkg/bootstrap/server.go#L626

`args.RegistryOptions.KubeOptions.WatchedNamespaces` is controlled by
the `-a` argument in istiod's CLI. This argument is only set if
`oneNamespace` is true: https://github.com/maistra/istio-operator/blob/06839494689ec31292a69356c928e7f00edbe618/resources/helm/v2.1/istio-control/istio-discovery/templates/deployment.yaml#L81

It's initialized to the control plane namespace, which is exactly what
we want.

This fixes an istiod startup error as seen in the logs:

```
github.com/maistra/xns-informer/pkg/informers/informer.go:204: Failed to watch *v1.ServiceMeshExtension: failed to list *v1.ServiceMeshExtension: servicemeshextensions.maistra.io is forbidden: User "system:serviceaccount:i1:istiod-service-account-basic" cannot list resource "servicemeshextensions" in API group "maistra.io" at the cluster scope
```