### PR TITLE
OSSM-1148 Synchronise CSV template with what we have in dist-git

### DIFF
--- a/build/generate-manifests.sh
+++ b/build/generate-manifests.sh
@@ -89,13 +89,17 @@ function generateCSV() {
     exit 1
   fi
 
-  RELATED_IMAGES=$(${YQ} eval 'select(.kind=="Deployment" and .metadata.name=="istio-operator") | .spec.template.metadata.annotations' ${DEPLOYMENT_FILE} | \
-    sed -n 's/olm\.relatedImage\.\([^:]*\): *\([^ ]*\)/- name: \1\
+  if [ "${BUILD_TYPE}" == "maistra" ]; then
+    RELATED_IMAGES=$(${YQ} eval 'select(.kind=="Deployment" and .metadata.name=="istio-operator") | .spec.template.metadata.annotations' ${DEPLOYMENT_FILE} | \
+      sed -n 's/olm\.relatedImage\.\([^:]*\): *\([^ ]*\)/- name: \1\
   image: \2/p' | \
-    sed 's/^/  /')
-  if [ "$RELATED_IMAGES" == "" ]; then
-     echo "generateCSV(): Operator deployment contains no olm.relatedImage annotations, please verify source yaml/path to the field."
-     exit 1
+      sed 's/^/  /')
+    if [ "$RELATED_IMAGES" == "" ]; then
+      echo "generateCSV(): Operator deployment contains no olm.relatedImage annotations, please verify source yaml/path to the field."
+      exit 1
+    fi
+    RELATED_IMAGES="  relatedImages:
+$RELATED_IMAGES"
   fi
 
   ICON=$(cat ${MY_LOCATION}/manifest-templates/${BUILD_TYPE}_rgb_icon_default_128px.png | base64 | sed -e 's+^+      +')

--- a/build/manifest-templates/clusterserviceversion.yaml
+++ b/build/manifest-templates/clusterserviceversion.yaml
@@ -175,7 +175,6 @@ __REPLACES_CSV__
     supported: false
   - type: AllNamespaces
     supported: true
-  relatedImages:
 __RELATED_IMAGES__
   install:
     strategy: deployment

--- a/deploy/servicemesh-operator.yaml
+++ b/deploy/servicemesh-operator.yaml
@@ -10643,56 +10643,57 @@ spec:
       labels:
         name: istio-operator
       annotations:
-        olm.relatedImage.v1_0.3scale-istio-adapter: registry.redhat.io/openshift-service-mesh/3scale-istio-adapter-rhel8:1.0.0
-        olm.relatedImage.v1_0.citadel: registry.redhat.io/openshift-service-mesh/citadel-rhel8:1.0.11
-        olm.relatedImage.v1_0.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel8:1.0.11
-        olm.relatedImage.v1_0.galley: registry.redhat.io/openshift-service-mesh/galley-rhel8:1.0.11
-        olm.relatedImage.v1_0.grafana: registry.redhat.io/openshift-service-mesh/grafana-rhel8:1.0.11
-        olm.relatedImage.v1_0.mixer: registry.redhat.io/openshift-service-mesh/mixer-rhel8:1.0.11
-        olm.relatedImage.v1_0.pilot: registry.redhat.io/openshift-service-mesh/pilot-rhel8:1.0.11
-        olm.relatedImage.v1_0.prometheus: registry.redhat.io/openshift-service-mesh/prometheus-rhel8:1.0.11
-        olm.relatedImage.v1_0.proxy-init: registry.redhat.io/openshift-service-mesh/proxy-init-rhel7:1.0.11
-        olm.relatedImage.v1_0.proxyv2: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:1.0.11
-        olm.relatedImage.v1_0.sidecar-injector: registry.redhat.io/openshift-service-mesh/sidecar-injector-rhel8:1.0.11
-
-        olm.relatedImage.v1_1.3scale-istio-adapter: registry.redhat.io/openshift-service-mesh/3scale-istio-adapter-rhel8:1.0.0
-        olm.relatedImage.v1_1.citadel: registry.redhat.io/openshift-service-mesh/citadel-rhel8:1.1.18
-        olm.relatedImage.v1_1.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel8:1.1.18
-        olm.relatedImage.v1_1.galley: registry.redhat.io/openshift-service-mesh/galley-rhel8:1.1.18
-        olm.relatedImage.v1_1.grafana: registry.redhat.io/openshift-service-mesh/grafana-rhel8:1.1.18
-        olm.relatedImage.v1_1.ior: registry.redhat.io/openshift-service-mesh/ior-rhel8:1.1.18
-        olm.relatedImage.v1_1.mixer: registry.redhat.io/openshift-service-mesh/mixer-rhel8:1.1.18
-        olm.relatedImage.v1_1.pilot: registry.redhat.io/openshift-service-mesh/pilot-rhel8:1.1.18
-        olm.relatedImage.v1_1.prometheus: registry.redhat.io/openshift-service-mesh/prometheus-rhel8:1.1.18
-        olm.relatedImage.v1_1.proxy-init: registry.redhat.io/openshift-service-mesh/proxy-init-rhel7:1.1.18
-        olm.relatedImage.v1_1.proxyv2: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:1.1.18
-        olm.relatedImage.v1_1.sidecar-injector: registry.redhat.io/openshift-service-mesh/sidecar-injector-rhel8:1.1.18
-
-        olm.relatedImage.v2_0.3scale-istio-adapter: registry.redhat.io/openshift-service-mesh/3scale-istio-adapter-rhel8:2.0.0
-        olm.relatedImage.v2_0.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel8:2.0.10
-        olm.relatedImage.v2_0.grafana: registry.redhat.io/openshift-service-mesh/grafana-rhel8:2.0.10
-        olm.relatedImage.v2_0.mixer: registry.redhat.io/openshift-service-mesh/mixer-rhel8:2.0.10
-        olm.relatedImage.v2_0.pilot: registry.redhat.io/openshift-service-mesh/pilot-rhel8:2.0.10
-        olm.relatedImage.v2_0.prometheus: registry.redhat.io/openshift-service-mesh/prometheus-rhel8:2.0.10
-        olm.relatedImage.v2_0.proxy-init: registry.redhat.io/openshift-service-mesh/proxy-init-rhel7:2.0.10
-        olm.relatedImage.v2_0.proxyv2: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.0.10
-        olm.relatedImage.v2_0.wasm-cacher: registry.redhat.io/openshift-service-mesh/pilot-rhel8:2.0.10
-
-        olm.relatedImage.v2_1.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel8:2.1.3
-        olm.relatedImage.v2_1.grafana: registry.redhat.io/openshift-service-mesh/grafana-rhel8:2.1.3
-        olm.relatedImage.v2_1.pilot: registry.redhat.io/openshift-service-mesh/pilot-rhel8:2.1.3
-        olm.relatedImage.v2_1.prometheus: registry.redhat.io/openshift-service-mesh/prometheus-rhel8:2.1.3
-        olm.relatedImage.v2_1.proxyv2: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.1.3
-        olm.relatedImage.v2_1.wasm-cacher: registry.redhat.io/openshift-service-mesh/pilot-rhel8:2.1.3
-        olm.relatedImage.v2_1.rls: registry.redhat.io/openshift-service-mesh/ratelimit-rhel8:2.1.3
-
-        olm.relatedImage.v2_2.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel8:2.2.0
-        olm.relatedImage.v2_2.grafana: registry.redhat.io/openshift-service-mesh/grafana-rhel8:2.2.0
-        olm.relatedImage.v2_2.pilot: registry.redhat.io/openshift-service-mesh/pilot-rhel8:2.2.0
-        olm.relatedImage.v2_2.prometheus: registry.redhat.io/openshift-service-mesh/prometheus-rhel8:2.2.0
-        olm.relatedImage.v2_2.proxyv2: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.2.0
-        olm.relatedImage.v2_2.wasm-cacher: registry.redhat.io/openshift-service-mesh/pilot-rhel8:2.2.0
-        olm.relatedImage.v2_2.rls: registry.redhat.io/openshift-service-mesh/ratelimit-rhel8:2.2.0
+        # 1.0 images
+        olm.relatedImage.v1_0.3scale-istio-adapter: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-3scale-istio-adapter-rhel8:1.0.0
+        olm.relatedImage.v1_0.citadel: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-citadel-rhel8:${OSSM_10}
+        olm.relatedImage.v1_0.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_10}
+        olm.relatedImage.v1_0.galley: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-galley-rhel8:${OSSM_10}
+        olm.relatedImage.v1_0.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_10}
+        olm.relatedImage.v1_0.mixer: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-mixer-rhel8:${OSSM_10}
+        olm.relatedImage.v1_0.pilot: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_10}
+        olm.relatedImage.v1_0.prometheus: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-prometheus-rhel8:${OSSM_10}
+        olm.relatedImage.v1_0.proxy-init: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxy-init-rhel7:${OSSM_10}
+        olm.relatedImage.v1_0.proxyv2: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxyv2-rhel8:${OSSM_10}
+        olm.relatedImage.v1_0.sidecar-injector: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-sidecar-injector-rhel8:${OSSM_10}
+        # 1.1 images
+        olm.relatedImage.v1_1.3scale-istio-adapter: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-3scale-istio-adapter-rhel8:1.0.0
+        olm.relatedImage.v1_1.citadel: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-citadel-rhel8:${OSSM_11}
+        olm.relatedImage.v1_1.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_11}
+        olm.relatedImage.v1_1.galley: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-galley-rhel8:${OSSM_11}
+        olm.relatedImage.v1_1.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_11}
+        olm.relatedImage.v1_1.ior: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-ior-rhel8:${OSSM_11}
+        olm.relatedImage.v1_1.mixer: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-mixer-rhel8:${OSSM_11}
+        olm.relatedImage.v1_1.pilot: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_11}
+        olm.relatedImage.v1_1.prometheus: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-prometheus-rhel8:${OSSM_11}
+        olm.relatedImage.v1_1.proxy-init: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxy-init-rhel7:${OSSM_11}
+        olm.relatedImage.v1_1.proxyv2: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxyv2-rhel8:${OSSM_11}
+        olm.relatedImage.v1_1.sidecar-injector: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-sidecar-injector-rhel8:${OSSM_11}
+        # 2.0 images
+        olm.relatedImage.v2_0.3scale-istio-adapter: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-3scale-istio-adapter-rhel8:1.0.0
+        olm.relatedImage.v2_0.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_20}
+        olm.relatedImage.v2_0.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_20}
+        olm.relatedImage.v2_0.mixer: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-mixer-rhel8:${OSSM_20}
+        olm.relatedImage.v2_0.pilot: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_20}
+        olm.relatedImage.v2_0.prometheus: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-prometheus-rhel8:${OSSM_20}
+        olm.relatedImage.v2_0.proxy-init: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxy-init-rhel7:${OSSM_20}
+        olm.relatedImage.v2_0.proxyv2: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxyv2-rhel8:${OSSM_20}
+        olm.relatedImage.v2_0.wasm-cacher: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_20}
+        # 2.1 images
+        olm.relatedImage.v2_1.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_21}
+        olm.relatedImage.v2_1.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_21}
+        olm.relatedImage.v2_1.pilot: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_21}
+        olm.relatedImage.v2_1.prometheus: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-prometheus-rhel8:${OSSM_21}
+        olm.relatedImage.v2_1.proxyv2: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxyv2-rhel8:${OSSM_21}
+        olm.relatedImage.v2_1.wasm-cacher: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_21}
+        olm.relatedImage.v2_1.rls: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-ratelimit-rhel8:${OSSM_21}
+        # 2.2 images
+        olm.relatedImage.v2_2.cni: ${OSSM_CNI_IMAGE}
+        olm.relatedImage.v2_2.grafana: ${OSSM_GRAFANA_IMAGE}
+        olm.relatedImage.v2_2.pilot: ${OSSM_PILOT_IMAGE}
+        olm.relatedImage.v2_2.prometheus: ${OSSM_PROMETHEUS_IMAGE}
+        olm.relatedImage.v2_2.proxyv2: ${OSSM_PROXY_IMAGE}
+        olm.relatedImage.v2_2.wasm-cacher: ${OSSM_PILOT_IMAGE}
+        olm.relatedImage.v2_2.rls: ${OSSM_RATELIMIT_IMAGE}
 
         oauth-proxy.query: "true"
         oauth-proxy.namespace: openshift
