### PR TITLE
OSSM-796 Remove patching rules for resources from maistra.io and route.openshift.io

### DIFF
--- a/build/patch-charts.sh
+++ b/build/patch-charts.sh
@@ -172,17 +172,6 @@ function patchGalley() {
   sed_wrap -i -e '/{{- if eq .Values.revision ""}}/,/{{- end }}/ { /istiod/! d }' $deployment
 
   # multitenant
-  echo '
-  # Maistra specific
-  - apiGroups: ["maistra.io"]
-    resources: ["servicemeshmemberrolls"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["route.openshift.io"]
-    resources: ["routes", "routes/custom-host"]
-    verbs: ["get", "list", "watch", "create", "delete", "update"]
-  - apiGroups: ["maistra.io"]
-    resources: ["servicemeshextensions"]
-    verbs: ["get", "list", "watch"]' >> ${HELM_DIR}/istio-control/istio-discovery/templates/clusterrole.yaml
   sed_wrap -i -e 's/, *"nodes"//' ${HELM_DIR}/istio-control/istio-discovery/templates/clusterrole.yaml
   sed_wrap -i -e '/- apiGroups:.*admissionregistration\.k8s\.io/,/verbs:/ d' ${HELM_DIR}/istio-control/istio-discovery/templates/clusterrole.yaml
   sed_wrap -i -e '/- apiGroups:.*certificates\.k8s\.io/,/verbs:/ d' ${HELM_DIR}/istio-control/istio-discovery/templates/clusterrole.yaml

--- a/resources/helm/v2.1/istio-control/istio-discovery/templates/clusterrole.yaml
+++ b/resources/helm/v2.1/istio-control/istio-discovery/templates/clusterrole.yaml
@@ -80,3 +80,14 @@ rules:
     resources: ["secrets"]
     verbs: ["get", "watch", "list"]
 
+  # Maistra specific
+  - apiGroups: ["maistra.io"]
+    resources: ["servicemeshmemberrolls"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["route.openshift.io"]
+    resources: ["routes", "routes/custom-host"]
+    verbs: ["get", "list", "watch", "create", "delete", "update"]
+  - apiGroups: ["maistra.io"]
+    resources: ["servicemeshextensions"]
+    verbs: ["get", "list", "watch"]
+

--- a/resources/helm/v2.1/istio-control/istio-discovery/templates/clusterrole.yaml
+++ b/resources/helm/v2.1/istio-control/istio-discovery/templates/clusterrole.yaml
@@ -80,14 +80,3 @@ rules:
     resources: ["secrets"]
     verbs: ["get", "watch", "list"]
 
-
-  # Maistra specific
-  - apiGroups: ["maistra.io"]
-    resources: ["servicemeshmemberrolls"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["route.openshift.io"]
-    resources: ["routes", "routes/custom-host"]
-    verbs: ["get", "list", "watch", "create", "delete", "update"]
-  - apiGroups: ["maistra.io"]
-    resources: ["servicemeshextensions"]
-    verbs: ["get", "list", "watch"]


### PR DESCRIPTION
Patching rules for resources from maistra.io and route.openshift.io will no longer be needed once pull request [OSSM-796 add SMMR integration test](https://github.com/maistra/istio/pull/458) is merged.