### PR TITLE
MAISTRA-2669: Webhook controller should handle secret deletion

### DIFF
--- a/pkg/controller/servicemesh/webhookca/controller.go
+++ b/pkg/controller/servicemesh/webhookca/controller.go
@@ -145,10 +145,10 @@ func sourceWatchPredicates(r *reconciler) predicate.Funcs {
 		UpdateFunc: func(event event.UpdateEvent) bool {
 			return r.isWatchingSourceObject(event.MetaNew, event.ObjectNew)
 		},
-		// deletion and generic events don't interest us
 		DeleteFunc: func(event event.DeleteEvent) bool {
-			return false
+			return r.isWatchingSourceObject(event.Meta, event.Object)
 		},
+		// generic events don't interest us
 		GenericFunc: func(event event.GenericEvent) bool {
 			return false
 		},


### PR DESCRIPTION
So that when the "cacerts" user-defined secret is deleted, it updates
the webhook with the old caBundle from the "istio-ca-secret" secret.