@@ -10702,7 +10703,7 @@ spec:
       serviceAccountName: istio-operator
       containers:
       - name: istio-operator
-        image: registry.redhat.io/openshift-service-mesh/istio-rhel8-operator:2.2.0
+        image: ${OSSM_OPERATOR_IMAGE}
         ports:
         - containerPort: 11999
           name: validation

--- a/deploy/src/deployment-servicemesh.yaml
+++ b/deploy/src/deployment-servicemesh.yaml
@@ -13,56 +13,57 @@ spec:
       labels:
         name: istio-operator
       annotations:
-        olm.relatedImage.v1_0.3scale-istio-adapter: registry.redhat.io/openshift-service-mesh/3scale-istio-adapter-rhel8:1.0.0
-        olm.relatedImage.v1_0.citadel: registry.redhat.io/openshift-service-mesh/citadel-rhel8:1.0.11
-        olm.relatedImage.v1_0.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel8:1.0.11
-        olm.relatedImage.v1_0.galley: registry.redhat.io/openshift-service-mesh/galley-rhel8:1.0.11
-        olm.relatedImage.v1_0.grafana: registry.redhat.io/openshift-service-mesh/grafana-rhel8:1.0.11
-        olm.relatedImage.v1_0.mixer: registry.redhat.io/openshift-service-mesh/mixer-rhel8:1.0.11
-        olm.relatedImage.v1_0.pilot: registry.redhat.io/openshift-service-mesh/pilot-rhel8:1.0.11
-        olm.relatedImage.v1_0.prometheus: registry.redhat.io/openshift-service-mesh/prometheus-rhel8:1.0.11
-        olm.relatedImage.v1_0.proxy-init: registry.redhat.io/openshift-service-mesh/proxy-init-rhel7:1.0.11
-        olm.relatedImage.v1_0.proxyv2: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:1.0.11
-        olm.relatedImage.v1_0.sidecar-injector: registry.redhat.io/openshift-service-mesh/sidecar-injector-rhel8:1.0.11
-
-        olm.relatedImage.v1_1.3scale-istio-adapter: registry.redhat.io/openshift-service-mesh/3scale-istio-adapter-rhel8:1.0.0
-        olm.relatedImage.v1_1.citadel: registry.redhat.io/openshift-service-mesh/citadel-rhel8:1.1.18
-        olm.relatedImage.v1_1.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel8:1.1.18
-        olm.relatedImage.v1_1.galley: registry.redhat.io/openshift-service-mesh/galley-rhel8:1.1.18
-        olm.relatedImage.v1_1.grafana: registry.redhat.io/openshift-service-mesh/grafana-rhel8:1.1.18
-        olm.relatedImage.v1_1.ior: registry.redhat.io/openshift-service-mesh/ior-rhel8:1.1.18
-        olm.relatedImage.v1_1.mixer: registry.redhat.io/openshift-service-mesh/mixer-rhel8:1.1.18
-        olm.relatedImage.v1_1.pilot: registry.redhat.io/openshift-service-mesh/pilot-rhel8:1.1.18
-        olm.relatedImage.v1_1.prometheus: registry.redhat.io/openshift-service-mesh/prometheus-rhel8:1.1.18
-        olm.relatedImage.v1_1.proxy-init: registry.redhat.io/openshift-service-mesh/proxy-init-rhel7:1.1.18
-        olm.relatedImage.v1_1.proxyv2: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:1.1.18
-        olm.relatedImage.v1_1.sidecar-injector: registry.redhat.io/openshift-service-mesh/sidecar-injector-rhel8:1.1.18
-
-        olm.relatedImage.v2_0.3scale-istio-adapter: registry.redhat.io/openshift-service-mesh/3scale-istio-adapter-rhel8:2.0.0
-        olm.relatedImage.v2_0.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel8:2.0.10
-        olm.relatedImage.v2_0.grafana: registry.redhat.io/openshift-service-mesh/grafana-rhel8:2.0.10
-        olm.relatedImage.v2_0.mixer: registry.redhat.io/openshift-service-mesh/mixer-rhel8:2.0.10
-        olm.relatedImage.v2_0.pilot: registry.redhat.io/openshift-service-mesh/pilot-rhel8:2.0.10
-        olm.relatedImage.v2_0.prometheus: registry.redhat.io/openshift-service-mesh/prometheus-rhel8:2.0.10
-        olm.relatedImage.v2_0.proxy-init: registry.redhat.io/openshift-service-mesh/proxy-init-rhel7:2.0.10
-        olm.relatedImage.v2_0.proxyv2: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.0.10
-        olm.relatedImage.v2_0.wasm-cacher: registry.redhat.io/openshift-service-mesh/pilot-rhel8:2.0.10
-
-        olm.relatedImage.v2_1.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel8:2.1.3
-        olm.relatedImage.v2_1.grafana: registry.redhat.io/openshift-service-mesh/grafana-rhel8:2.1.3
-        olm.relatedImage.v2_1.pilot: registry.redhat.io/openshift-service-mesh/pilot-rhel8:2.1.3
-        olm.relatedImage.v2_1.prometheus: registry.redhat.io/openshift-service-mesh/prometheus-rhel8:2.1.3
-        olm.relatedImage.v2_1.proxyv2: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.1.3
-        olm.relatedImage.v2_1.wasm-cacher: registry.redhat.io/openshift-service-mesh/pilot-rhel8:2.1.3
-        olm.relatedImage.v2_1.rls: registry.redhat.io/openshift-service-mesh/ratelimit-rhel8:2.1.3
-
-        olm.relatedImage.v2_2.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel8:2.2.0
-        olm.relatedImage.v2_2.grafana: registry.redhat.io/openshift-service-mesh/grafana-rhel8:2.2.0
-        olm.relatedImage.v2_2.pilot: registry.redhat.io/openshift-service-mesh/pilot-rhel8:2.2.0
-        olm.relatedImage.v2_2.prometheus: registry.redhat.io/openshift-service-mesh/prometheus-rhel8:2.2.0
-        olm.relatedImage.v2_2.proxyv2: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.2.0
-        olm.relatedImage.v2_2.wasm-cacher: registry.redhat.io/openshift-service-mesh/pilot-rhel8:2.2.0
-        olm.relatedImage.v2_2.rls: registry.redhat.io/openshift-service-mesh/ratelimit-rhel8:2.2.0
+        # 1.0 images
+        olm.relatedImage.v1_0.3scale-istio-adapter: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-3scale-istio-adapter-rhel8:1.0.0
+        olm.relatedImage.v1_0.citadel: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-citadel-rhel8:${OSSM_10}
+        olm.relatedImage.v1_0.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_10}
+        olm.relatedImage.v1_0.galley: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-galley-rhel8:${OSSM_10}
+        olm.relatedImage.v1_0.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_10}
+        olm.relatedImage.v1_0.mixer: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-mixer-rhel8:${OSSM_10}
+        olm.relatedImage.v1_0.pilot: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_10}
+        olm.relatedImage.v1_0.prometheus: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-prometheus-rhel8:${OSSM_10}
+        olm.relatedImage.v1_0.proxy-init: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxy-init-rhel7:${OSSM_10}
+        olm.relatedImage.v1_0.proxyv2: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxyv2-rhel8:${OSSM_10}
+        olm.relatedImage.v1_0.sidecar-injector: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-sidecar-injector-rhel8:${OSSM_10}
+        # 1.1 images
+        olm.relatedImage.v1_1.3scale-istio-adapter: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-3scale-istio-adapter-rhel8:1.0.0
+        olm.relatedImage.v1_1.citadel: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-citadel-rhel8:${OSSM_11}
+        olm.relatedImage.v1_1.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_11}
+        olm.relatedImage.v1_1.galley: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-galley-rhel8:${OSSM_11}
+        olm.relatedImage.v1_1.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_11}
+        olm.relatedImage.v1_1.ior: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-ior-rhel8:${OSSM_11}
+        olm.relatedImage.v1_1.mixer: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-mixer-rhel8:${OSSM_11}
+        olm.relatedImage.v1_1.pilot: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_11}
+        olm.relatedImage.v1_1.prometheus: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-prometheus-rhel8:${OSSM_11}
+        olm.relatedImage.v1_1.proxy-init: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxy-init-rhel7:${OSSM_11}
+        olm.relatedImage.v1_1.proxyv2: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxyv2-rhel8:${OSSM_11}
+        olm.relatedImage.v1_1.sidecar-injector: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-sidecar-injector-rhel8:${OSSM_11}
+        # 2.0 images
+        olm.relatedImage.v2_0.3scale-istio-adapter: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-3scale-istio-adapter-rhel8:1.0.0
+        olm.relatedImage.v2_0.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_20}
+        olm.relatedImage.v2_0.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_20}
+        olm.relatedImage.v2_0.mixer: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-mixer-rhel8:${OSSM_20}
+        olm.relatedImage.v2_0.pilot: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_20}
+        olm.relatedImage.v2_0.prometheus: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-prometheus-rhel8:${OSSM_20}
+        olm.relatedImage.v2_0.proxy-init: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxy-init-rhel7:${OSSM_20}
+        olm.relatedImage.v2_0.proxyv2: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxyv2-rhel8:${OSSM_20}
+        olm.relatedImage.v2_0.wasm-cacher: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_20}
+        # 2.1 images
+        olm.relatedImage.v2_1.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_21}
+        olm.relatedImage.v2_1.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_21}
+        olm.relatedImage.v2_1.pilot: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_21}
+        olm.relatedImage.v2_1.prometheus: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-prometheus-rhel8:${OSSM_21}
+        olm.relatedImage.v2_1.proxyv2: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxyv2-rhel8:${OSSM_21}
+        olm.relatedImage.v2_1.wasm-cacher: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_21}
+        olm.relatedImage.v2_1.rls: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-ratelimit-rhel8:${OSSM_21}
+        # 2.2 images
+        olm.relatedImage.v2_2.cni: ${OSSM_CNI_IMAGE}
+        olm.relatedImage.v2_2.grafana: ${OSSM_GRAFANA_IMAGE}
+        olm.relatedImage.v2_2.pilot: ${OSSM_PILOT_IMAGE}
+        olm.relatedImage.v2_2.prometheus: ${OSSM_PROMETHEUS_IMAGE}
+        olm.relatedImage.v2_2.proxyv2: ${OSSM_PROXY_IMAGE}
+        olm.relatedImage.v2_2.wasm-cacher: ${OSSM_PILOT_IMAGE}
+        olm.relatedImage.v2_2.rls: ${OSSM_RATELIMIT_IMAGE}
 
         oauth-proxy.query: "true"
         oauth-proxy.namespace: openshift
