### PR TITLE
Instruct istio-iptables to capture DNS

### DIFF
--- a/resources/helm/overlays/istio_cni/templates/daemonset.yaml
+++ b/resources/helm/overlays/istio_cni/templates/daemonset.yaml
@@ -227,6 +227,9 @@ spec:
                 configMapKeyRef:
                   name: istio-cni-config
                   key: cni_network_config_v2_1
+            # Enable interception of DNS so Federation works
+            - name: ISTIO_META_DNS_CAPTURE
+              value: "true"
           volumeMounts:
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir

--- a/resources/helm/v2.1/istio_cni/templates/daemonset.yaml
+++ b/resources/helm/v2.1/istio_cni/templates/daemonset.yaml
@@ -228,6 +228,9 @@ spec:
                 configMapKeyRef:
                   name: istio-cni-config
                   key: cni_network_config_v2_1
+            # Enable interception of DNS so Federation works
+            - name: ISTIO_META_DNS_CAPTURE
+              value: "true"
           volumeMounts:
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir


### PR DESCRIPTION
So that federation works.

iptables rules that redirect DNS traffic are only applied if this
variable is true.