### PR TITLE
OSSM-1107 Add jwksResolverExtraRootCA feature

### DIFF
--- a/deploy/maistra-operator.yaml
+++ b/deploy/maistra-operator.yaml
@@ -4946,6 +4946,8 @@ spec:
                           workloadCertTTLMax:
                             type: string
                         type: object
+                      jwksResolverExtraRootCA:
+                        type: string
                       type:
                         type: string
                     type: object
@@ -9813,6 +9815,8 @@ spec:
                               workloadCertTTLMax:
                                 type: string
                             type: object
+                          jwksResolverExtraRootCA:
+                            type: string
                           type:
                             type: string
                         type: object

--- a/deploy/servicemesh-operator.yaml
+++ b/deploy/servicemesh-operator.yaml
@@ -4946,6 +4946,8 @@ spec:
                           workloadCertTTLMax:
                             type: string
                         type: object
+                      jwksResolverExtraRootCA:
+                        type: string
                       type:
                         type: string
                     type: object
@@ -9813,6 +9815,8 @@ spec:
                               workloadCertTTLMax:
                                 type: string
                             type: object
+                          jwksResolverExtraRootCA:
+                            type: string
                           type:
                             type: string
                         type: object

--- a/deploy/src/crd.yaml
+++ b/deploy/src/crd.yaml
@@ -4945,6 +4945,8 @@ spec:
                           workloadCertTTLMax:
                             type: string
                         type: object
+                      jwksResolverExtraRootCA:
+                        type: string
                       type:
                         type: string
                     type: object
@@ -9812,6 +9814,8 @@ spec:
                               workloadCertTTLMax:
                                 type: string
                             type: object
+                          jwksResolverExtraRootCA:
+                            type: string
                           type:
                             type: string
                         type: object

--- a/manifests-maistra/2.2.0/servicemeshcontrolplanes.crd.yaml
+++ b/manifests-maistra/2.2.0/servicemeshcontrolplanes.crd.yaml
@@ -4945,6 +4945,8 @@ spec:
                           workloadCertTTLMax:
                             type: string
                         type: object
+                      jwksResolverExtraRootCA:
+                        type: string
                       type:
                         type: string
                     type: object
@@ -9812,6 +9814,8 @@ spec:
                               workloadCertTTLMax:
                                 type: string
                             type: object
+                          jwksResolverExtraRootCA:
+                            type: string
                           type:
                             type: string
                         type: object

--- a/manifests-servicemesh/2.2.0/servicemeshcontrolplanes.crd.yaml
+++ b/manifests-servicemesh/2.2.0/servicemeshcontrolplanes.crd.yaml
@@ -4945,6 +4945,8 @@ spec:
                           workloadCertTTLMax:
                             type: string
                         type: object
+                      jwksResolverExtraRootCA:
+                        type: string
                       type:
                         type: string
                     type: object
@@ -9812,6 +9814,8 @@ spec:
                               workloadCertTTLMax:
                                 type: string
                             type: object
+                          jwksResolverExtraRootCA:
+                            type: string
                           type:
                             type: string
                         type: object

--- a/pkg/apis/maistra/conversion/security.go
+++ b/pkg/apis/maistra/conversion/security.go
@@ -153,6 +153,13 @@ func populateSecurityValues(in *v2.ControlPlaneSpec, values map[string]interface
 		default:
 			return fmt.Errorf("unknown CertificateAuthority type: %s", security.CertificateAuthority.Type)
 		}
+
+		// JWKS Resolver Extra CA
+		if security.CertificateAuthority.JwksResolverExtraRootCA != "" {
+			if err := setHelmStringValue(values, "pilot.jwksResolverExtraRootCA", string(security.CertificateAuthority.JwksResolverExtraRootCA)); err != nil {
+				return err
+			}
+		}
 	}
 
 	// Identity
@@ -427,6 +434,15 @@ func populateSecurityConfig(in *v1.HelmValues, out *v2.ControlPlaneSpec, version
 	case "":
 		// don't configure CA
 	}
