### PR TITLE
OSSM-1361: Tell Kiali not to use gRPC when talking to Jaeger

### DIFF
--- a/resources/helm/overlays/istio-telemetry/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/overlays/istio-telemetry/kiali/templates/kiali-cr.yaml
@@ -128,6 +128,7 @@ spec:
       url: "{{ .Values.kiali.dashboard.jaegerURL }}"
 {{- end }}
 {{- end }}
+      use_grpc: false
 
 {{- if .Values.kiali.contextPath }}
   server:

--- a/resources/helm/v2.2/istio-telemetry/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/v2.2/istio-telemetry/kiali/templates/kiali-cr.yaml
@@ -130,6 +130,7 @@ spec:
       url: "{{ .Values.kiali.dashboard.jaegerURL }}"
 {{- end }}
 {{- end }}
+      use_grpc: false
 
 {{- if .Values.kiali.contextPath }}
   server:


### PR DESCRIPTION
The gRPC endpoint does not support OAuth yet.

fixes: https://issues.redhat.com/browse/OSSM-1361

_Note: I used [PR 911](https://github.com/maistra/istio-operator/pull/911) as a template for this PR. I don't know all the intricacies of the Maistra operator - so make sure you review this carefully to ensure I got all the touch-points :-)_