@@ -72,7 +73,7 @@ spec:
       serviceAccountName: istio-operator
       containers:
       - name: istio-operator
-        image: registry.redhat.io/openshift-service-mesh/istio-rhel8-operator:2.2.0
+        image: ${OSSM_OPERATOR_IMAGE}
         ports:
         - containerPort: 11999
           name: validation

--- a/manifests-servicemesh/2.2.0/servicemeshoperator.v2.2.0.clusterserviceversion.yaml
+++ b/manifests-servicemesh/2.2.0/servicemeshoperator.v2.2.0.clusterserviceversion.yaml
@@ -16,8 +16,8 @@ metadata:
     description: |-
       The OpenShift Service Mesh Operator enables you to install, configure, and manage an instance of Red Hat OpenShift Service Mesh. OpenShift Service Mesh is based on the open source Istio project.
 
-    containerImage: registry.redhat.io/openshift-service-mesh/istio-rhel8-operator:2.2.0
-    createdAt: 2022-06-13T08:16:28MDT
+    containerImage: ${OSSM_OPERATOR_IMAGE}
+    createdAt: 2022-06-20T18:00:22CEST
     support: Red Hat, Inc. 
     olm.skipRange: ">=1.0.2 <2.2.0-0"
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
@@ -258,99 +258,7 @@ spec:
     supported: false
   - type: AllNamespaces
     supported: true
