### PR TITLE
OSSM-218: requeue reconcilation when Jaeger or Grafana routes are empty

### DIFF
--- a/pkg/apis/maistra/v2/servicemeshcontrolplane_types.go
+++ b/pkg/apis/maistra/v2/servicemeshcontrolplane_types.go
@@ -175,7 +175,16 @@ func (s ControlPlaneSpec) IsKialiEnabled() bool {
 }
 
 func (s ControlPlaneSpec) IsPrometheusEnabled() bool {
-	return s.Addons.Prometheus != nil &&
+	return s.Addons != nil &&
+		s.Addons.Prometheus != nil &&
 		s.Addons.Prometheus.Enabled != nil &&
 		*s.Addons.Prometheus.Enabled
+}
+
+func (s ControlPlaneSpec) IsGrafanaEnabled() bool {
+	return s.Addons != nil && s.Addons.Grafana != nil && s.Addons.Grafana.Enabled != nil && *s.Addons.Grafana.Enabled
+}
+
+func (s ControlPlaneSpec) IsJaegerEnabled() bool {
+	return s.Tracing != nil && s.Tracing.Type == TracerTypeJaeger
 }

--- a/pkg/controller/common/reconcile_result.go
+++ b/pkg/controller/common/reconcile_result.go
@@ -1,0 +1,19 @@
+package common
+
+import (
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func Reconciled() (reconcile.Result, error) {
+	return reconcile.Result{}, nil
+}
+
+func RequeueWithError(err error) (reconcile.Result, error) {
+	return reconcile.Result{}, err
+}
+
+func RequeueAfter(time time.Duration) (reconcile.Result, error) {
+	return reconcile.Result{RequeueAfter: time}, nil
+}

--- a/pkg/controller/common/test/controller-test-utils.go
+++ b/pkg/controller/common/test/controller-test-utils.go
@@ -37,7 +37,10 @@ func GetScheme() *runtime.Scheme {
 }
 
 func CreateClient(clientObjects ...runtime.Object) (client.Client, *EnhancedTracker) {
-	s := GetScheme()
+	return CreateClientWithScheme(GetScheme(), clientObjects...)
+}
+
+func CreateClientWithScheme(s *runtime.Scheme, clientObjects ...runtime.Object) (client.Client, *EnhancedTracker) {
 	codecs := serializer.NewCodecFactory(s)
 	tracker := clienttesting.NewObjectTracker(s, codecs.UniversalDecoder())
 	enhancedTracker := NewEnhancedTracker(tracker, s, v2.SchemeGroupVersion)

--- a/pkg/controller/servicemesh/controlplane/addons.go
+++ b/pkg/controller/servicemesh/controlplane/addons.go
@@ -11,22 +11,23 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/maistra/istio-operator/pkg/apis/external"
 	kialiv1alpha1 "github.com/maistra/istio-operator/pkg/apis/external/kiali/v1alpha1"
-	v1 "github.com/maistra/istio-operator/pkg/apis/maistra/v1"
-	v2 "github.com/maistra/istio-operator/pkg/apis/maistra/v2"
+	"github.com/maistra/istio-operator/pkg/apis/maistra/v1"
+	"github.com/maistra/istio-operator/pkg/apis/maistra/v2"
 	"github.com/maistra/istio-operator/pkg/controller/common"
 )
 
-func (r *controlPlaneInstanceReconciler) PatchAddons(ctx context.Context) error {
+func (r *controlPlaneInstanceReconciler) PatchAddons(ctx context.Context, spec *v2.ControlPlaneSpec) (reconcile.Result, error) {
 	// so far, only need to patch kiali
-	return r.patchKiali(ctx)
+	return r.patchKiali(ctx, spec.IsGrafanaEnabled(), spec.IsJaegerEnabled())
 }
 
-func (r *controlPlaneInstanceReconciler) patchKiali(ctx context.Context) error {
+func (r *controlPlaneInstanceReconciler) patchKiali(ctx context.Context, grafanaEnabled, jaegerEnabled bool) (reconcile.Result, error) {
 	if r.Instance == nil || !r.Instance.Status.AppliedSpec.IsKialiEnabled() {
-		return nil
+		return common.Reconciled()
 	}
 
 	log := common.LogFromContext(ctx)
@@ -38,9 +39,9 @@ func (r *controlPlaneInstanceReconciler) patchKiali(ctx context.Context) error {
 	if err := r.Client.Get(ctx, types.NamespacedName{Name: kialiConfig.ResourceName(), Namespace: r.Instance.Namespace}, kiali); err != nil {
 		if errors.IsNotFound(err) || errors.IsGone(err) {
 			log.Error(nil, fmt.Sprintf("could not patch kiali CR, %s/%s does not exist", r.Instance.Namespace, kialiConfig.ResourceName()))
-			return nil
+			return common.Reconciled()
 		}
-		return err
+		return common.RequeueWithError(err)
 	}
 	log.Info("patching kiali CR", kiali.Kind, kiali.GetName())
 
@@ -61,40 +62,38 @@ func (r *controlPlaneInstanceReconciler) patchKiali(ctx context.Context) error {
 	// grafana
 	grafanaURL, err := r.grafanaURL(ctx, log)
 	if err != nil {
-		return err
+		return common.RequeueWithError(err)
 	} else if grafanaURL == "" {
 		// disable grafana
 		if err := updatedKiali.Spec.SetField("external_services.grafana.enabled", false); err != nil {
-			return fmt.Errorf("could not set external_services.grafana.enabled in kiali CR: %s", err)
+			return common.RequeueWithError(errorOnSettingValueInKialiCR("external_services.grafana.enabled", err))
 		}
 	} else {
 		// enable grafana and set URL
 		// XXX: should we also configure the in_cluster_url
 		if err := updatedKiali.Spec.SetField("external_services.grafana.url", grafanaURL); err != nil {
-			return fmt.Errorf("could not set external_services.grafana.url in kiali CR: %s", err)
+			return common.RequeueWithError(errorOnSettingValueInKialiCR("external_services.grafana.url", err))
 		}
 		if err := updatedKiali.Spec.SetField("external_services.grafana.enabled", true); err != nil {
-			return fmt.Errorf("could not set external_services.grafana.enabled in kiali CR: %s", err)
+			return common.RequeueWithError(errorOnSettingValueInKialiCR("external_services.grafana.enabled", err))
 		}
 	}
 
 	// jaeger
-	jaegerURL, err := r.jaegerURL(ctx, log)
-	if err != nil {
-		return nil
-	} else if jaegerURL == "" {
+	jaegerURL := r.jaegerURL(ctx, log)
+	if jaegerURL == "" {
 		// disable jaeger
 		if err := updatedKiali.Spec.SetField("external_services.tracing.enabled", false); err != nil {
-			return fmt.Errorf("could not set external_services.tracing.enabled in kiali CR: %s", err)
+			return common.RequeueWithError(errorOnSettingValueInKialiCR("external_services.tracing.enabled", err))
 		}
 	} else {
 		// enable jaeger and set URL
 		// XXX: should we also configure the in_cluster_url
 		if err := updatedKiali.Spec.SetField("external_services.tracing.url", jaegerURL); err != nil {
-			return fmt.Errorf("could not set external_services.tracing.url in kiali CR: %s", err)
+			return common.RequeueWithError(errorOnSettingValueInKialiCR("external_services.tracing.url", err))
 		}
 		if err := updatedKiali.Spec.SetField("external_services.tracing.enabled", true); err != nil {
-			return fmt.Errorf("could not set external_services.tracing.enabled in kiali CR: %s", err)
+			return common.RequeueWithError(errorOnSettingValueInKialiCR("external_services.tracing.enabled", err))
 		}
 	}
 
@@ -103,16 +102,16 @@ func (r *controlPlaneInstanceReconciler) patchKiali(ctx context.Context) error {
 	// credentials
 	rawPassword, err := r.getRawHtPasswd(ctx)
 	if err != nil {
-		return fmt.Errorf("could not get htpasswd required for kiali external_serivces: %s", err)
+		return common.RequeueWithError(fmt.Errorf("could not get htpasswd required for kiali external_serivces: %s", err))
 	}
 	if err := updatedKiali.Spec.SetField("external_services.grafana.auth.password", rawPassword); err != nil {
-		return fmt.Errorf("could not set external_services.grafana.auth.password in kiali CR: %s", err)
+		return common.RequeueWithError(errorOnSettingValueInKialiCR("external_services.grafana.auth.password", err))
 	}
 	if err := updatedKiali.Spec.SetField("external_services.prometheus.auth.password", rawPassword); err != nil {
-		return fmt.Errorf("could not set external_services.prometheus.auth.password in kiali CR: %s", err)
+		return common.RequeueWithError(errorOnSettingValueInKialiCR("external_services.prometheus.auth.password", err))
 	}
 	if err := updatedKiali.Spec.SetField("external_services.tracing.auth.password", rawPassword); err != nil {
-		return fmt.Errorf("could not set external_services.tracing.auth.password in kiali CR: %s", err)
+		return common.RequeueWithError(errorOnSettingValueInKialiCR("external_services.tracing.auth.password", err))
 	}
 
 	// FUTURE: add support for synchronizing kiali version with control plane version
@@ -120,12 +119,19 @@ func (r *controlPlaneInstanceReconciler) patchKiali(ctx context.Context) error {
 	if err := r.Client.Patch(ctx, updatedKiali, client.Merge); err != nil {
 		if meta.IsNoMatchError(err) || errors.IsNotFound(err) || errors.IsGone(err) {
 			log.Info(fmt.Sprintf("skipping kiali update, %s/%s is no longer available", kiali.GetNamespace(), kiali.GetName()))
-			return nil
+			return common.Reconciled()
 		}
-		return err
+		return common.RequeueWithError(err)
 	}
 
-	return nil
+	if (grafanaEnabled && grafanaURL == "") || (jaegerEnabled && jaegerURL == "") {
+		log.Info(fmt.Sprintf(
+			"requeue patching Kiali after %s, because %s", patchKialiRequeueInterval,
+			getReconciliationCause(grafanaEnabled, jaegerEnabled, grafanaURL, jaegerURL)))
+		return common.RequeueAfter(patchKialiRequeueInterval)
+	}
+
+	return common.Reconciled()
 }
 
 func (r *controlPlaneInstanceReconciler) grafanaURL(ctx context.Context, log logr.Logger) (string, error) {
@@ -142,12 +148,11 @@ func (r *controlPlaneInstanceReconciler) grafanaURL(ctx context.Context, log log
 	return getURLForRoute(grafanaRoute), nil
 }
 
-func (r *controlPlaneInstanceReconciler) jaegerURL(ctx context.Context, log logr.Logger) (string, error) {
+func (r *controlPlaneInstanceReconciler) jaegerURL(ctx context.Context, log logr.Logger) string {
 	log.Info("attempting to auto-detect Jaeger for Kiali")
-	if r.Instance.Status.AppliedSpec.Addons == nil ||
-		r.Instance.Status.AppliedSpec.Tracing.Type != v2.TracerTypeJaeger {
+	if r.Instance.Status.AppliedSpec.Addons == nil || !r.Instance.Status.AppliedSpec.IsJaegerEnabled() {
 		log.Info("Jaeger is not installed, disabling tracing in Kiali")
-		return "", nil
+		return ""
 	}
 	jaegerName := "jaeger"
 	if r.Instance.Status.AppliedSpec.Addons.Jaeger != nil {
@@ -165,14 +170,14 @@ func (r *controlPlaneInstanceReconciler) jaegerURL(ctx context.Context, log logr
 			log.Error(err, "error retrieving Jaeger route - will disable it in Kiali")
 			// we aren't going to return here - Grafana is optional for Kiali; Kiali can still run without it
 		}
-		return "", nil
+		return ""
 	} else if len(jaegerRoutes.Items) == 0 {
 		// no routes
 		log.Info("could not locate Jaeger query route resource, disabling tracing in Kiali")
-		return "", nil
+		return ""
 	}
 	// we'll just use the first.  there should only ever be one route
-	return getURLForRoute(&jaegerRoutes.Items[0]), nil
+	return getURLForRoute(&jaegerRoutes.Items[0])
 }
 
 func getURLForRoute(route *routev1.Route) string {
@@ -185,4 +190,21 @@ func getURLForRoute(route *routev1.Route) string {
 		routeURL = fmt.Sprintf("%s://%s", routeScheme, routeURL)
 	}
 	return routeURL
+}
+
+func errorOnSettingValueInKialiCR(fieldPath string, err error) error {
+	return fmt.Errorf("could not set %s in kiali CR: %s", fieldPath, err)
+}
+
+func getReconciliationCause(grafanaEnabled, jaegerEnabled bool, grafanaURL, jaegerURL string) string {
+	if grafanaEnabled && grafanaURL == "" && jaegerEnabled && jaegerURL == "" {
+		return "Grafana and Jaeger routes do not exist"
+	}
+	if grafanaEnabled && grafanaURL == "" {
+		return "Grafana route does not exist"
+	}
+	if jaegerEnabled && jaegerURL == "" {
+		return "Jaeger route does not exist"
+	}
+	return ""
 }

--- a/pkg/controller/servicemesh/controlplane/addons_test.go
+++ b/pkg/controller/servicemesh/controlplane/addons_test.go
@@ -1,19 +1,25 @@
 package controlplane
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"testing"
 
 	"go.uber.org/zap/zapcore"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/kubernetes/scheme"
 	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
 	"github.com/maistra/istio-operator/pkg/apis/external"
@@ -21,10 +27,16 @@ import (
 	kialiv1alpha1 "github.com/maistra/istio-operator/pkg/apis/external/kiali/v1alpha1"
 	maistrav1 "github.com/maistra/istio-operator/pkg/apis/maistra/v1"
 	maistrav2 "github.com/maistra/istio-operator/pkg/apis/maistra/v2"
+	"github.com/maistra/istio-operator/pkg/controller/common/cni"
 	. "github.com/maistra/istio-operator/pkg/controller/common/test"
+	"github.com/maistra/istio-operator/pkg/controller/common/test/assert"
 	"github.com/maistra/istio-operator/pkg/controller/versions"
 	routev1 "github.com/openshift/api/route/v1"
 )
+
+var featureEnabled = maistrav2.Enablement{
+	Enabled: ptrTrue,
+}
 
 func TestAddonsInstall(t *testing.T) {
 	const (
@@ -358,4 +370,219 @@ func VerifyKialiUpdate(jaegerName, domain string, values *maistrav1.HelmValues) 
 		return errors.NewAggregate(allErrors)
 	}
 	return nil
+}
+
+func TestPatchAddonsResult(t *testing.T) {
+	requeueWithTimeout := reconcile.Result{RequeueAfter: patchKialiRequeueInterval}
+	kiali := newKiali()
+	htpasswd := newHtpasswd()
+	grafanaRoute := newGrafanaRoute("grafana.istio-system.svc.cluster.local")
+	jaegerRoute := newJaegerRoute("jaeger-query.istio-system.svc.cluster.local")
+
+	testCases := []struct {
+		name                         string
+		kialiEnabled                 bool
+		grafanaEnabled               bool
+		jaegerEnabled                bool
+		objects                      []runtime.Object
+		expectedReconciliationResult reconcile.Result
+	}{
+		{
+			name:                         "reconciliation should succeed when Kiali is disabled",
+			kialiEnabled:                 false,
+			grafanaEnabled:               true,
+			jaegerEnabled:                true,
+			objects:                      []runtime.Object{},
+			expectedReconciliationResult: reconcile.Result{},
+		},
+		{
+			name:           "reconciliation should succeed when jaeger and grafana are enabled and their routes exist",
+			kialiEnabled:   true,
+			grafanaEnabled: true,
+			jaegerEnabled:  true,
+			objects: []runtime.Object{
+				kiali,
+				htpasswd,
+				grafanaRoute,
+				jaegerRoute,
+			},
+			expectedReconciliationResult: reconcile.Result{},
+		},
+		{
+			name:           "reconciliation should succeed when jaeger is disabled and its route does not exist",
+			kialiEnabled:   true,
+			grafanaEnabled: true,
+			jaegerEnabled:  false,
+			objects: []runtime.Object{
+				kiali,
+				htpasswd,
+				grafanaRoute,
+			},
+			expectedReconciliationResult: reconcile.Result{},
+		},
+		{
+			name:           "reconciliation should succeed when grafana is disabled and its route does not exist",
+			kialiEnabled:   true,
+			grafanaEnabled: false,
+			jaegerEnabled:  true,
+			objects: []runtime.Object{
+				kiali,
+				htpasswd,
+				jaegerRoute,
+			},
+			expectedReconciliationResult: reconcile.Result{},
+		},
+		{
+			name:           "should requeue reconciliation with timeout when jaeger and grafana are enabled, but their routes do not exist",
+			kialiEnabled:   true,
+			grafanaEnabled: true,
+			jaegerEnabled:  true,
+			objects: []runtime.Object{
+				kiali,
+				htpasswd,
+			},
+			expectedReconciliationResult: requeueWithTimeout,
+		},
+		{
+			name:           "should requeue reconciliation with timeout when jaeger and grafana are enabled, but jaeger route does not exist",
+			kialiEnabled:   true,
+			grafanaEnabled: true,
+			jaegerEnabled:  true,
+			objects: []runtime.Object{
+				kiali,
+				htpasswd,
+				grafanaRoute,
+			},
+			expectedReconciliationResult: requeueWithTimeout,
+		},
+		{
+			name:           "should requeue reconciliation with timeout when jaeger and grafana are enabled, but grafana route does not exist",
+			kialiEnabled:   true,
+			grafanaEnabled: true,
+			jaegerEnabled:  true,
+			objects: []runtime.Object{
+				kiali,
+				htpasswd,
+				jaegerRoute,
+			},
+			expectedReconciliationResult: requeueWithTimeout,
+		},
+	}
+
+	for _, tc := range testCases {
+		smcpSpec := newSmcpSpec(tc.kialiEnabled, tc.grafanaEnabled, tc.jaegerEnabled)
+		smcp := New21SMCPResource("basic", "istio-system", smcpSpec)
+		smcp.Status = maistrav2.ControlPlaneStatus{AppliedSpec: *smcpSpec}
+
+		s := scheme.Scheme
+		configureKialiAPI(s)
+		configureRouteAPI(s)
+
+		c, _ := CreateClientWithScheme(s, tc.objects...)
+		r := newReconciler(c, s, &record.FakeRecorder{}, "istio-operator", cni.Config{Enabled: true})
+		r.instanceReconcilerFactory = NewControlPlaneInstanceReconciler
+
+		_, smcpReconciler := r.getOrCreateReconciler(smcp)
+		res, err := smcpReconciler.PatchAddons(context.TODO(), &smcp.Spec)
+
+		assert.Nil(err, "unexpected error occurred", t)
+		assert.Equals(res, tc.expectedReconciliationResult, "unexpected reconciliation result", t)
+	}
+}
+
+func newSmcpSpec(kialiEnabled, grafanaEnabled, jaegerEnabled bool) *maistrav2.ControlPlaneSpec {
+	spec := &maistrav2.ControlPlaneSpec{
+		Addons: &maistrav2.AddonsConfig{},
+	}
+
+	if kialiEnabled {
+		spec.Addons.Kiali = &maistrav2.KialiAddonConfig{
+			Enablement: featureEnabled,
+		}
+	}
+	if grafanaEnabled {
+		spec.Addons.Grafana = &maistrav2.GrafanaAddonConfig{
+			Enablement: featureEnabled,
+		}
+	}
+	if jaegerEnabled {
+		spec.Tracing = &maistrav2.TracingConfig{
+			Type: maistrav2.TracerTypeJaeger,
+		}
+	}
+
+	return spec
+}
+
+func newHtpasswd() *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "htpasswd",
+			Namespace: "istio-system",
+		},
+		Data: map[string][]byte{
+			"rawPasswd": []byte("123"),
+		},
+	}
+}
+
+func newKiali() *kialiv1alpha1.Kiali {
+	return &kialiv1alpha1.Kiali{
+		Base: external.Base{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kiali",
+				Namespace: "istio-system",
+			},
+		},
+	}
+}
+
+func newGrafanaRoute(hostname string) *routev1.Route {
+	return &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "grafana",
+			Namespace: "istio-system",
+		},
+		Spec: routev1.RouteSpec{
+			Host: hostname,
+		},
+	}
+}
+
+func newJaegerRoute(hostname string) *routev1.Route {
+	return &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "jaeger",
+			Namespace: "istio-system",
+			Labels: map[string]string{
+				"app.kubernetes.io/instance":  "jaeger",
+				"app.kubernetes.io/component": "query-route",
+			},
+		},
+		Spec: routev1.RouteSpec{
+			Host: hostname,
+		},
+	}
+}
+
+func configureKialiAPI(s *runtime.Scheme) {
+	kialiGroupVersion := schema.GroupVersion{
+		Group:   "kiali.io",
+		Version: "v1alpha1",
+	}
+	s.AddKnownTypes(kialiGroupVersion, &kialiv1alpha1.Kiali{})
+}
+
+func configureRouteAPI(s *runtime.Scheme) {
+	routeGroupVersion := schema.GroupVersion{
+		Group:   "route.openshift.io",
+		Version: "v1",
+	}
+	s.AddKnownTypes(routeGroupVersion, &routev1.Route{}, &routev1.RouteList{})
+}
+
+var routeGVR = schema.GroupVersionResource{
+	Group:    "route.openshift.io",
+	Version:  "v1",
+	Resource: "routes",
 }

--- a/pkg/controller/servicemesh/controlplane/controller_test.go
+++ b/pkg/controller/servicemesh/controlplane/controller_test.go
@@ -160,9 +160,9 @@ func (r *fakeInstanceReconciler) UpdateReadiness(ctx context.Context) error {
 	return nil
 }
 
-func (r *fakeInstanceReconciler) PatchAddons(ctx context.Context) error {
+func (r *fakeInstanceReconciler) PatchAddons(ctx context.Context, _ *maistrav2.ControlPlaneSpec) (reconcile.Result, error) {
 	r.updateReadinessInvoked = true
-	return nil
+	return common.Reconciled()
 }
 
 func (r *fakeInstanceReconciler) Delete(ctx context.Context) error {

--- a/pkg/controller/servicemesh/controlplane/hooks.go
+++ b/pkg/controller/servicemesh/controlplane/hooks.go
@@ -102,10 +102,8 @@ func (r *controlPlaneInstanceReconciler) patchKialiConfig(ctx context.Context, o
 	// if the user has not yet configured this, let's try to auto-detect it now.
 	if len(jaegerURL) == 0 && jaegerEnabled {
 		log.Info("attempting to auto-detect jaeger for kiali")
-		jaegerURL, err = r.jaegerURL(ctx, log)
-		if err != nil {
-			jaegerEnabled = false
-		} else if jaegerURL == "" {
+		jaegerURL = r.jaegerURL(ctx, log)
+		if jaegerURL == "" {
 			jaegerEnabled = false // there is no host on this route - disable it in kiali
 		}
 	}

--- a/pkg/controller/servicemesh/controlplane/reconciler.go
+++ b/pkg/controller/servicemesh/controlplane/reconciler.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -62,6 +63,8 @@ const (
 	eventReasonFailedDeletingResources = "FailedDeletingResources"
 	eventReasonNotReady                = "NotReady"
 	eventReasonReady                   = "Ready"
+
+	patchKialiRequeueInterval = 1 * time.Minute
 )
 
 func NewControlPlaneInstanceReconciler(controllerResources common.ControllerResources, newInstance *v2.ServiceMeshControlPlane, cniConfig cni.Config) ControlPlaneInstanceReconciler {


### PR DESCRIPTION
Signed-off-by: Jacek Ewertowski <jewertow@redhat.com>

#### Background context
Users sometimes encounter that tracing is disabled in Kiali CR when SMCP has configured `Elastic` as storage type for Jaeger.

The cause of this bug is function `PatchAddons` which disables Grafana or Jaeger in Kiali CR if their routes are empty.
It doesn't handle the case where Grafana or Jaeger routes are temporarily unavailable. In such a case tracing will be disabled until the next reconciliation of SMCP. The solution is to requeue reconciliation of SMCP in case of getting empty routes.

#### TODO:
- [x] unit tests
- [x] exponential backoff