### PR TITLE
OSSM-569 Use default resources for prometheus sidecar

### DIFF
--- a/build/patch-prometheus.sh
+++ b/build/patch-prometheus.sh
@@ -100,6 +100,14 @@ function prometheus_patch_deployment() {
     rollingUpdate:\
       maxSurge: 25%\
       maxUnavailable: 25%' $file
+  
+  sed_wrap -i -e '/        - name: istio-proxy/ a\
+          resources:\
+{{- if .Values.global.proxy.resources }}\
+{{ toYaml .Values.global.proxy.resources | indent 12 }}\
+{{- else }}\
+{{ toYaml .Values.global.defaultResources | indent 12 }}\
+{{- end }}' ${HELM_DIR}/istio-telemetry/prometheus/templates/deployment.yaml
 }
 
 function prometheus_patch_service() {

--- a/resources/helm/v2.0/istio-telemetry/prometheus/templates/deployment.yaml
+++ b/resources/helm/v2.0/istio-telemetry/prometheus/templates/deployment.yaml
@@ -132,6 +132,12 @@ spec:
 
 {{- if and .Values.prometheus.provisionPrometheusCert (not .Values.meshConfig.enablePrometheusMerge) }}
         - name: istio-proxy
+          resources:
+{{- if .Values.global.proxy.resources }}
+{{ toYaml .Values.global.proxy.resources | indent 12 }}
+{{- else }}
+{{ toYaml .Values.global.defaultResources | indent 12 }}
+{{- end }}
 {{- if contains "/" .Values.global.proxy.image }}
           image: "{{ .Values.global.proxy.image }}"
 {{- else }}


### PR DESCRIPTION
There's currently no way for users to set resources for the istio-proxy that comes with prometheus. This can cause scheduling problems in kubernetes.

Adding a /hold as we'll need to decide whether we want to ship this in 2.0.8. I verified that it works locally.

PS: This needs a manual cherry-pick for 2.1 as the template for prometheus has become an overlay