-  relatedImages:
-  - name: v1_0.3scale-istio-adapter
-    image: registry.redhat.io/openshift-service-mesh/3scale-istio-adapter-rhel8:1.0.0
-  - name: v1_0.citadel
-    image: registry.redhat.io/openshift-service-mesh/citadel-rhel8:1.0.11
-  - name: v1_0.cni
-    image: registry.redhat.io/openshift-service-mesh/istio-cni-rhel8:1.0.11
-  - name: v1_0.galley
-    image: registry.redhat.io/openshift-service-mesh/galley-rhel8:1.0.11
-  - name: v1_0.grafana
-    image: registry.redhat.io/openshift-service-mesh/grafana-rhel8:1.0.11
-  - name: v1_0.mixer
-    image: registry.redhat.io/openshift-service-mesh/mixer-rhel8:1.0.11
-  - name: v1_0.pilot
-    image: registry.redhat.io/openshift-service-mesh/pilot-rhel8:1.0.11
-  - name: v1_0.prometheus
-    image: registry.redhat.io/openshift-service-mesh/prometheus-rhel8:1.0.11
-  - name: v1_0.proxy-init
-    image: registry.redhat.io/openshift-service-mesh/proxy-init-rhel7:1.0.11
-  - name: v1_0.proxyv2
-    image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:1.0.11
-  - name: v1_0.sidecar-injector
-    image: registry.redhat.io/openshift-service-mesh/sidecar-injector-rhel8:1.0.11
-  - name: v1_1.3scale-istio-adapter
-    image: registry.redhat.io/openshift-service-mesh/3scale-istio-adapter-rhel8:1.0.0
-  - name: v1_1.citadel
-    image: registry.redhat.io/openshift-service-mesh/citadel-rhel8:1.1.18
-  - name: v1_1.cni
-    image: registry.redhat.io/openshift-service-mesh/istio-cni-rhel8:1.1.18
-  - name: v1_1.galley
-    image: registry.redhat.io/openshift-service-mesh/galley-rhel8:1.1.18
-  - name: v1_1.grafana
-    image: registry.redhat.io/openshift-service-mesh/grafana-rhel8:1.1.18
-  - name: v1_1.ior
-    image: registry.redhat.io/openshift-service-mesh/ior-rhel8:1.1.18
-  - name: v1_1.mixer
-    image: registry.redhat.io/openshift-service-mesh/mixer-rhel8:1.1.18
-  - name: v1_1.pilot
-    image: registry.redhat.io/openshift-service-mesh/pilot-rhel8:1.1.18
-  - name: v1_1.prometheus
-    image: registry.redhat.io/openshift-service-mesh/prometheus-rhel8:1.1.18
-  - name: v1_1.proxy-init
-    image: registry.redhat.io/openshift-service-mesh/proxy-init-rhel7:1.1.18
-  - name: v1_1.proxyv2
-    image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:1.1.18
-  - name: v1_1.sidecar-injector
-    image: registry.redhat.io/openshift-service-mesh/sidecar-injector-rhel8:1.1.18
-  - name: v2_0.3scale-istio-adapter
-    image: registry.redhat.io/openshift-service-mesh/3scale-istio-adapter-rhel8:2.0.0
-  - name: v2_0.cni
-    image: registry.redhat.io/openshift-service-mesh/istio-cni-rhel8:2.0.10
-  - name: v2_0.grafana
-    image: registry.redhat.io/openshift-service-mesh/grafana-rhel8:2.0.10
-  - name: v2_0.mixer
-    image: registry.redhat.io/openshift-service-mesh/mixer-rhel8:2.0.10
-  - name: v2_0.pilot
-    image: registry.redhat.io/openshift-service-mesh/pilot-rhel8:2.0.10
-  - name: v2_0.prometheus
-    image: registry.redhat.io/openshift-service-mesh/prometheus-rhel8:2.0.10
-  - name: v2_0.proxy-init
-    image: registry.redhat.io/openshift-service-mesh/proxy-init-rhel7:2.0.10
-  - name: v2_0.proxyv2
-    image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.0.10
-  - name: v2_0.wasm-cacher
-    image: registry.redhat.io/openshift-service-mesh/pilot-rhel8:2.0.10
-  - name: v2_1.cni
-    image: registry.redhat.io/openshift-service-mesh/istio-cni-rhel8:2.1.3
-  - name: v2_1.grafana
-    image: registry.redhat.io/openshift-service-mesh/grafana-rhel8:2.1.3
-  - name: v2_1.pilot
-    image: registry.redhat.io/openshift-service-mesh/pilot-rhel8:2.1.3
-  - name: v2_1.prometheus
-    image: registry.redhat.io/openshift-service-mesh/prometheus-rhel8:2.1.3
-  - name: v2_1.proxyv2
-    image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.1.3
-  - name: v2_1.wasm-cacher
-    image: registry.redhat.io/openshift-service-mesh/pilot-rhel8:2.1.3
-  - name: v2_1.rls
-    image: registry.redhat.io/openshift-service-mesh/ratelimit-rhel8:2.1.3
-  - name: v2_2.cni
-    image: registry.redhat.io/openshift-service-mesh/istio-cni-rhel8:2.2.0
-  - name: v2_2.grafana
-    image: registry.redhat.io/openshift-service-mesh/grafana-rhel8:2.2.0
-  - name: v2_2.pilot
-    image: registry.redhat.io/openshift-service-mesh/pilot-rhel8:2.2.0
-  - name: v2_2.prometheus
-    image: registry.redhat.io/openshift-service-mesh/prometheus-rhel8:2.2.0
-  - name: v2_2.proxyv2
-    image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.2.0
-  - name: v2_2.wasm-cacher
-    image: registry.redhat.io/openshift-service-mesh/pilot-rhel8:2.2.0
-  - name: v2_2.rls
-    image: registry.redhat.io/openshift-service-mesh/ratelimit-rhel8:2.2.0
+
   install:
     strategy: deployment
     spec:
