### PR TITLE
OSSM-1437: use the new retention setting; do not use deprecated setting.

### DIFF
--- a/resources/helm/overlays/istio-telemetry/prometheus/templates/deployment.yaml
+++ b/resources/helm/overlays/istio-telemetry/prometheus/templates/deployment.yaml
@@ -99,7 +99,7 @@ spec:
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
 {{- end }}
           args:
-            - '--storage.tsdb.retention={{ .Values.prometheus.retention }}'
+            - '--storage.tsdb.retention.time={{ .Values.prometheus.retention }}'
             - '--storage.tsdb.path=/prometheus'
             - '--config.file=/etc/prometheus/prometheus.yml'
             - --discovery.member-roll-name=default

--- a/resources/helm/v2.2/istio-telemetry/prometheus/templates/deployment.yaml
+++ b/resources/helm/v2.2/istio-telemetry/prometheus/templates/deployment.yaml
@@ -101,7 +101,7 @@ spec:
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
 {{- end }}
           args:
-            - '--storage.tsdb.retention={{ .Values.prometheus.retention }}'
+            - '--storage.tsdb.retention.time={{ .Values.prometheus.retention }}'
             - '--storage.tsdb.path=/prometheus'
             - '--config.file=/etc/prometheus/prometheus.yml'
             - --discovery.member-roll-name=default


### PR DESCRIPTION
See: https://prometheus.io/docs/prometheus/latest/storage/#operational-aspects
fixes: https://issues.redhat.com/browse/OSSM-1437

Using this old deprecated setting broke Kiali. Thus, moving away from the deprecated setting and instead using the new setting has the added bonus of fixing that, too.