### PR TITLE
MAISTRA-2236: Make NetworkPolicy optional

### DIFF
--- a/deploy/maistra-operator.yaml
+++ b/deploy/maistra-operator.yaml
@@ -4985,6 +4985,8 @@ spec:
                       type:
                         type: string
                     type: object
+                  manageNetworkPolicy:
+                    type: boolean
                   trust:
                     properties:
                       additionalDomains:
@@ -9845,6 +9847,8 @@ spec:
                           type:
                             type: string
                         type: object
+                      manageNetworkPolicy:
+                        type: boolean
                       trust:
                         properties:
                           additionalDomains:

--- a/deploy/servicemesh-operator.yaml
+++ b/deploy/servicemesh-operator.yaml
@@ -4985,6 +4985,8 @@ spec:
                       type:
                         type: string
                     type: object
+                  manageNetworkPolicy:
+                    type: boolean
                   trust:
                     properties:
                       additionalDomains:
@@ -9845,6 +9847,8 @@ spec:
                           type:
                             type: string
                         type: object
+                      manageNetworkPolicy:
+                        type: boolean
                       trust:
                         properties:
                           additionalDomains:

--- a/deploy/src/crd.yaml
+++ b/deploy/src/crd.yaml
@@ -4984,6 +4984,8 @@ spec:
                       type:
                         type: string
                     type: object
+                  manageNetworkPolicy:
+                    type: boolean
                   trust:
                     properties:
                       additionalDomains:
@@ -9844,6 +9846,8 @@ spec:
                           type:
                             type: string
                         type: object
+                      manageNetworkPolicy:
+                        type: boolean
                       trust:
                         properties:
                           additionalDomains:

--- a/manifests-maistra/2.1.0/servicemeshcontrolplanes.crd.yaml
+++ b/manifests-maistra/2.1.0/servicemeshcontrolplanes.crd.yaml
@@ -4984,6 +4984,8 @@ spec:
                       type:
                         type: string
                     type: object
+                  manageNetworkPolicy:
+                    type: boolean
                   trust:
                     properties:
                       additionalDomains:
@@ -9844,6 +9846,8 @@ spec:
                           type:
                             type: string
                         type: object
+                      manageNetworkPolicy:
+                        type: boolean
                       trust:
                         properties:
                           additionalDomains:

--- a/manifests-servicemesh/2.1.0/servicemeshcontrolplanes.crd.yaml
+++ b/manifests-servicemesh/2.1.0/servicemeshcontrolplanes.crd.yaml
@@ -4984,6 +4984,8 @@ spec:
                       type:
                         type: string
                     type: object
+                  manageNetworkPolicy:
+                    type: boolean
                   trust:
                     properties:
                       additionalDomains:
@@ -9844,6 +9846,8 @@ spec:
                           type:
                             type: string
                         type: object
+                      manageNetworkPolicy:
+                        type: boolean
                       trust:
                         properties:
                           additionalDomains:

--- a/pkg/apis/maistra/conversion/security.go
+++ b/pkg/apis/maistra/conversion/security.go
@@ -226,6 +226,12 @@ func populateSecurityValues(in *v2.ControlPlaneSpec, values map[string]interface
 		}
 	}
 
