### PR TITLE
OSSM-1162: Remove a non-existing annotation

### DIFF
--- a/resources/helm/overlays/istio_cni/templates/daemonset.yaml
+++ b/resources/helm/overlays/istio_cni/templates/daemonset.yaml
@@ -27,11 +27,6 @@ spec:
         istio: cni
       annotations:
         sidecar.istio.io/inject: "false"
-        # This, along with the CriticalAddonsOnly toleration below,
-        # marks the pod as a critical add-on, ensuring it gets
-        # priority scheduling and that its resources are reserved
-        # if it ever gets evicted.
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
@@ -48,9 +43,7 @@ spec:
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
-{{- if .Values.priorityClassName }}
-      priorityClassName: "{{ .Values.priorityClassName }}"
-{{- end }}
+      priorityClassName: system-cluster-critical
 {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{- range .Values.imagePullSecrets }}

--- a/resources/helm/v2.1/istio_cni/templates/daemonset.yaml
+++ b/resources/helm/v2.1/istio_cni/templates/daemonset.yaml
@@ -28,11 +28,6 @@ spec:
         istio: cni
       annotations:
         sidecar.istio.io/inject: "false"
-        # This, along with the CriticalAddonsOnly toleration below,
-        # marks the pod as a critical add-on, ensuring it gets
-        # priority scheduling and that its resources are reserved
-        # if it ever gets evicted.
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
@@ -49,9 +44,7 @@ spec:
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
-{{- if .Values.priorityClassName }}
-      priorityClassName: "{{ .Values.priorityClassName }}"
-{{- end }}
+      priorityClassName: system-cluster-critical
 {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{- range .Values.imagePullSecrets }}


### PR DESCRIPTION
And replace it with a proper `priorityClassName` field. Its value is
aligned with upstream 1.9 release.