### PR TITLE
MAISTRA-2589 Do not allow 2.1 control planes with Mixer enabled

### DIFF
--- a/pkg/controller/servicemesh/controlplane/reconciler_test.go
+++ b/pkg/controller/servicemesh/controlplane/reconciler_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/maistra/istio-operator/pkg/apis/maistra/status"
 	maistrav1 "github.com/maistra/istio-operator/pkg/apis/maistra/v1"
 	maistrav2 "github.com/maistra/istio-operator/pkg/apis/maistra/v2"
+	v2 "github.com/maistra/istio-operator/pkg/apis/maistra/v2"
 	"github.com/maistra/istio-operator/pkg/controller/common"
 	"github.com/maistra/istio-operator/pkg/controller/common/cni"
 	"github.com/maistra/istio-operator/pkg/controller/common/test"
@@ -541,6 +542,17 @@ func TestValidation(t *testing.T) {
 						},
 					},
 				}),
+			},
+			expectValid: false,
+		},
+		{
+			name: "v2.1 control plane with mixer",
+			spec: maistrav2.ControlPlaneSpec{
+				Version:  versions.V2_1.String(),
+				Profiles: []string{"maistra"},
+				Policy: &maistrav2.PolicyConfig{
+					Type: v2.PolicyTypeMixer,
+				},
 			},
 			expectValid: false,
 		},

--- a/pkg/controller/versions/strategy_v2_1.go
+++ b/pkg/controller/versions/strategy_v2_1.go
@@ -145,7 +145,7 @@ func (v *versionStrategyV2_1) validateProtocolDetection(ctx context.Context, met
 
 func (v *versionStrategyV2_1) validateMixerDisabled(spec *v2.ControlPlaneSpec, allErrors []error) []error {
 	if spec.Policy != nil && (spec.Policy.Type == v2.PolicyTypeMixer || spec.Policy.Mixer != nil) {
-		allErrors = append(allErrors, fmt.Errorf("support for policy.type '%s' and policy.Mixer options been removed in v2.1, please use another alternative", v2.PolicyTypeMixer))
+		allErrors = append(allErrors, fmt.Errorf("support for policy.type %q and policy.Mixer options have been removed in v2.1, please use another alternative", v2.PolicyTypeMixer))
 	}
 	if spec.Telemetry != nil && (spec.Telemetry.Type == v2.TelemetryTypeMixer || spec.Telemetry.Mixer != nil) {
 		allErrors = append(allErrors, fmt.Errorf("support for telemetry.type '%s' and telemetry.Mixer options have been removed in v2.1, please use another alternative", v2.TelemetryTypeMixer))

--- a/pkg/controller/versions/strategy_v2_1.go
+++ b/pkg/controller/versions/strategy_v2_1.go
@@ -148,7 +148,7 @@ func (v *versionStrategyV2_1) validateMixerDisabled(spec *v2.ControlPlaneSpec, a
 		allErrors = append(allErrors, fmt.Errorf("support for policy.type %q and policy.Mixer options have been removed in v2.1, please use another alternative", v2.PolicyTypeMixer))
 	}
 	if spec.Telemetry != nil && (spec.Telemetry.Type == v2.TelemetryTypeMixer || spec.Telemetry.Mixer != nil) {
-		allErrors = append(allErrors, fmt.Errorf("support for telemetry.type '%s' and telemetry.Mixer options have been removed in v2.1, please use another alternative", v2.TelemetryTypeMixer))
+		allErrors = append(allErrors, fmt.Errorf("support for telemetry.type %q and telemetry.Mixer options have been removed in v2.1, please use another alternative", v2.TelemetryTypeMixer))
 	}
 	return allErrors
 }


### PR DESCRIPTION
This will make sure people cannot upgrade to 2.1 when they have Mixer enabled.