+
+	// jwksResolverExtraRootCA
+	if jwksExtraCA, ok, err := in.GetAndRemoveString("pilot.jwksResolverExtraRootCA"); ok {
+		ca.JwksResolverExtraRootCA = jwksExtraCA
+		setCA = true
+	} else if err != nil {
+		return err
+	}
+
 	if setCA {
 		security.CertificateAuthority = ca
 		setSecurity = true

--- a/pkg/apis/maistra/conversion/security_test.go
+++ b/pkg/apis/maistra/conversion/security_test.go
@@ -9,6 +9,43 @@ import (
 	"github.com/maistra/istio-operator/pkg/controller/versions"
 )
 
+const (
+	testcert = `
+-----BEGIN CERTIFICATE-----
+MIIFgTCCA2mgAwIBAgIUZzX0jMIVIU3a75olJeNv8qEnMAcwDQYJKoZIhvcNAQEL
+BQAwUDELMAkGA1UEBhMCVVMxDzANBgNVBAgMBkRlbmlhbDEOMAwGA1UEBwwFRXRo
+ZXIxDDAKBgNVBAoMA0RpczESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTE5MDkxOTEz
+NDc0MFoXDTI5MDkxNjEzNDc0MFowUDELMAkGA1UEBhMCVVMxDzANBgNVBAgMBkRl
+bmlhbDEOMAwGA1UEBwwFRXRoZXIxDDAKBgNVBAoMA0RpczESMBAGA1UEAwwJbG9j
+YWxob3N0MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA3lX/t3mQ//Hf
+wdhmwpFvL0eNFxQGlDgPs72Puh+VWDuSs+okSo3pcvQEv+q2rlqGlx81w2owuoFz
+8fASBQ3jFH6HPbA50gkBU87RQ8czcn7ASypybukC1aa1o4yhwCqrOudPdtcvqSx9
+FS4VA8l1o3QBTIXnTyz68338l/ZNdcdEyQoNwdkmI4qPOxx5IhgQeiuLGVcxnVzw
+eBGIPIVuxX8tuSWdu4UKjswHpok3w/PrphTpPsXIWChdlex840namnfIb7B3iYEZ
+EDOkKA/VkjImdxEHq9FktjSkdshXh4TcJAjbL2IuJ/V/JyzmXPndIMDvu8tQgdkI
+atAgfL8Ah2VkXFbVSqoXkgoSVSQtDBGyBIp2ZOISOCtKeb55Gy/PfpjL6dsr20UE
+TS6nDJ9o5Rk7CIobniGxPEoXYYma2ZHXNYraR5KwUGaz4bDpBZll6UtQKifQMp1t
+M1bBB6Y2ubjkbevdjkM/le668vIvr31GlkXVXiJrycumpTpgyIJh62yOL9HZTiio
+U+qpqUJM2qUBUS0JBddQoNMvbNBBVlP3ZKinrywldtyqJ24Kwml18a/dv3Cxxdjt
+wubgdeMV3wPISnnkoArO8jcrjSX3U2spcLDi2W6x11Xg+KJcy4sS3cI2SE4gTrBE
+YgyE+awhduu4awknbPPYgL8DXGvo8PsCAwEAAaNTMFEwHQYDVR0OBBYEFB0VZJU5
+SznwI4m7beqJPNP+SFHyMB8GA1UdIwQYMBaAFB0VZJU5SznwI4m7beqJPNP+SFHy
+MA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggIBAAdOWfGS3UjAucdw
+U9/Qr78nKyC4YJJn1keFxzf2tJQOAa6k57Ln6fbJTNoMEwnCPWUBR44kCfQMEOup
+TNG4AEvJfHroCIgAuuPZ0AX75TBFB0UU9gnl2g8eou78+6tAw+r+KVcMAr/yvQYs
+fCpM7k+rte8rCuIXSb9m9kJxKRNkILRSGhyhCfBDUi0iXqjKYI+Utetg3pe8Vrkl
+rhYe6o2sGLkf8VbawC2ZNBqm1ehhjVIDDGcGAz6RcscqIR+f7MLy3oUNypiIoJ3M
+yVwTCn34vbIViDcu9yebgrt0ZOq3AyFgtCKCHswO21BM97NelbZ7wdJNJXOXhzuW
+aqlciI+5kj3sYwbFq3eNTZuFad+AJvCEO5xLusAl0WZENMJ1TLDymSd0yi8pEtu0
+GtbtGLsMrHVhfqW8XWmqiCBUe6nP2W1OgjJt0jGNsiQ3IbK3/M5Fk5iM5kNTtKZY
+h9/bp+//GG/VUYpAP9J1/uunf2L+z0XLqwN1+++8RQgUqtN9B9Qe8FgQ+eiUmmyC
+xj7nwwfaTzoRw8MIpj17bz/pkDvTGOiDrc5woaEePV7gyfLGrK5dHN+E27Xs8ZCx
+iWBfESF8eP/PdF9JG3g7+5Bmz0yuiZErqWp17VH3o/gb2BSWK3MfO6UYYVnCNpok
+nFnKhRHgeHQiN8p4DaXm4BDNUVnU
+-----END CERTIFICATE-----	
+`
+)
+
 var securityTestCases []conversionTestCase
 
 var securityTestCasesV1 = []conversionTestCase{
@@ -1167,6 +1204,49 @@ func securityTestCasesV2(version versions.Version) []conversionTestCase {
 				"global": map[string]interface{}{
 					"multiCluster":  globalMultiClusterDefaults,
 					"meshExpansion": globalMeshExpansionDefaults,
+				},
+			}),
+		},
+		{
+			name: "ca.jwksResolverExtraRootCA.empty." + ver,
+			spec: &v2.ControlPlaneSpec{
+				Version: ver,
+				Security: &v2.SecurityConfig{
+					CertificateAuthority: &v2.CertificateAuthorityConfig{
+						JwksResolverExtraRootCA: "",
+					},
+				},
+			},
+			isolatedIstio: v1.NewHelmValues(map[string]interface{}{}),
+			completeIstio: v1.NewHelmValues(map[string]interface{}{
+				"global": map[string]interface{}{
+					"multiCluster":  globalMultiClusterDefaults,
+					"meshExpansion": globalMeshExpansionDefaults,
+				},
+			}),
+		},
+		{
+			name: "ca.jwksResolverExtraRootCA.nonempty." + ver,
+			spec: &v2.ControlPlaneSpec{
+				Version: ver,
+				Security: &v2.SecurityConfig{
+					CertificateAuthority: &v2.CertificateAuthorityConfig{
+						JwksResolverExtraRootCA: testcert,
+					},
+				},
+			},
+			isolatedIstio: v1.NewHelmValues(map[string]interface{}{
+				"pilot": map[string]interface{}{
+					"jwksResolverExtraRootCA": testcert,
+				},
+			}),
+			completeIstio: v1.NewHelmValues(map[string]interface{}{
+				"global": map[string]interface{}{
+					"multiCluster":  globalMultiClusterDefaults,
+					"meshExpansion": globalMeshExpansionDefaults,
+				},
+				"pilot": map[string]interface{}{
+					"jwksResolverExtraRootCA": testcert,
 				},
 			}),
 		},

