### PR TITLE
MAISTRA-2688 Ensure pruner never deletes RoleBindings in member namespaces

### DIFF
--- a/pkg/controller/servicemesh/member/controller_test.go
+++ b/pkg/controller/servicemesh/member/controller_test.go
@@ -611,6 +611,8 @@ func newMeshRoleBinding() *rbac.RoleBinding {
 	roleBinding := newRoleBinding(controlPlaneNamespace, "role-binding")
 	roleBinding.Labels = map[string]string{}
 	roleBinding.Labels[common.OwnerKey] = controlPlaneNamespace
+	roleBinding.Labels[common.OwnerNameKey] = controlPlaneName
+	roleBinding.Labels[common.KubernetesAppVersionKey] = "0"
 	return roleBinding
 }
 

--- a/pkg/controller/servicemesh/member/namespace_reconciler_test.go
+++ b/pkg/controller/servicemesh/member/namespace_reconciler_test.go
@@ -50,7 +50,14 @@ func TestReconcileNamespaceInMesh(t *testing.T) {
 	for _, meshRB := range meshRoleBindings {
 		expectedRB := meshRB.DeepCopy()
 		expectedRB.Namespace = appNamespace
-		expectedRB.Labels[common.MemberOfKey] = controlPlaneNamespace
+		// the RoleBinding must not contain the maistra.io/owner label or any
+		// other labels of the RoleBinding in the control plane namespace so
+		// that it won't be deleted by the pruner, but it must contain the
+		// maistra.io/member-of label, so that it can be later deleted by the
+		// SMM controller
+		expectedRB.Labels = map[string]string{
+			common.MemberOfKey: controlPlaneNamespace,
+		}
 		expectedRoleBindings = append(expectedRoleBindings, *expectedRB)
 	}
 

--- a/pkg/controller/servicemesh/member/ovs_networkpolicy.go
+++ b/pkg/controller/servicemesh/member/ovs_networkpolicy.go
@@ -89,6 +89,7 @@ func (s *networkPolicyStrategy) reconcileNamespaceInMesh(ctx context.Context, na
 				Annotations: copyMap(meshNetworkPolicy.Annotations),
 			}
 			common.SetLabel(networkPolicy, common.MemberOfKey, s.meshNamespace)
+			removeLabelsUsedByPruner(networkPolicy)
 			err = s.Client.Create(ctx, networkPolicy)
 			if err == nil {
 				addedNetworkPolicies.Insert(networkPolicyName)

--- a/pkg/controller/servicemesh/member/ovs_networkpolicy_test.go
+++ b/pkg/controller/servicemesh/member/ovs_networkpolicy_test.go
@@ -24,7 +24,15 @@ func TestMeshNetworkPolicyIsCopiedIntoAppNamespace(t *testing.T) {
 	nsNetworkPolicy := getNamespaceNetworkPolicy(cl, t)
 
 	expectedNsNetworkPolicy := newMeshNetworkPolicy()
-	expectedNsNetworkPolicy.Labels[common.MemberOfKey] = controlPlaneNamespace
+	// the NetworkPolicy must not contain the maistra.io/owner label or any
+	// other labels of the NetworkPolicy in the control plane namespace so
+	// that it won't be deleted by the pruner, but it must contain the
+	// maistra.io/member-of label, so that it can be later deleted by the
+	// SMM controller
+	expectedNsNetworkPolicy.Labels = map[string]string{
+		"my-label":         "foo",
+		common.MemberOfKey: controlPlaneNamespace,
+	}
 	expectedNsNetworkPolicy.Namespace = appNamespace
 
 	assert.DeepEquals(nsNetworkPolicy, expectedNsNetworkPolicy, "Unexpected state of app namespace NetworkPolicy", t)


### PR DESCRIPTION
These RoleBindings are created by the SMM controller (by copying the RoleBindings from the mesh namespace). Thus, they should only be deleted by the SMM controller.