@@ -608,52 +516,57 @@ spec:
               labels:
                 name: istio-operator
               annotations:
-                olm.relatedImage.v1_0.3scale-istio-adapter: registry.redhat.io/openshift-service-mesh/3scale-istio-adapter-rhel8:1.0.0
-                olm.relatedImage.v1_0.citadel: registry.redhat.io/openshift-service-mesh/citadel-rhel8:1.0.11
-                olm.relatedImage.v1_0.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel8:1.0.11
-                olm.relatedImage.v1_0.galley: registry.redhat.io/openshift-service-mesh/galley-rhel8:1.0.11
-                olm.relatedImage.v1_0.grafana: registry.redhat.io/openshift-service-mesh/grafana-rhel8:1.0.11
-                olm.relatedImage.v1_0.mixer: registry.redhat.io/openshift-service-mesh/mixer-rhel8:1.0.11
-                olm.relatedImage.v1_0.pilot: registry.redhat.io/openshift-service-mesh/pilot-rhel8:1.0.11
-                olm.relatedImage.v1_0.prometheus: registry.redhat.io/openshift-service-mesh/prometheus-rhel8:1.0.11
-                olm.relatedImage.v1_0.proxy-init: registry.redhat.io/openshift-service-mesh/proxy-init-rhel7:1.0.11
-                olm.relatedImage.v1_0.proxyv2: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:1.0.11
-                olm.relatedImage.v1_0.sidecar-injector: registry.redhat.io/openshift-service-mesh/sidecar-injector-rhel8:1.0.11
-                olm.relatedImage.v1_1.3scale-istio-adapter: registry.redhat.io/openshift-service-mesh/3scale-istio-adapter-rhel8:1.0.0
-                olm.relatedImage.v1_1.citadel: registry.redhat.io/openshift-service-mesh/citadel-rhel8:1.1.18
-                olm.relatedImage.v1_1.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel8:1.1.18
-                olm.relatedImage.v1_1.galley: registry.redhat.io/openshift-service-mesh/galley-rhel8:1.1.18
-                olm.relatedImage.v1_1.grafana: registry.redhat.io/openshift-service-mesh/grafana-rhel8:1.1.18
-                olm.relatedImage.v1_1.ior: registry.redhat.io/openshift-service-mesh/ior-rhel8:1.1.18
-                olm.relatedImage.v1_1.mixer: registry.redhat.io/openshift-service-mesh/mixer-rhel8:1.1.18
-                olm.relatedImage.v1_1.pilot: registry.redhat.io/openshift-service-mesh/pilot-rhel8:1.1.18
-                olm.relatedImage.v1_1.prometheus: registry.redhat.io/openshift-service-mesh/prometheus-rhel8:1.1.18
-                olm.relatedImage.v1_1.proxy-init: registry.redhat.io/openshift-service-mesh/proxy-init-rhel7:1.1.18
-                olm.relatedImage.v1_1.proxyv2: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:1.1.18
-                olm.relatedImage.v1_1.sidecar-injector: registry.redhat.io/openshift-service-mesh/sidecar-injector-rhel8:1.1.18
-                olm.relatedImage.v2_0.3scale-istio-adapter: registry.redhat.io/openshift-service-mesh/3scale-istio-adapter-rhel8:2.0.0
-                olm.relatedImage.v2_0.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel8:2.0.10
-                olm.relatedImage.v2_0.grafana: registry.redhat.io/openshift-service-mesh/grafana-rhel8:2.0.10
-                olm.relatedImage.v2_0.mixer: registry.redhat.io/openshift-service-mesh/mixer-rhel8:2.0.10
-                olm.relatedImage.v2_0.pilot: registry.redhat.io/openshift-service-mesh/pilot-rhel8:2.0.10
-                olm.relatedImage.v2_0.prometheus: registry.redhat.io/openshift-service-mesh/prometheus-rhel8:2.0.10
-                olm.relatedImage.v2_0.proxy-init: registry.redhat.io/openshift-service-mesh/proxy-init-rhel7:2.0.10
-                olm.relatedImage.v2_0.proxyv2: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.0.10
-                olm.relatedImage.v2_0.wasm-cacher: registry.redhat.io/openshift-service-mesh/pilot-rhel8:2.0.10
-                olm.relatedImage.v2_1.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel8:2.1.3
-                olm.relatedImage.v2_1.grafana: registry.redhat.io/openshift-service-mesh/grafana-rhel8:2.1.3
-                olm.relatedImage.v2_1.pilot: registry.redhat.io/openshift-service-mesh/pilot-rhel8:2.1.3
-                olm.relatedImage.v2_1.prometheus: registry.redhat.io/openshift-service-mesh/prometheus-rhel8:2.1.3
-                olm.relatedImage.v2_1.proxyv2: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.1.3
-                olm.relatedImage.v2_1.wasm-cacher: registry.redhat.io/openshift-service-mesh/pilot-rhel8:2.1.3
-                olm.relatedImage.v2_1.rls: registry.redhat.io/openshift-service-mesh/ratelimit-rhel8:2.1.3
-                olm.relatedImage.v2_2.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel8:2.2.0
-                olm.relatedImage.v2_2.grafana: registry.redhat.io/openshift-service-mesh/grafana-rhel8:2.2.0
-                olm.relatedImage.v2_2.pilot: registry.redhat.io/openshift-service-mesh/pilot-rhel8:2.2.0
-                olm.relatedImage.v2_2.prometheus: registry.redhat.io/openshift-service-mesh/prometheus-rhel8:2.2.0
-                olm.relatedImage.v2_2.proxyv2: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.2.0
-                olm.relatedImage.v2_2.wasm-cacher: registry.redhat.io/openshift-service-mesh/pilot-rhel8:2.2.0
-                olm.relatedImage.v2_2.rls: registry.redhat.io/openshift-service-mesh/ratelimit-rhel8:2.2.0
+                # 1.0 images
+                olm.relatedImage.v1_0.3scale-istio-adapter: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-3scale-istio-adapter-rhel8:1.0.0
+                olm.relatedImage.v1_0.citadel: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-citadel-rhel8:${OSSM_10}
+                olm.relatedImage.v1_0.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_10}
+                olm.relatedImage.v1_0.galley: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-galley-rhel8:${OSSM_10}
+                olm.relatedImage.v1_0.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_10}
+                olm.relatedImage.v1_0.mixer: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-mixer-rhel8:${OSSM_10}
+                olm.relatedImage.v1_0.pilot: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_10}
+                olm.relatedImage.v1_0.prometheus: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-prometheus-rhel8:${OSSM_10}
+                olm.relatedImage.v1_0.proxy-init: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxy-init-rhel7:${OSSM_10}
+                olm.relatedImage.v1_0.proxyv2: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxyv2-rhel8:${OSSM_10}
+                olm.relatedImage.v1_0.sidecar-injector: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-sidecar-injector-rhel8:${OSSM_10}
+                # 1.1 images
+                olm.relatedImage.v1_1.3scale-istio-adapter: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-3scale-istio-adapter-rhel8:1.0.0
+                olm.relatedImage.v1_1.citadel: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-citadel-rhel8:${OSSM_11}
+                olm.relatedImage.v1_1.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_11}
+                olm.relatedImage.v1_1.galley: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-galley-rhel8:${OSSM_11}
+                olm.relatedImage.v1_1.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_11}
+                olm.relatedImage.v1_1.ior: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-ior-rhel8:${OSSM_11}
+                olm.relatedImage.v1_1.mixer: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-mixer-rhel8:${OSSM_11}
+                olm.relatedImage.v1_1.pilot: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_11}
+                olm.relatedImage.v1_1.prometheus: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-prometheus-rhel8:${OSSM_11}
+                olm.relatedImage.v1_1.proxy-init: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxy-init-rhel7:${OSSM_11}
+                olm.relatedImage.v1_1.proxyv2: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxyv2-rhel8:${OSSM_11}
+                olm.relatedImage.v1_1.sidecar-injector: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-sidecar-injector-rhel8:${OSSM_11}
+                # 2.0 images
+                olm.relatedImage.v2_0.3scale-istio-adapter: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-3scale-istio-adapter-rhel8:1.0.0
+                olm.relatedImage.v2_0.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_20}
+                olm.relatedImage.v2_0.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_20}
+                olm.relatedImage.v2_0.mixer: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-mixer-rhel8:${OSSM_20}
+                olm.relatedImage.v2_0.pilot: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_20}
+                olm.relatedImage.v2_0.prometheus: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-prometheus-rhel8:${OSSM_20}
+                olm.relatedImage.v2_0.proxy-init: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxy-init-rhel7:${OSSM_20}
+                olm.relatedImage.v2_0.proxyv2: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxyv2-rhel8:${OSSM_20}
+                olm.relatedImage.v2_0.wasm-cacher: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_20}
+                # 2.1 images
+                olm.relatedImage.v2_1.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_21}
+                olm.relatedImage.v2_1.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_21}
+                olm.relatedImage.v2_1.pilot: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_21}
+                olm.relatedImage.v2_1.prometheus: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-prometheus-rhel8:${OSSM_21}
+                olm.relatedImage.v2_1.proxyv2: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxyv2-rhel8:${OSSM_21}
+                olm.relatedImage.v2_1.wasm-cacher: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_21}
+                olm.relatedImage.v2_1.rls: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-ratelimit-rhel8:${OSSM_21}
+                # 2.2 images
+                olm.relatedImage.v2_2.cni: ${OSSM_CNI_IMAGE}
+                olm.relatedImage.v2_2.grafana: ${OSSM_GRAFANA_IMAGE}
+                olm.relatedImage.v2_2.pilot: ${OSSM_PILOT_IMAGE}
+                olm.relatedImage.v2_2.prometheus: ${OSSM_PROMETHEUS_IMAGE}
+                olm.relatedImage.v2_2.proxyv2: ${OSSM_PROXY_IMAGE}
+                olm.relatedImage.v2_2.wasm-cacher: ${OSSM_PILOT_IMAGE}
+                olm.relatedImage.v2_2.rls: ${OSSM_RATELIMIT_IMAGE}
                 oauth-proxy.query: "true"
                 oauth-proxy.namespace: openshift
                 oauth-proxy.name: oauth-proxy
@@ -662,7 +575,7 @@ spec:
               serviceAccountName: istio-operator
               containers:
                 - name: istio-operator
-                  image: registry.redhat.io/openshift-service-mesh/istio-rhel8-operator:2.2.0
+                  image: ${OSSM_OPERATOR_IMAGE}
                   ports:
                     - containerPort: 11999
                       name: validation


### PR DESCRIPTION
This turns the production CSV (servicemeshoperator CSV) into a template for use in CPaaS. Community CSV stays untouched.

Note that
- it now has variables for container images so they can be filled in by CPaaS during a build
- the `relatedImages` section was removed, this is necessary for the OSBS pipeline to replace image references automatically

One negative side-effect is that you cannot directly `kubectl apply` the Deployment anymore because of the unreplaced variables. If we need this deployment model we'll need to find a way around that (e.g. generate another Deployment with the values filled in)