### PR TITLE
OSSM-303 | Make creating OpenShift Route for istio-ingressgateway optional

### DIFF
--- a/build/patch-charts.sh
+++ b/build/patch-charts.sh
@@ -243,14 +243,6 @@ function patchGateways() {
   # do not expose port 15012, support for mesh expansion will automatically add this port
   sed_wrap -i -e '/port: 15012/,+3d' ${HELM_DIR}/gateways/istio-ingress/values.yaml
 
-  # add route config
-  routeConfig='\
-\
-    # specifies whether to create a Route resource (route.openshift.io/v1) for the istio-ingressgateway deployment\
-    routeConfig:\
-      enabled: true'
-  sed_wrap -i -e "/runAsRoot: false/a $routeConfig" ${HELM_DIR}/gateways/istio-ingress/values.yaml
-
   # add tracer config
   tracerConfig='\
   # Configuration for each of the supported tracers\

--- a/build/patch-charts.sh
+++ b/build/patch-charts.sh
@@ -243,6 +243,13 @@ function patchGateways() {
   # do not expose port 15012, support for mesh expansion will automatically add this port
   sed_wrap -i -e '/port: 15012/,+3d' ${HELM_DIR}/gateways/istio-ingress/values.yaml
 
+  # add route config
+  routeConfig='\
+\
+    # specifies whether to create a Route resource (route.openshift.io/v1) for the istio-ingressgateway deployment\
+    route: true'
+  sed_wrap -i -e "/runAsRoot: false/a $routeConfig" ${HELM_DIR}/gateways/istio-ingress/values.yaml
+
   # add tracer config
   tracerConfig='\
   # Configuration for each of the supported tracers\

--- a/build/patch-charts.sh
+++ b/build/patch-charts.sh
@@ -247,7 +247,8 @@ function patchGateways() {
   routeConfig='\
 \
     # specifies whether to create a Route resource (route.openshift.io/v1) for the istio-ingressgateway deployment\
-    route: true'
+    routeConfig:\
+      enabled: true'
   sed_wrap -i -e "/runAsRoot: false/a $routeConfig" ${HELM_DIR}/gateways/istio-ingress/values.yaml
 
   # add tracer config

--- a/deploy/maistra-operator.yaml
+++ b/deploy/maistra-operator.yaml
@@ -3391,6 +3391,8 @@ spec:
                         type: array
                       namespace:
                         type: string
+                      route:
+                        type: boolean
                       routerMode:
                         type: string
                       runtime:
@@ -8253,6 +8255,8 @@ spec:
                             type: array
                           namespace:
                             type: string
+                          route:
+                            type: boolean
                           routerMode:
                             type: string
                           runtime:

--- a/deploy/maistra-operator.yaml
+++ b/deploy/maistra-operator.yaml
@@ -3391,8 +3391,31 @@ spec:
                         type: array
                       namespace:
                         type: string
-                      route:
-                        type: boolean
+                      routeConfig:
+                        properties:
+                          contextPath:
+                            type: string
+                          enabled:
+                            type: boolean
+                          hosts:
+                            items:
+                              type: string
+                            type: array
+                          metadata:
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          tls:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
                       routerMode:
                         type: string
                       runtime:
@@ -8255,8 +8278,31 @@ spec:
                             type: array
                           namespace:
                             type: string
-                          route:
-                            type: boolean
+                          routeConfig:
+                            properties:
+                              contextPath:
+                                type: string
+                              enabled:
+                                type: boolean
+                              hosts:
+                                items:
+                                  type: string
+                                type: array
+                              metadata:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              tls:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
                           routerMode:
                             type: string
                           runtime:

--- a/deploy/maistra-operator.yaml
+++ b/deploy/maistra-operator.yaml
@@ -3393,28 +3393,8 @@ spec:
                         type: string
                       routeConfig:
                         properties:
-                          contextPath:
-                            type: string
                           enabled:
                             type: boolean
-                          hosts:
-                            items:
-                              type: string
-                            type: array
-                          metadata:
-                            properties:
-                              annotations:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                              labels:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                            type: object
-                          tls:
-                            type: object
-                            x-kubernetes-preserve-unknown-fields: true
                         type: object
                       routerMode:
                         type: string
@@ -8280,28 +8260,8 @@ spec:
                             type: string
                           routeConfig:
                             properties:
-                              contextPath:
-                                type: string
                               enabled:
                                 type: boolean
-                              hosts:
-                                items:
-                                  type: string
-                                type: array
-                              metadata:
-                                properties:
-                                  annotations:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                  labels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              tls:
-                                type: object
-                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           routerMode:
                             type: string

--- a/deploy/servicemesh-operator.yaml
+++ b/deploy/servicemesh-operator.yaml
@@ -3391,6 +3391,8 @@ spec:
                         type: array
                       namespace:
                         type: string
+                      route:
+                        type: boolean
                       routerMode:
                         type: string
                       runtime:
@@ -8253,6 +8255,8 @@ spec:
                             type: array
                           namespace:
                             type: string
+                          route:
+                            type: boolean
                           routerMode:
                             type: string
                           runtime:

--- a/deploy/servicemesh-operator.yaml
+++ b/deploy/servicemesh-operator.yaml
@@ -3391,8 +3391,31 @@ spec:
                         type: array
                       namespace:
                         type: string
-                      route:
-                        type: boolean
+                      routeConfig:
+                        properties:
+                          contextPath:
+                            type: string
+                          enabled:
+                            type: boolean
+                          hosts:
+                            items:
+                              type: string
+                            type: array
+                          metadata:
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          tls:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
                       routerMode:
                         type: string
                       runtime:
@@ -8255,8 +8278,31 @@ spec:
                             type: array
                           namespace:
                             type: string
-                          route:
-                            type: boolean
+                          routeConfig:
+                            properties:
+                              contextPath:
+                                type: string
+                              enabled:
+                                type: boolean
+                              hosts:
+                                items:
+                                  type: string
+                                type: array
+                              metadata:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              tls:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
                           routerMode:
                             type: string
                           runtime:

--- a/deploy/servicemesh-operator.yaml
+++ b/deploy/servicemesh-operator.yaml
@@ -3393,28 +3393,8 @@ spec:
                         type: string
                       routeConfig:
                         properties:
-                          contextPath:
-                            type: string
                           enabled:
                             type: boolean
-                          hosts:
-                            items:
-                              type: string
-                            type: array
-                          metadata:
-                            properties:
-                              annotations:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                              labels:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                            type: object
-                          tls:
-                            type: object
-                            x-kubernetes-preserve-unknown-fields: true
                         type: object
                       routerMode:
                         type: string
@@ -8280,28 +8260,8 @@ spec:
                             type: string
                           routeConfig:
                             properties:
-                              contextPath:
-                                type: string
                               enabled:
                                 type: boolean
-                              hosts:
-                                items:
-                                  type: string
-                                type: array
-                              metadata:
-                                properties:
-                                  annotations:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                  labels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              tls:
-                                type: object
-                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           routerMode:
                             type: string

--- a/deploy/src/crd.yaml
+++ b/deploy/src/crd.yaml
@@ -3390,8 +3390,31 @@ spec:
                         type: array
                       namespace:
                         type: string
-                      route:
-                        type: boolean
+                      routeConfig:
+                        properties:
+                          contextPath:
+                            type: string
+                          enabled:
+                            type: boolean
+                          hosts:
+                            items:
+                              type: string
+                            type: array
+                          metadata:
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          tls:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
                       routerMode:
                         type: string
                       runtime:
@@ -8254,8 +8277,31 @@ spec:
                             type: array
                           namespace:
                             type: string
-                          route:
-                            type: boolean
+                          routeConfig:
+                            properties:
+                              contextPath:
+                                type: string
+                              enabled:
+                                type: boolean
+                              hosts:
+                                items:
+                                  type: string
+                                type: array
+                              metadata:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              tls:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
                           routerMode:
                             type: string
                           runtime:

--- a/deploy/src/crd.yaml
+++ b/deploy/src/crd.yaml
@@ -3390,6 +3390,8 @@ spec:
                         type: array
                       namespace:
                         type: string
+                      route:
+                        type: boolean
                       routerMode:
                         type: string
                       runtime:
@@ -8252,6 +8254,8 @@ spec:
                             type: array
                           namespace:
                             type: string
+                          route:
+                            type: boolean
                           routerMode:
                             type: string
                           runtime:

--- a/deploy/src/crd.yaml
+++ b/deploy/src/crd.yaml
@@ -3392,28 +3392,8 @@ spec:
                         type: string
                       routeConfig:
                         properties:
-                          contextPath:
-                            type: string
                           enabled:
                             type: boolean
-                          hosts:
-                            items:
-                              type: string
-                            type: array
-                          metadata:
-                            properties:
-                              annotations:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                              labels:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                            type: object
-                          tls:
-                            type: object
-                            x-kubernetes-preserve-unknown-fields: true
                         type: object
                       routerMode:
                         type: string
@@ -8279,28 +8259,8 @@ spec:
                             type: string
                           routeConfig:
                             properties:
-                              contextPath:
-                                type: string
                               enabled:
                                 type: boolean
-                              hosts:
-                                items:
-                                  type: string
-                                type: array
-                              metadata:
-                                properties:
-                                  annotations:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                  labels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              tls:
-                                type: object
-                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           routerMode:
                             type: string

--- a/manifests-maistra/2.1.1/servicemeshcontrolplanes.crd.yaml
+++ b/manifests-maistra/2.1.1/servicemeshcontrolplanes.crd.yaml
@@ -3390,8 +3390,31 @@ spec:
                         type: array
                       namespace:
                         type: string
-                      route:
-                        type: boolean
+                      routeConfig:
+                        properties:
+                          contextPath:
+                            type: string
+                          enabled:
+                            type: boolean
+                          hosts:
+                            items:
+                              type: string
+                            type: array
+                          metadata:
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          tls:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
                       routerMode:
                         type: string
                       runtime:
@@ -8254,8 +8277,31 @@ spec:
                             type: array
                           namespace:
                             type: string
-                          route:
-                            type: boolean
+                          routeConfig:
+                            properties:
+                              contextPath:
+                                type: string
+                              enabled:
+                                type: boolean
+                              hosts:
+                                items:
+                                  type: string
+                                type: array
+                              metadata:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              tls:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
                           routerMode:
                             type: string
                           runtime:

--- a/manifests-maistra/2.1.1/servicemeshcontrolplanes.crd.yaml
+++ b/manifests-maistra/2.1.1/servicemeshcontrolplanes.crd.yaml
@@ -3390,6 +3390,8 @@ spec:
                         type: array
                       namespace:
                         type: string
+                      route:
+                        type: boolean
                       routerMode:
                         type: string
                       runtime:
@@ -8252,6 +8254,8 @@ spec:
                             type: array
                           namespace:
                             type: string
+                          route:
+                            type: boolean
                           routerMode:
                             type: string
                           runtime:

--- a/manifests-maistra/2.1.1/servicemeshcontrolplanes.crd.yaml
+++ b/manifests-maistra/2.1.1/servicemeshcontrolplanes.crd.yaml
@@ -3392,28 +3392,8 @@ spec:
                         type: string
                       routeConfig:
                         properties:
-                          contextPath:
-                            type: string
                           enabled:
                             type: boolean
-                          hosts:
-                            items:
-                              type: string
-                            type: array
-                          metadata:
-                            properties:
-                              annotations:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                              labels:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                            type: object
-                          tls:
-                            type: object
-                            x-kubernetes-preserve-unknown-fields: true
                         type: object
                       routerMode:
                         type: string
@@ -8279,28 +8259,8 @@ spec:
                             type: string
                           routeConfig:
                             properties:
-                              contextPath:
-                                type: string
                               enabled:
                                 type: boolean
-                              hosts:
-                                items:
-                                  type: string
-                                type: array
-                              metadata:
-                                properties:
-                                  annotations:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                  labels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              tls:
-                                type: object
-                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           routerMode:
                             type: string

--- a/manifests-servicemesh/2.1.1/servicemeshcontrolplanes.crd.yaml
+++ b/manifests-servicemesh/2.1.1/servicemeshcontrolplanes.crd.yaml
@@ -3390,8 +3390,31 @@ spec:
                         type: array
                       namespace:
                         type: string
-                      route:
-                        type: boolean
+                      routeConfig:
+                        properties:
+                          contextPath:
+                            type: string
+                          enabled:
+                            type: boolean
+                          hosts:
+                            items:
+                              type: string
+                            type: array
+                          metadata:
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          tls:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
                       routerMode:
                         type: string
                       runtime:
@@ -8254,8 +8277,31 @@ spec:
                             type: array
                           namespace:
                             type: string
-                          route:
-                            type: boolean
+                          routeConfig:
+                            properties:
+                              contextPath:
+                                type: string
+                              enabled:
+                                type: boolean
+                              hosts:
+                                items:
+                                  type: string
+                                type: array
+                              metadata:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              tls:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
                           routerMode:
                             type: string
                           runtime:

--- a/manifests-servicemesh/2.1.1/servicemeshcontrolplanes.crd.yaml
+++ b/manifests-servicemesh/2.1.1/servicemeshcontrolplanes.crd.yaml
@@ -3390,6 +3390,8 @@ spec:
                         type: array
                       namespace:
                         type: string
+                      route:
+                        type: boolean
                       routerMode:
                         type: string
                       runtime:
@@ -8252,6 +8254,8 @@ spec:
                             type: array
                           namespace:
                             type: string
+                          route:
+                            type: boolean
                           routerMode:
                             type: string
                           runtime:

--- a/manifests-servicemesh/2.1.1/servicemeshcontrolplanes.crd.yaml
+++ b/manifests-servicemesh/2.1.1/servicemeshcontrolplanes.crd.yaml
@@ -3392,28 +3392,8 @@ spec:
                         type: string
                       routeConfig:
                         properties:
-                          contextPath:
-                            type: string
                           enabled:
                             type: boolean
-                          hosts:
-                            items:
-                              type: string
-                            type: array
-                          metadata:
-                            properties:
-                              annotations:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                              labels:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                            type: object
-                          tls:
-                            type: object
-                            x-kubernetes-preserve-unknown-fields: true
                         type: object
                       routerMode:
                         type: string
@@ -8279,28 +8259,8 @@ spec:
                             type: string
                           routeConfig:
                             properties:
-                              contextPath:
-                                type: string
                               enabled:
                                 type: boolean
-                              hosts:
-                                items:
-                                  type: string
-                                type: array
-                              metadata:
-                                properties:
-                                  annotations:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                  labels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              tls:
-                                type: object
-                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           routerMode:
                             type: string

--- a/pkg/apis/maistra/conversion/gateways.go
+++ b/pkg/apis/maistra/conversion/gateways.go
@@ -108,6 +108,11 @@ func populateGatewaysValues(in *v2.ControlPlaneSpec, values map[string]interface
 					return err
 				}
 			}
+			if gateways.ClusterIngress.RouteEnabled != nil {
+				if err := setHelmBoolValue(values, "gateways.istio-ingressgateway.route", *gateways.ClusterIngress.RouteEnabled); err != nil {
+					return err
+				}
+			}
 			if err := setHelmValue(gatewayValues, "name", "istio-ingressgateway"); err != nil {
 				return err
 			}
@@ -423,6 +428,11 @@ func populateGatewaysConfig(in *v1.HelmValues, out *v2.ControlPlaneSpec) error {
 					}
 					if k8sIngressEnabled, ok, err := in.GetAndRemoveBool("global.k8sIngress.enabled"); ok {
 						clusterIngress.IngressEnabled = &k8sIngressEnabled
+					} else if err != nil {
+						return err
+					}
+					if routeEnabled, ok, err := gatewayValues.GetAndRemoveBool("route"); ok {
+						clusterIngress.RouteEnabled = &routeEnabled
 					} else if err != nil {
 						return err
 					}

--- a/pkg/apis/maistra/conversion/gateways.go
+++ b/pkg/apis/maistra/conversion/gateways.go
@@ -432,10 +432,8 @@ func populateGatewaysConfig(in *v1.HelmValues, out *v2.ControlPlaneSpec) error {
 						return err
 					}
 					if routeEnabled, ok, err := gatewayValues.GetAndRemoveBool("routeConfig.enabled"); ok {
-						clusterIngress.RouteConfig = &v2.ComponentIngressConfig{
-							Enablement: v2.Enablement{
-								Enabled: &routeEnabled,
-							},
+						clusterIngress.RouteConfig = &v2.Enablement{
+							Enabled: &routeEnabled,
 						}
 					} else if err != nil {
 						return err

--- a/pkg/apis/maistra/conversion/gateways.go
+++ b/pkg/apis/maistra/conversion/gateways.go
@@ -108,8 +108,8 @@ func populateGatewaysValues(in *v2.ControlPlaneSpec, values map[string]interface
 					return err
 				}
 			}
-			if gateways.ClusterIngress.RouteEnabled != nil {
-				if err := setHelmBoolValue(values, "gateways.istio-ingressgateway.route", *gateways.ClusterIngress.RouteEnabled); err != nil {
+			if gateways.ClusterIngress.RouteConfig != nil && gateways.ClusterIngress.RouteConfig.Enabled != nil {
+				if err := setHelmBoolValue(values, "gateways.istio-ingressgateway.routeConfig.enabled", *gateways.ClusterIngress.RouteConfig.Enabled); err != nil {
 					return err
 				}
 			}
@@ -431,8 +431,12 @@ func populateGatewaysConfig(in *v1.HelmValues, out *v2.ControlPlaneSpec) error {
 					} else if err != nil {
 						return err
 					}
-					if routeEnabled, ok, err := gatewayValues.GetAndRemoveBool("route"); ok {
-						clusterIngress.RouteEnabled = &routeEnabled
+					if routeEnabled, ok, err := gatewayValues.GetAndRemoveBool("routeConfig.enabled"); ok {
+						clusterIngress.RouteConfig = &v2.ComponentIngressConfig{
+							Enablement: v2.Enablement{
+								Enabled: &routeEnabled,
+							},
+						}
 					} else if err != nil {
 						return err
 					}

--- a/pkg/apis/maistra/conversion/gateways_test.go
+++ b/pkg/apis/maistra/conversion/gateways_test.go
@@ -1496,10 +1496,8 @@ func gatewaysTestCasesV2(version versions.Version) []conversionTestCase {
 				Version: ver,
 				Gateways: &v2.GatewaysConfig{
 					ClusterIngress: &v2.ClusterIngressGatewayConfig{
-						RouteConfig: &v2.ComponentIngressConfig{
-							Enablement: v2.Enablement{
-								Enabled: &featureEnabled,
-							},
+						RouteConfig: &v2.Enablement{
+							Enabled: &featureEnabled,
 						},
 					},
 				},
@@ -1528,10 +1526,8 @@ func gatewaysTestCasesV2(version versions.Version) []conversionTestCase {
 				Version: ver,
 				Gateways: &v2.GatewaysConfig{
 					ClusterIngress: &v2.ClusterIngressGatewayConfig{
-						RouteConfig: &v2.ComponentIngressConfig{
-							Enablement: v2.Enablement{
-								Enabled: &featureDisabled,
-							},
+						RouteConfig: &v2.Enablement{
+							Enabled: &featureDisabled,
 						},
 					},
 				},

--- a/pkg/apis/maistra/conversion/gateways_test.go
+++ b/pkg/apis/maistra/conversion/gateways_test.go
@@ -1490,6 +1490,83 @@ func gatewaysTestCasesV2(version versions.Version) []conversionTestCase {
 				},
 			}),
 		},
+		{
+			name: "ingress.route.enabled" + ver,
+			spec: &v2.ControlPlaneSpec{
+				Version: ver,
+				Gateways: &v2.GatewaysConfig{
+					ClusterIngress: &v2.ClusterIngressGatewayConfig{
+						RouteEnabled: &featureEnabled,
+					},
+				},
+			},
+			isolatedIstio: v1.NewHelmValues(map[string]interface{}{
+				"gateways": map[string]interface{}{
+					"istio-ingressgateway": map[string]interface{}{
+						"name":        "istio-ingressgateway",
+						"gatewayType": "ingress",
+						"route":       true,
+					},
+				},
+			}),
+			completeIstio: v1.NewHelmValues(map[string]interface{}{
+				"global": map[string]interface{}{
+					"multiCluster":  globalMultiClusterDefaults,
+					"meshExpansion": globalMeshExpansionDefaults,
+				},
+			}),
+		},
+		{
+			name: "ingress.route.disabled" + ver,
+			spec: &v2.ControlPlaneSpec{
+				Version: ver,
+				Gateways: &v2.GatewaysConfig{
+					ClusterIngress: &v2.ClusterIngressGatewayConfig{
+						RouteEnabled: &featureDisabled,
+					},
+				},
+			},
+			isolatedIstio: v1.NewHelmValues(map[string]interface{}{
+				"gateways": map[string]interface{}{
+					"istio-ingressgateway": map[string]interface{}{
+						"name":        "istio-ingressgateway",
+						"gatewayType": "ingress",
+						"route":       false,
+					},
+				},
+			}),
+			completeIstio: v1.NewHelmValues(map[string]interface{}{
+				"global": map[string]interface{}{
+					"multiCluster":  globalMultiClusterDefaults,
+					"meshExpansion": globalMeshExpansionDefaults,
+				},
+			}),
+		},
+		{
+			name: "ingress.route.undefined" + ver,
+			spec: &v2.ControlPlaneSpec{
+				Version: ver,
+				Gateways: &v2.GatewaysConfig{
+					ClusterIngress: &v2.ClusterIngressGatewayConfig{
+						RouteEnabled: nil,
+					},
+				},
+			},
+			isolatedIstio: v1.NewHelmValues(map[string]interface{}{
+				"gateways": map[string]interface{}{
+					"istio-ingressgateway": map[string]interface{}{
+						"name":        "istio-ingressgateway",
+						"gatewayType": "ingress",
+					},
+				},
+			}),
+			completeIstio: v1.NewHelmValues(map[string]interface{}{
+				"global": map[string]interface{}{
+					"multiCluster":  globalMultiClusterDefaults,
+					"meshExpansion": globalMeshExpansionDefaults,
+				},
+			}),
+		},
 	}
 }
 

--- a/pkg/apis/maistra/conversion/gateways_test.go
+++ b/pkg/apis/maistra/conversion/gateways_test.go
@@ -1496,7 +1496,11 @@ func gatewaysTestCasesV2(version versions.Version) []conversionTestCase {
 				Version: ver,
 				Gateways: &v2.GatewaysConfig{
 					ClusterIngress: &v2.ClusterIngressGatewayConfig{
-						RouteEnabled: &featureEnabled,
+						RouteConfig: &v2.ComponentIngressConfig{
+							Enablement: v2.Enablement{
+								Enabled: &featureEnabled,
+							},
+						},
 					},
 				},
 			},
@@ -1505,7 +1509,9 @@ func gatewaysTestCasesV2(version versions.Version) []conversionTestCase {
 					"istio-ingressgateway": map[string]interface{}{
 						"name":        "istio-ingressgateway",
 						"gatewayType": "ingress",
-						"route":       true,
+						"routeConfig": map[string]interface{}{
+							"enabled": true,
+						},
 					},
 				},
 			}),
@@ -1522,7 +1528,11 @@ func gatewaysTestCasesV2(version versions.Version) []conversionTestCase {
 				Version: ver,
 				Gateways: &v2.GatewaysConfig{
 					ClusterIngress: &v2.ClusterIngressGatewayConfig{
-						RouteEnabled: &featureDisabled,
+						RouteConfig: &v2.ComponentIngressConfig{
+							Enablement: v2.Enablement{
+								Enabled: &featureDisabled,
+							},
+						},
 					},
 				},
 			},
@@ -1531,7 +1541,9 @@ func gatewaysTestCasesV2(version versions.Version) []conversionTestCase {
 					"istio-ingressgateway": map[string]interface{}{
 						"name":        "istio-ingressgateway",
 						"gatewayType": "ingress",
-						"route":       false,
+						"routeConfig": map[string]interface{}{
+							"enabled": false,
+						},
 					},
 				},
 			}),
@@ -1548,7 +1560,7 @@ func gatewaysTestCasesV2(version versions.Version) []conversionTestCase {
 				Version: ver,
 				Gateways: &v2.GatewaysConfig{
 					ClusterIngress: &v2.ClusterIngressGatewayConfig{
-						RouteEnabled: nil,
+						RouteConfig: nil,
 					},
 				},
 			},

--- a/pkg/apis/maistra/v2/gateways.go
+++ b/pkg/apis/maistra/v2/gateways.go
@@ -112,9 +112,9 @@ type ClusterIngressGatewayConfig struct {
 	// MeshExpansionPorts define the port set used with multi-cluster/mesh expansion
 	// +optional
 	MeshExpansionPorts []corev1.ServicePort `json:"meshExpansionPorts,omitempty"`
-	// RouteConfig is used to customize an OpenShift Route associated with istio-ingressgateway deployment
+	// RouteConfig specifies whether to create an OpenShift Route for istio-ingressgateway deployment
 	// +optional
-	RouteConfig *ComponentIngressConfig `json:"routeConfig,omitempty"`
+	RouteConfig *Enablement `json:"routeConfig,omitempty"`
 }
 
 // RouterModeType represents the router modes available.

--- a/pkg/apis/maistra/v2/gateways.go
+++ b/pkg/apis/maistra/v2/gateways.go
@@ -112,6 +112,9 @@ type ClusterIngressGatewayConfig struct {
 	// MeshExpansionPorts define the port set used with multi-cluster/mesh expansion
 	// +optional
 	MeshExpansionPorts []corev1.ServicePort `json:"meshExpansionPorts,omitempty"`
+	// RouteEnabled specifies whether to create a Route (route.openshift.io/v1) for the istio-ingressgateway component
+	// +optional
+	RouteEnabled *bool `json:"route,omitempty"`
 }
 
 // RouterModeType represents the router modes available.

--- a/pkg/apis/maistra/v2/gateways.go
+++ b/pkg/apis/maistra/v2/gateways.go
@@ -112,9 +112,9 @@ type ClusterIngressGatewayConfig struct {
 	// MeshExpansionPorts define the port set used with multi-cluster/mesh expansion
 	// +optional
 	MeshExpansionPorts []corev1.ServicePort `json:"meshExpansionPorts,omitempty"`
-	// RouteEnabled specifies whether to create a Route (route.openshift.io/v1) for the istio-ingressgateway component
+	// RouteConfig is used to customize an OpenShift Route associated with istio-ingressgateway deployment
 	// +optional
-	RouteEnabled *bool `json:"route,omitempty"`
+	RouteConfig *ComponentIngressConfig `json:"routeConfig,omitempty"`
 }
 
 // RouterModeType represents the router modes available.

--- a/pkg/apis/maistra/v2/smcp_new.yaml
+++ b/pkg/apis/maistra/v2/smcp_new.yaml
@@ -302,7 +302,8 @@ spec:
           port: 443
           targetPort: 8443
       meshExpansionPorts: [] # additional expansion ports. default expansion ports will be added automatically if multiCluster is configured
-      route: true
+      routeConfig:
+        enabled: true
     egress: # _the_ istio-egressgateway
       service:
         type: ClusterIP

--- a/pkg/apis/maistra/v2/smcp_new.yaml
+++ b/pkg/apis/maistra/v2/smcp_new.yaml
@@ -302,6 +302,7 @@ spec:
           port: 443
           targetPort: 8443
       meshExpansionPorts: [] # additional expansion ports. default expansion ports will be added automatically if multiCluster is configured
+      route: true
     egress: # _the_ istio-egressgateway
       service:
         type: ClusterIP

--- a/pkg/apis/maistra/v2/smcp_new.yaml
+++ b/pkg/apis/maistra/v2/smcp_new.yaml
@@ -302,7 +302,7 @@ spec:
           port: 443
           targetPort: 8443
       meshExpansionPorts: [] # additional expansion ports. default expansion ports will be added automatically if multiCluster is configured
-      routeConfig:
+      routeConfig: # specifies whether to create an OpenShift Route for istio-ingressgateway
         enabled: true
     egress: # _the_ istio-egressgateway
       service:

--- a/pkg/apis/maistra/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/maistra/v2/zz_generated.deepcopy.go
@@ -159,10 +159,10 @@ func (in *ClusterIngressGatewayConfig) DeepCopyInto(out *ClusterIngressGatewayCo
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.RouteEnabled != nil {
-		in, out := &in.RouteEnabled, &out.RouteEnabled
-		*out = new(bool)
-		**out = **in
+	if in.RouteConfig != nil {
+		in, out := &in.RouteConfig, &out.RouteConfig
+		*out = new(ComponentIngressConfig)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/pkg/apis/maistra/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/maistra/v2/zz_generated.deepcopy.go
@@ -159,6 +159,11 @@ func (in *ClusterIngressGatewayConfig) DeepCopyInto(out *ClusterIngressGatewayCo
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.RouteEnabled != nil {
+		in, out := &in.RouteEnabled, &out.RouteEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/maistra/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/maistra/v2/zz_generated.deepcopy.go
@@ -161,7 +161,7 @@ func (in *ClusterIngressGatewayConfig) DeepCopyInto(out *ClusterIngressGatewayCo
 	}
 	if in.RouteConfig != nil {
 		in, out := &in.RouteConfig, &out.RouteConfig
-		*out = new(ComponentIngressConfig)
+		*out = new(Enablement)
 		(*in).DeepCopyInto(*out)
 	}
 	return

--- a/pkg/controller/servicemesh/controlplane/gateways_test.go
+++ b/pkg/controller/servicemesh/controlplane/gateways_test.go
@@ -219,7 +219,11 @@ func TestAdditionalIngressGatewayInstall(t *testing.T) {
 			smcp: New21SMCPResource(controlPlaneName, controlPlaneNamespace, &v2.ControlPlaneSpec{
 				Gateways: &v2.GatewaysConfig{
 					ClusterIngress: &v2.ClusterIngressGatewayConfig{
-						RouteEnabled: &enabled,
+						RouteConfig: &v2.ComponentIngressConfig{
+							Enablement: v2.Enablement{
+								Enabled: &enabled,
+							},
+						},
 					},
 				},
 			}),
@@ -245,7 +249,11 @@ func TestAdditionalIngressGatewayInstall(t *testing.T) {
 			smcp: New21SMCPResource(controlPlaneName, controlPlaneNamespace, &v2.ControlPlaneSpec{
 				Gateways: &v2.GatewaysConfig{
 					ClusterIngress: &v2.ClusterIngressGatewayConfig{
-						RouteEnabled: &disabled,
+						RouteConfig: &v2.ComponentIngressConfig{
+							Enablement: v2.Enablement{
+								Enabled: &disabled,
+							},
+						},
 					},
 				},
 			}),

--- a/pkg/controller/servicemesh/controlplane/gateways_test.go
+++ b/pkg/controller/servicemesh/controlplane/gateways_test.go
@@ -219,10 +219,8 @@ func TestAdditionalIngressGatewayInstall(t *testing.T) {
 			smcp: New21SMCPResource(controlPlaneName, controlPlaneNamespace, &v2.ControlPlaneSpec{
 				Gateways: &v2.GatewaysConfig{
 					ClusterIngress: &v2.ClusterIngressGatewayConfig{
-						RouteConfig: &v2.ComponentIngressConfig{
-							Enablement: v2.Enablement{
-								Enabled: &enabled,
-							},
+						RouteConfig: &v2.Enablement{
+							Enabled: &enabled,
 						},
 					},
 				},
@@ -249,10 +247,8 @@ func TestAdditionalIngressGatewayInstall(t *testing.T) {
 			smcp: New21SMCPResource(controlPlaneName, controlPlaneNamespace, &v2.ControlPlaneSpec{
 				Gateways: &v2.GatewaysConfig{
 					ClusterIngress: &v2.ClusterIngressGatewayConfig{
-						RouteConfig: &v2.ComponentIngressConfig{
-							Enablement: v2.Enablement{
-								Enabled: &disabled,
-							},
+						RouteConfig: &v2.Enablement{
+							Enabled: &disabled,
 						},
 					},
 				},

--- a/resources/helm/overlays/gateways/istio-ingress/templates/istio-ingressgateway-route.yaml
+++ b/resources/helm/overlays/gateways/istio-ingress/templates/istio-ingressgateway-route.yaml
@@ -1,5 +1,5 @@
 {{ $gateway := index .Values "gateways" "istio-ingressgateway" }}
-{{- if and $gateway.enabled $gateway.route }}
+{{- if and $gateway.enabled $gateway.routeConfig.enabled }}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:

--- a/resources/helm/overlays/gateways/istio-ingress/templates/istio-ingressgateway-route.yaml
+++ b/resources/helm/overlays/gateways/istio-ingress/templates/istio-ingressgateway-route.yaml
@@ -1,5 +1,5 @@
 {{ $gateway := index .Values "gateways" "istio-ingressgateway" }}
-{{- if $gateway.enabled }}
+{{- if and $gateway.enabled $gateway.route }}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:

--- a/resources/helm/v2.1/gateways/istio-ingress/templates/istio-ingressgateway-route.yaml
+++ b/resources/helm/v2.1/gateways/istio-ingress/templates/istio-ingressgateway-route.yaml
@@ -1,5 +1,5 @@
 {{ $gateway := index .Values "gateways" "istio-ingressgateway" }}
-{{- if and $gateway.enabled $gateway.route }}
+{{- if and $gateway.enabled $gateway.routeConfig.enabled }}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:

--- a/resources/helm/v2.1/gateways/istio-ingress/templates/istio-ingressgateway-route.yaml
+++ b/resources/helm/v2.1/gateways/istio-ingress/templates/istio-ingressgateway-route.yaml
@@ -1,5 +1,5 @@
 {{ $gateway := index .Values "gateways" "istio-ingressgateway" }}
-{{- if $gateway.enabled }}
+{{- if and $gateway.enabled $gateway.route }}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:

--- a/resources/helm/v2.1/gateways/istio-ingress/values.yaml
+++ b/resources/helm/v2.1/gateways/istio-ingress/values.yaml
@@ -116,6 +116,9 @@ gateways:
     # whether to run the gateway in a privileged container
     runAsRoot: false
 
+    # specifies whether to create a Route resource (route.openshift.io/v1) for the istio-ingressgateway deployment
+    route: true
+
     # The injection template to use for the gateway. If not set, no injection will be performed.
     injectionTemplate: ""
 

--- a/resources/helm/v2.1/gateways/istio-ingress/values.yaml
+++ b/resources/helm/v2.1/gateways/istio-ingress/values.yaml
@@ -117,7 +117,8 @@ gateways:
     runAsRoot: false
 
     # specifies whether to create a Route resource (route.openshift.io/v1) for the istio-ingressgateway deployment
-    route: true
+    routeConfig:
+      enabled: true
 
     # The injection template to use for the gateway. If not set, no injection will be performed.
     injectionTemplate: ""

--- a/resources/helm/v2.1/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
+++ b/resources/helm/v2.1/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
@@ -28,7 +28,7 @@ data:
 {{ toYaml .Values.sidecarInjectorWebhook.neverInjectSelector | trim | indent 6 }}
     injectedAnnotations:
       {{- range $key, $val := .Values.sidecarInjectorWebhook.injectedAnnotations }}
-      "{{ $key }}": "{{ $val }}"
+      "{{ $key }}": {{ $val | quote }}
       {{- end }}
     {{- /* If someone ends up with this new template, but an older Istiod image, they will attempt to render this template
          which will fail with "Pod injection failed: template: inject:1: function "Istio_1_9_Required_Template_And_Version_Mismatched" not defined".


### PR DESCRIPTION
This change enables users to control creation of OpenShift Route for istio-ingressgateway deployment by setting the following config in the SMCP spec:
```
apiVersion: maistra.io/v2
kind: ServiceMeshControlPlane
metadata:
  name: basic
  namespace: istio-system
spec:
  version: v2.1
  gateways:
    ingress:
      routeConfig:
        enabled: true # or false
```
Setting `gateways.ingress.routeConfig` is optional, because creation of OpenShift Route is enabled by default.

Important:
- this change affects SMCP **v2.1**
- `routeConfig` **does not apply** to egress gateway nor additional gateways.