--- a/pkg/apis/maistra/v2/security.go
+++ b/pkg/apis/maistra/v2/security.go
@@ -53,6 +53,9 @@ type CertificateAuthorityConfig struct {
 	// Custom is the configuration for a custom certificate authority.
 	// +optional
 	Custom *CustomCertificateAuthorityConfig `json:"custom,omitempty"`
+	// JwksResolverExtraRootCA is the configuration for injecting a trusted CA into the JWKSResolver.
+	// +optional
+	JwksResolverExtraRootCA string `json:"jwksResolverExtraRootCA,omitempty"`
 }
 
 // CertificateAuthorityType represents the type of CertificateAuthority implementation.

--- a/pkg/apis/maistra/v2/smcp_new.yaml
+++ b/pkg/apis/maistra/v2/smcp_new.yaml
@@ -1,6 +1,6 @@
 spec:
   template: default
-  version: v2.1
+  version: v2.2
   cluster:
     name: Kubernetes
     network: main
@@ -266,6 +266,9 @@ spec:
       # or
       custom: # i have no idea about this
         address: some.location.domain
+      # JWKSResolver extra CA
+      jwksResolverExtraRootCA: "" # PEM-encoded certificate content to trust an additional CA
+
     identity: # specifies how service tokens are verified
       type: Kubernetes # or ThirdParty
       # one of


### PR DESCRIPTION
- This PR is related to OSSM-1107 and Istio PR 17176 https://github.com/istio/istio/pull/17176
- Add a new SMCP spec field as
  .spec.security.certificateAuthority.jwksResolverExtraRootCA

Signed-off-by: Yuanlin Xu <yuanlin.xu@redhat.com>