+	if security.ManageNetworkPolicy != nil {
+		if err := setHelmBoolValue(values, "global.manageNetworkPolicy", *security.ManageNetworkPolicy); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -523,6 +529,13 @@ func populateSecurityConfig(in *v1.HelmValues, out *v2.ControlPlaneSpec) error {
 	if setControlPlane {
 		security.ControlPlane = controlPlane
 		setSecurity = true
+	}
+
+	if manageNetworkPolicy, ok, err := in.GetAndRemoveBool("global.manageNetworkPolicy"); ok {
+		security.ManageNetworkPolicy = &manageNetworkPolicy
+		setSecurity = true
+	} else if err != nil {
+		return err
 	}
 
 	if setSecurity {

--- a/pkg/apis/maistra/conversion/security_test.go
+++ b/pkg/apis/maistra/conversion/security_test.go
@@ -651,7 +651,7 @@ var securityTestCasesV1 = []conversionTestCase{
 	},
 }
 
-func securityTestCasesV2(version versions.Version) []conversionTestCase{
+func securityTestCasesV2(version versions.Version) []conversionTestCase {
 	ver := version.String()
 	return []conversionTestCase{
 		{
@@ -707,6 +707,48 @@ func securityTestCasesV2(version versions.Version) []conversionTestCase{
 				"global": map[string]interface{}{
 					"multiCluster":  globalMultiClusterDefaults,
 					"meshExpansion": globalMeshExpansionDefaults,
+				},
+			}),
+		},
+		{
+			name: "networkpolicy.enabled." + ver,
+			spec: &v2.ControlPlaneSpec{
+				Version: ver,
+				Security: &v2.SecurityConfig{
+					ManageNetworkPolicy: &featureEnabled,
+				},
+			},
+			isolatedIstio: v1.NewHelmValues(map[string]interface{}{
+				"global": map[string]interface{}{
+					"manageNetworkPolicy": true,
+				},
+			}),
+			completeIstio: v1.NewHelmValues(map[string]interface{}{
+				"global": map[string]interface{}{
+					"manageNetworkPolicy": true,
+					"multiCluster":        globalMultiClusterDefaults,
+					"meshExpansion":       globalMeshExpansionDefaults,
+				},
+			}),
+		},
+		{
+			name: "networkpolicy.disabled." + ver,
+			spec: &v2.ControlPlaneSpec{
+				Version: ver,
+				Security: &v2.SecurityConfig{
+					ManageNetworkPolicy: &featureDisabled,
+				},
+			},
+			isolatedIstio: v1.NewHelmValues(map[string]interface{}{
+				"global": map[string]interface{}{
+					"manageNetworkPolicy": false,
+				},
+			}),
+			completeIstio: v1.NewHelmValues(map[string]interface{}{
+				"global": map[string]interface{}{
+					"manageNetworkPolicy": false,
+					"multiCluster":        globalMultiClusterDefaults,
+					"meshExpansion":       globalMeshExpansionDefaults,
 				},
 			}),
 		},

--- a/pkg/apis/maistra/v2/security.go
+++ b/pkg/apis/maistra/v2/security.go
@@ -18,6 +18,11 @@ type SecurityConfig struct {
 	// DataPlane configures mutual TLS for data plane communication.
 	// +optional
 	DataPlane *DataPlaneSecurityConfig `json:"dataPlane,omitempty"`
+	// Manages network policies that allows communication between namespace members and control plane, defaults to `true`
+	// If false, operator does not create any NetworkPolicy resource, and users are responsible for managing them
+	// .Values.global.manageNetworkPolicy
+	// +optional
+	ManageNetworkPolicy *bool `json:"manageNetworkPolicy,omitempty"`
 }
 
 // TrustConfig configures trust aspects associated with mutual TLS clients

--- a/pkg/apis/maistra/v2/smcp_new.yaml
+++ b/pkg/apis/maistra/v2/smcp_new.yaml
@@ -1,6 +1,6 @@
 spec:
   template: default
-  version: v2.0
+  version: v2.1
   cluster:
     name: Kubernetes
     network: main
@@ -286,6 +286,7 @@ spec:
     dataPlane:
       mlts: true # enable mtls for data plane
       automtls: true
+    manageNetworkPolicy: true # manages network policies that allows communication between namespace members and control plane
   gateways:
     ingress: # _the_ istio-ingressgateway
       # same settings as ilb gateway above

--- a/pkg/apis/maistra/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/maistra/v2/zz_generated.deepcopy.go
@@ -2629,6 +2629,11 @@ func (in *SecurityConfig) DeepCopyInto(out *SecurityConfig) {
 		*out = new(DataPlaneSecurityConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ManageNetworkPolicy != nil {
+		in, out := &in.ManageNetworkPolicy, &out.ManageNetworkPolicy
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/bootstrap/cni.go
+++ b/pkg/bootstrap/cni.go
@@ -75,8 +75,8 @@ func internalProcessManifests(ctx context.Context, cl client.Client, rendering [
 	return nil
 }
 
-func preProcessObject(ctx context.Context, obj *unstructured.Unstructured) error {
-	return nil
+func preProcessObject(ctx context.Context, obj *unstructured.Unstructured) (bool, error) {
+	return true, nil
 }
 
 func postProcessObject(ctx context.Context, obj *unstructured.Unstructured) error {

--- a/pkg/controller/servicemesh/controlplane/networkpolicy_test.go
+++ b/pkg/controller/servicemesh/controlplane/networkpolicy_test.go
@@ -1,0 +1,72 @@
+package controlplane
+
+import (
+	"testing"
+
+	v2 "github.com/maistra/istio-operator/pkg/apis/maistra/v2"
+	. "github.com/maistra/istio-operator/pkg/controller/common/test"
+	"github.com/maistra/istio-operator/pkg/controller/versions"
+)
+
+// Number of network polocies in our charts
+const numberOfNetworkPolicies = 8
+
+func TestNetworkPolicy(t *testing.T) {
+	testCases := []IntegrationTestCase{
+		{
+			name: "np.enabled",
+			smcp: NewV2SMCPResource(controlPlaneName, controlPlaneNamespace, &v2.ControlPlaneSpec{
+				Version: versions.V2_1.String(),
+				Security: &v2.SecurityConfig{
+					ManageNetworkPolicy: ptrTrue,
+				},
+			}),
+			create: IntegrationTestValidation{
+				Assertions: ActionAssertions{
+					Assert("create").On("networkpolicies").In(controlPlaneNamespace).SeenCountIs(numberOfNetworkPolicies),
+				},
+			},
+			delete: IntegrationTestValidation{
+				Assertions: ActionAssertions{
+					Assert("delete").On("networkpolicies").In(controlPlaneNamespace).SeenCountIs(numberOfNetworkPolicies),
+				},
+			},
+		},
+		{
+			name: "np.missing", // Same behavior as the above case, since the default value is `enabled`.
+			smcp: NewV2SMCPResource(controlPlaneName, controlPlaneNamespace, &v2.ControlPlaneSpec{
+				Version: versions.V2_1.String(),
+			}),
+			create: IntegrationTestValidation{
+				Assertions: ActionAssertions{
+					Assert("create").On("networkpolicies").In(controlPlaneNamespace).SeenCountIs(numberOfNetworkPolicies),
+				},
+			},
+			delete: IntegrationTestValidation{
+				Assertions: ActionAssertions{
+					Assert("delete").On("networkpolicies").In(controlPlaneNamespace).SeenCountIs(numberOfNetworkPolicies),
+				},
+			},
+		},
+		{
+			name: "np.disabled",
+			smcp: NewV2SMCPResource(controlPlaneName, controlPlaneNamespace, &v2.ControlPlaneSpec{
+				Version: versions.V2_1.String(),
+				Security: &v2.SecurityConfig{
+					ManageNetworkPolicy: ptrFalse,
+				},
+			}),
+			create: IntegrationTestValidation{
+				Assertions: ActionAssertions{
+					Assert("create").On("networkpolicies").In(controlPlaneNamespace).IsNotSeen(),
+				},
+			},
+			delete: IntegrationTestValidation{
+				Assertions: ActionAssertions{
+					Assert("delete").On("networkpolicies").In(controlPlaneNamespace).IsNotSeen(),
+				},
+			},
+		},
+	}
+	RunSimpleInstallTest(t, testCases)
+}

--- a/resources/helm/overlays/global.yaml
+++ b/resources/helm/overlays/global.yaml
@@ -42,6 +42,10 @@ global:
   # external istiod controls all remote clusters: disabled by default
   externalIstiod: false
 
+  # Manage network policies that allows communication between namespace members and control plane
+  # If false, operator does not create any NetworkPolicy resource, and users are responsible for managing them
+  manageNetworkPolicy: true
+
   proxy:
     image: proxyv2
 

--- a/resources/helm/v2.1/global.yaml
+++ b/resources/helm/v2.1/global.yaml
@@ -42,6 +42,10 @@ global:
   # external istiod controls all remote clusters: disabled by default
   externalIstiod: false
 
+  # Manage network policies that allows communication between namespace members and control plane
+  # If false, operator does not create any NetworkPolicy resource, and users are responsible for managing them
+  manageNetworkPolicy: true
+
   proxy:
     image: proxyv2
 


### PR DESCRIPTION
This adds the boolean flag `spec.security.spec.security.manageNetworkPolicy` to
the SMCP, with the default value of `true`.

If it is true, current behavior is preserved, i.e., the operator creates
and manages the `NetworkPolicies` that allow communication between the
control plane and namespaces that are members of the mesh.

If it is false, the operator doesn't create such resources. The user is
entirely responsible for managing the `NetworkPolicies` and troubleshoot
any issue that might occur as a result of opting out of this feature.