### PR TITLE
WIP: backport istio csr backport 2 1

### DIFF
--- a/build/patch-charts.sh
+++ b/build/patch-charts.sh
@@ -513,6 +513,39 @@ function copyGlobalValues() {
   cp ${SOURCE_DIR}/resources/helm/overlays/global.yaml ${SOURCE_DIR}/resources/helm/v2.1/
 }
 
+# This hack is hopefully only needed for a few versions until this PR is merged: https://github.com/istio/istio/pull/37264
+# It essentially modifies the chart to have the exact same changes
+function patchPilotServingCert() {
+  # add extra values
+  sed_wrap -i -e '/traceSampling:/ a\
+  extraArgs: []\
+  extraVolumeMounts: []\
+  extraVolumes: []' ${HELM_DIR}/istio-control/istio-discovery/values.yaml
+
+  # add extra volume in deployments (prepend before end of file)
+  sed_wrap -i -e '/^---$/ i\
+{{- if .Values.pilot.extraVolumes }}\
+{{ toYaml .Values.pilot.extraVolumes | indent 6 }}\
+{{- end }}' ${HELM_DIR}/istio-control/istio-discovery/templates/deployment.yaml
+
+
+
+  # add extra volume mounts (by prepending to volumesMounts: block)
+  sed_wrap -i -e '/volumeMounts:/ a\
+{{- if .Values.pilot.extraVolumeMounts }}\
+{{ toYaml .Values.pilot.extraVolumeMounts | indent 10 }}\
+{{- end }}' ${HELM_DIR}/istio-control/istio-discovery/templates/deployment.yaml
+
+  # Add extraArgs (by appending after discovery argument)
+  sed_wrap -i -e '/- "discovery"/ a\
+{{- if .Values.pilot.extraArgs }}\
+  {{-  range .Values.pilot.extraArgs }}\
+          - {{ . | quote }}\
+  {{- end }}\
+{{- end }}'  ${HELM_DIR}/istio-control/istio-discovery/templates/deployment.yaml
+
+}
+
 function hacks() {
   sed_wrap -i -e '/containers:/,/name: discovery/ {
       /name: discovery/a\
@@ -528,10 +561,8 @@ patchTemplates
 patchGalley
 patchGateways
 patchSidecarInjector
-#patchMixer # no longer present in 2.1
-#patchKialiTemplate # no longer present upstream
-#patchKialiOpenShift
 moveEnvoyFiltersToMeshConfigChart
 copyGlobalValues
+patchPilotServingCert
 # TODO: remove this hack once the image is updated to include workingDir
 hacks

--- a/deploy/src/crd.yaml
+++ b/deploy/src/crd.yaml
@@ -4915,6 +4915,15 @@ spec:
                 properties:
                   certificateAuthority:
                     properties:
+                      cert-manager:
+                        properties:
+                          address:
+                            type: string
+                          pilotSecretName:
+                            type: string
+                          rootCAConfigMapName:
+                            type: string
+                        type: object
                       custom:
                         properties:
                           address:
@@ -9784,6 +9793,15 @@ spec:
                     properties:
                       certificateAuthority:
                         properties:
+                          cert-manager:
+                            properties:
+                              address:
+                                type: string
+                              pilotSecretName:
+                                type: string
+                              rootCAConfigMapName:
+                                type: string
+                            type: object
                           custom:
                             properties:
                               address:

--- a/manifests-maistra/2.1.2/servicemeshcontrolplanes.crd.yaml
+++ b/manifests-maistra/2.1.2/servicemeshcontrolplanes.crd.yaml
@@ -4915,6 +4915,15 @@ spec:
                 properties:
                   certificateAuthority:
                     properties:
+                      cert-manager:
+                        properties:
+                          address:
+                            type: string
+                          pilotSecretName:
+                            type: string
+                          rootCAConfigMapName:
+                            type: string
+                        type: object
                       custom:
                         properties:
                           address:
@@ -9784,6 +9793,15 @@ spec:
                     properties:
                       certificateAuthority:
                         properties:
+                          cert-manager:
+                            properties:
+                              address:
+                                type: string
+                              pilotSecretName:
+                                type: string
+                              rootCAConfigMapName:
+                                type: string
+                            type: object
                           custom:
                             properties:
                               address:

--- a/manifests-servicemesh/2.1.2/servicemeshcontrolplanes.crd.yaml
+++ b/manifests-servicemesh/2.1.2/servicemeshcontrolplanes.crd.yaml
@@ -4915,6 +4915,15 @@ spec:
                 properties:
                   certificateAuthority:
                     properties:
+                      cert-manager:
+                        properties:
+                          address:
+                            type: string
+                          pilotSecretName:
+                            type: string
+                          rootCAConfigMapName:
+                            type: string
+                        type: object
                       custom:
                         properties:
                           address:
@@ -9784,6 +9793,15 @@ spec:
                     properties:
                       certificateAuthority:
                         properties:
+                          cert-manager:
+                            properties:
+                              address:
+                                type: string
+                              pilotSecretName:
+                                type: string
+                              rootCAConfigMapName:
+                                type: string
+                            type: object
                           custom:
                             properties:
                               address:

--- a/pkg/apis/maistra/conversion/common.go
+++ b/pkg/apis/maistra/conversion/common.go
@@ -187,6 +187,15 @@ func setHelmStringSliceValue(obj map[string]interface{}, path string, value []st
 	return setHelmValue(obj, path, rawval)
 }
 
+func setHelmMapSliceValue(obj map[string]interface{}, path string, value []map[string]interface{}) error {
+	vallen := len(value)
+	rawval := make([]interface{}, vallen)
+	for index, val := range value {
+		rawval[index] = val
+	}
+	return setHelmValue(obj, path, rawval)
+}
+
 func setHelmStringMapValue(obj map[string]interface{}, path string, value map[string]string) error {
 	rawValue, err := toValues(value)
 	if err != nil {

--- a/pkg/apis/maistra/conversion/security_test.go
+++ b/pkg/apis/maistra/conversion/security_test.go
@@ -1198,6 +1198,122 @@ func securityTestCasesV2(version versions.Version) []conversionTestCase {
 			}),
 		},
 		{
+			name: "ca.cert-manager.basic" + ver,
+			spec: &v2.ControlPlaneSpec{
+				Version: ver,
+				Security: &v2.SecurityConfig{
+					CertificateAuthority: &v2.CertificateAuthorityConfig{
+						Type: v2.CertificateAuthorityTypeCertManager,
+						CertManager: &v2.CertManagerCertificateAuthorityConfig{
+							Address: "my-istio-csr.namespace.svc.cluster.local",
+							PilotCertSecretName: "istiod-tls",
+						},
+					},
+				},
+			},
+			isolatedIstio: v1.NewHelmValues(map[string]interface{}{
+				"global": map[string]interface{}{
+					"caAddress": "my-istio-csr.namespace.svc.cluster.local",
+				},
+				"pilot": map[string]interface{}{
+					"ca":map[string]interface {}{"implementation":"cert-manager"},
+					"extraArgs": []string{
+						"--tlsCertFile=/etc/cert-manager/tls/tls.crt",
+						"--tlsKeyFile=/etc/cert-manager/tls/tls.key",
+						"--caCertFile=/etc/cert-manager/tls/ca.crt",
+					},
+					"extraVolumeMounts": []interface{}{map[string]interface{}{
+							"name":      "cert-manager",
+							"mountPath": "/etc/cert-manager/tls",
+							"readyOnly": "true",
+					}},
+					"extraVolumes":[]interface{}{map[string]interface{}{
+							"name": "cert-manager",
+							"secret": map[string]interface{}{
+								"secretName": "istiod-tls",
+							},
+					}},
+				},
+			}),
+			completeIstio: v1.NewHelmValues(map[string]interface{}{
+				"global": map[string]interface{}{
+					"multiCluster":  globalMultiClusterDefaults,
+					"meshExpansion": globalMeshExpansionDefaults,
+				},
+				"pilot": map[string]interface{}{
+					"env": map[string]interface{}{
+							"ENABLE_CA_SERVER": string("false"),
+						},
+				},
+			}),
+		},
+		{
+			name: "ca.cert-manager.casuppiled" + ver,
+			spec: &v2.ControlPlaneSpec{
+				Version: ver,
+				Security: &v2.SecurityConfig{
+					CertificateAuthority: &v2.CertificateAuthorityConfig{
+						Type: v2.CertificateAuthorityTypeCertManager,
+						CertManager: &v2.CertManagerCertificateAuthorityConfig{
+							Address: "my-istio-csr.namespace.svc.cluster.local",
+							PilotCertSecretName: "istiod-tls",
+							RootCAConfigMapName: "istio-ca-root-cert",
+						},
+					},
+				},
+			},
+			isolatedIstio: v1.NewHelmValues(map[string]interface{}{
+				"global": map[string]interface{}{
+					"caAddress": "my-istio-csr.namespace.svc.cluster.local",
+				},
+				"pilot": map[string]interface{}{
+					"ca":map[string]interface {}{"implementation":"cert-manager"},
+					"extraArgs": []string{
+						"--tlsCertFile=/etc/cert-manager/tls/tls.crt",
+						"--tlsKeyFile=/etc/cert-manager/tls/tls.key",
+						"--caCertFile=/etc/cert-manager/ca/root-cert.pem",
+					},
+					"extraVolumeMounts": []interface{}{
+						map[string]interface{}{
+							"name":      "cert-manager",
+							"mountPath": "/etc/cert-manager/tls",
+							"readyOnly": "true",
+						},
+						map[string]interface{}{
+								"name":      "ca-root-cert",
+								"mountPath": "/etc/cert-manager/ca",
+								"readyOnly": "true",
+						},
+					},
+					"extraVolumes":[]interface{}{
+						map[string]interface{}{
+							"name": "cert-manager",
+							"secret": map[string]interface{}{
+								"secretName": "istiod-tls",
+							},
+						},
+						map[string]interface{}{
+							"name": "ca-root-cert",
+							"configMap": map[string]interface{}{
+								"name": "istio-ca-root-cert",
+							},
+						},
+					},
+				},
+			}),
+			completeIstio: v1.NewHelmValues(map[string]interface{}{
+				"global": map[string]interface{}{
+					"multiCluster":  globalMultiClusterDefaults,
+					"meshExpansion": globalMeshExpansionDefaults,
+				},
+				"pilot": map[string]interface{}{
+					"env": map[string]interface{}{
+							"ENABLE_CA_SERVER": string("false"),
+						},
+				},
+			}),
+		},
+		{
 			name: "identity.kubernetes." + ver,
 			spec: &v2.ControlPlaneSpec{
 				Version: ver,

--- a/pkg/apis/maistra/v2/security.go
+++ b/pkg/apis/maistra/v2/security.go
@@ -55,7 +55,8 @@ type CertificateAuthorityConfig struct {
 	Istiod *IstiodCertificateAuthorityConfig `json:"istiod,omitempty"`
 	// Custom is the configuration for a custom certificate authority.
 	// +optional
-	Custom *CustomCertificateAuthorityConfig `json:"custom,omitempty"`
+	Custom      *CustomCertificateAuthorityConfig      `json:"custom,omitempty"`
+	CertManager *CertManagerCertificateAuthorityConfig `json:"cert-manager,omitempty"`
 }
 
 // CertificateAuthorityType represents the type of CertificateAuthority implementation.
@@ -66,6 +67,8 @@ const (
 	CertificateAuthorityTypeIstiod CertificateAuthorityType = "Istiod"
 	// CertificateAuthorityTypeCustom represents a custom certificate authority implementation
 	CertificateAuthorityTypeCustom CertificateAuthorityType = "Custom"
+	// CertificateAuthorityTypeCertManager represents a cert-manager istio-csr certificate authority implementation
+	CertificateAuthorityTypeCertManager CertificateAuthorityType = "cert-manager"
 )
 
 // IstiodCertificateAuthorityConfig is the configuration for Istio's internal
@@ -166,6 +169,14 @@ type CustomCertificateAuthorityConfig struct {
 	// .Values.global.caAddress
 	// XXX: assumption is this is a grpc endpoint that provides methods like istio.v1.auth.IstioCertificateService/CreateCertificate
 	Address string `json:"address,omitempty"`
+}
+
+type CertManagerCertificateAuthorityConfig struct {
+	// Address is the grpc address for an Istio compatible certificate authority endpoint.
+	// .Values.global.caAddress
+	Address             string `json:"address,omitempty"`
+	PilotCertSecretName string `json:"pilotSecretName,omitempty"`
+	RootCAConfigMapName string `json:"rootCAConfigMapName,omitempty"`
 }
 
 // IdentityConfig configures the types of user tokens used by clients


### PR DESCRIPTION
As mentioned by Jamie and Rob in #890, the release process requires us to backport new improvements such as the new cert-manager CA implementation to the last version of Maistra.
I was not aware of this until a few weeks back, it would be good to see the documentation on this, especially if it might have something to do with the TechnologyPreview field or something like that?
please clarify about that @rcernich 

This implementation was already tested for 2.1 before the 2.2 release, we've simply backported our code and tests, we will conduct a further e2e hence the WIP mark on PR.