### PR TITLE
OSSM-1718 Allow deployment of gateways to not-yet-configured namespaces

### DIFF
--- a/pkg/controller/servicemesh/controlplane/reconciler_test.go
+++ b/pkg/controller/servicemesh/controlplane/reconciler_test.go
@@ -193,9 +193,9 @@ func TestManifestValidation(t *testing.T) {
 			},
 			errorMessages: map[versions.Version]string{
 				versions.V1_1: "namespace of manifest b/another-ingress not in mesh",
-				versions.V2_0: "Spec is invalid: error: [namespace \"b\" for gateway \"another-ingress\" is not configured as a mesh member, namespace \"d\" for gateway \"another-egress\" is not configured as a mesh member]",
-				versions.V2_1: "Spec is invalid: error: [namespace \"b\" for gateway \"another-ingress\" is not configured as a mesh member, namespace \"d\" for gateway \"another-egress\" is not configured as a mesh member]",
-				versions.V2_2: "Spec is invalid: error: [namespace \"b\" for gateway \"another-ingress\" is not configured as a mesh member, namespace \"d\" for gateway \"another-egress\" is not configured as a mesh member]",
+				versions.V2_0: "namespace of manifest b/another-ingress not in mesh",
+				versions.V2_1: "namespace of manifest b/another-ingress not in mesh",
+				versions.V2_2: "namespace of manifest b/another-ingress not in mesh",
 			},
 		},
 		{

--- a/pkg/controller/servicemesh/member/controller.go
+++ b/pkg/controller/servicemesh/member/controller.go
@@ -236,13 +236,7 @@ func (r *MemberReconciler) reconcileObject(ctx context.Context, member *maistrav
 		return reconcile.Result{}, r.reportError(ctx, member, false, eventReasonErrorConfiguringNamespace, err)
 	}
 
-	// 4. Check if the SMCP is fully reconciled
-	if !isReconciled(smcp) {
-		err = r.reportError(ctx, member, false, eventReasonControlPlaneNotReconciled, fmt.Errorf("The referenced ServiceMeshControlPlane object is being reconciled."))
-		return reconcile.Result{}, err
-	}
-
-	// 5. Update the status
+	// 4. Update the status
 	// TODO: should the following two fields be updated every time we update the status?
 	member.Status.ServiceMeshGeneration = smcp.Status.ObservedGeneration
 	member.Status.ServiceMeshReconciledVersion = smcp.Status.GetReconciledVersion()

--- a/pkg/controller/servicemesh/memberroll/controller.go
+++ b/pkg/controller/servicemesh/memberroll/controller.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/maistra/istio-operator/pkg/apis/external"
 	kialiv1alpha1 "github.com/maistra/istio-operator/pkg/apis/external/kiali/v1alpha1"
-	"github.com/maistra/istio-operator/pkg/apis/maistra/status"
 	maistrav1 "github.com/maistra/istio-operator/pkg/apis/maistra/v1"
 	maistrav2 "github.com/maistra/istio-operator/pkg/apis/maistra/v2"
 	"github.com/maistra/istio-operator/pkg/controller/common"
@@ -326,7 +325,7 @@ func (r *MemberRollReconciler) reconcileObject(ctx context.Context, roll *maistr
 		memberStatus, exists := memberStatusMap[ns]
 		if !exists {
 			memberStatus = maistrav1.ServiceMeshMemberStatusSummary{
-				Namespace: ns,
+				Namespace:  ns,
 				Conditions: []maistrav1.ServiceMeshMemberCondition{},
 			}
 		}
@@ -397,13 +396,7 @@ func (r *MemberRollReconciler) getServiceMeshControlPlane(ctx context.Context, n
 		return nil, maistrav1.ConditionReasonMultipleSMCP, "Multiple ServiceMeshControlPlane resources exist in the namespace", nil
 	}
 
-	mesh := &meshList.Items[0]
-	if mesh.Status.ObservedGeneration == 0 {
-		return nil, maistrav1.ConditionReasonSMCPNotReconciled, "Initial service mesh installation has not completed", nil
-	} else if meshReconcileStatus := mesh.Status.GetCondition(status.ConditionTypeReconciled); meshReconcileStatus.Status != status.ConditionStatusTrue {
-		return nil, maistrav1.ConditionReasonSMCPNotReconciled, "Service mesh installation is not in a known good state", nil
-	}
-	return mesh, "", "", nil
+	return &meshList.Items[0], "", "", nil
 }
 
 func setReadyCondition(roll *maistrav1.ServiceMeshMemberRoll, ready bool, reason maistrav1.ServiceMeshMemberRollConditionReason, message string) {

--- a/pkg/controller/servicemesh/memberroll/controller_test.go
+++ b/pkg/controller/servicemesh/memberroll/controller_test.go
@@ -155,54 +155,6 @@ func TestReconcileDoesNothingIfMultipleControlPlanesFound(t *testing.T) {
 	}, t)
 }
 
-func TestReconcileDoesNothingIfControlPlaneNotReconciledAtLeastOnce(t *testing.T) {
-	roll := newDefaultMemberRoll()
-	controlPlane := newControlPlane("")
-	controlPlane.Status.ObservedGeneration = 0
-
-	cl, tracker, r, _ := createClientAndReconciler(t, roll, controlPlane)
-
-	assertReconcileSucceeds(r, t)
-	test.AssertNumberOfWriteActions(t, tracker.Actions(), 1)
-
-	updatedRoll := test.GetUpdatedObject(ctx, cl, roll.ObjectMeta, &maistrav1.ServiceMeshMemberRoll{}).(*maistrav1.ServiceMeshMemberRoll)
-	assertConditions(updatedRoll, []maistrav1.ServiceMeshMemberRollCondition{
-		{
-			Type:    maistrav1.ConditionTypeMemberRollReady,
-			Status:  core.ConditionFalse,
-			Reason:  maistrav1.ConditionReasonSMCPNotReconciled,
-			Message: "Initial service mesh installation has not completed",
-		},
-	}, t)
-}
-
-func TestReconcileDoesNothingIfControlPlaneReconciledConditionIsNotTrue(t *testing.T) {
-	roll := newDefaultMemberRoll()
-	controlPlane := newControlPlane("")
-	controlPlane.Status.ObservedGeneration = 1
-	controlPlane.Status.Conditions = []status.Condition{
-		{
-			Type:   status.ConditionTypeReconciled,
-			Status: status.ConditionStatusFalse,
-		},
-	}
-
-	cl, tracker, r, _ := createClientAndReconciler(t, roll, controlPlane)
-
-	assertReconcileSucceeds(r, t)
-	test.AssertNumberOfWriteActions(t, tracker.Actions(), 1)
-
-	updatedRoll := test.GetUpdatedObject(ctx, cl, roll.ObjectMeta, &maistrav1.ServiceMeshMemberRoll{}).(*maistrav1.ServiceMeshMemberRoll)
-	assertConditions(updatedRoll, []maistrav1.ServiceMeshMemberRollCondition{
-		{
-			Type:    maistrav1.ConditionTypeMemberRollReady,
-			Status:  core.ConditionFalse,
-			Reason:  maistrav1.ConditionReasonSMCPNotReconciled,
-			Message: "Service mesh installation is not in a known good state",
-		},
-	}, t)
-}
-
 func TestReconcileFailsIfListingMembersFails(t *testing.T) {
 	roll := newDefaultMemberRoll()
 	controlPlane := newControlPlane("")

--- a/pkg/controller/versions/util.go
+++ b/pkg/controller/versions/util.go
@@ -147,28 +147,19 @@ func validateGateways(ctx context.Context, meta *metav1.ObjectMeta, spec *v2.Con
 }
 
 func validateGatewaysInternal(meta *metav1.ObjectMeta, spec *v2.ControlPlaneSpec, smmr *v1.ServiceMeshMemberRoll, allErrors []error) []error {
-	meshNamespaces := common.GetMeshNamespaces(meta.Namespace, smmr)
 	gatewayNames := sets.NewString()
 	if spec.Gateways != nil {
-		if spec.Gateways.ClusterIngress != nil {
-			validateGatewayNamespace(clusterIngressName, &spec.Gateways.ClusterIngress.GatewayConfig, meshNamespaces, &allErrors)
-		}
-		if spec.Gateways.ClusterEgress != nil {
-			validateGatewayNamespace(clusterEgressName, &spec.Gateways.ClusterEgress.GatewayConfig, meshNamespaces, &allErrors)
-		}
 		for name, gateway := range spec.Gateways.IngressGateways {
-			validateAdditionalGateway(name, &gateway.GatewayConfig, gatewayNames, meshNamespaces, meta.Namespace, &allErrors)
+			validateAdditionalGateway(name, &gateway.GatewayConfig, gatewayNames, meta.Namespace, &allErrors)
 		}
 		for name, gateway := range spec.Gateways.EgressGateways {
-			validateAdditionalGateway(name, &gateway.GatewayConfig, gatewayNames, meshNamespaces, meta.Namespace, &allErrors)
+			validateAdditionalGateway(name, &gateway.GatewayConfig, gatewayNames, meta.Namespace, &allErrors)
 		}
 	}
 	return allErrors
 }
 
-func validateAdditionalGateway(name string, gateway *v2.GatewayConfig, gatewayNames sets.String, meshNamespaces sets.String, meshNamespace string, allErrors *[]error) {
-	validateGatewayNamespace(name, gateway, meshNamespaces, allErrors)
-
+func validateAdditionalGateway(name string, gateway *v2.GatewayConfig, gatewayNames sets.String, meshNamespace string, allErrors *[]error) {
 	namespace := gateway.Namespace
 	if namespace == "" {
 		namespace = meshNamespace
@@ -182,12 +173,6 @@ func validateAdditionalGateway(name string, gateway *v2.GatewayConfig, gatewayNa
 
 	if reservedGatewayNames.Has(name) {
 		*allErrors = append(*allErrors, fmt.Errorf("cannot define additional gateway named %q", name))
-	}
-}
-
-func validateGatewayNamespace(name string, gateway *v2.GatewayConfig, meshNamespaces sets.String, allErrors *[]error) {
-	if (gateway.Enabled == nil || *gateway.Enabled) && gateway.Namespace != "" && !meshNamespaces.Has(gateway.Namespace) {
-		*allErrors = append(*allErrors, fmt.Errorf("namespace %q for gateway %q is not configured as a mesh member", gateway.Namespace, name))
 	}
 }
 

--- a/pkg/controller/versions/util_test.go
+++ b/pkg/controller/versions/util_test.go
@@ -6,7 +6,6 @@ import (
 	maistrav1 "github.com/maistra/istio-operator/pkg/apis/maistra/v1"
 	maistrav2 "github.com/maistra/istio-operator/pkg/apis/maistra/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 const controlPlaneNamespace = "cp-namespace"
@@ -26,101 +25,6 @@ func TestValidateGateways(t *testing.T) {
 			gateways:    nil,
 			expectError: false,
 		},
-
-		{
-			name: "cluster-ingress-in-non-member",
-			gateways: &maistrav2.GatewaysConfig{
-				ClusterIngress: newClusterIngressGatewayConfig("non-member-namespace", nil),
-			},
-			expectError: true,
-		},
-		{
-			name: "cluster-ingress-in-non-member-but-disabled",
-			gateways: &maistrav2.GatewaysConfig{
-				ClusterIngress: newClusterIngressGatewayConfig("non-member-namespace", pointer.BoolPtr(false)),
-			},
-			expectError: false,
-		},
-		{
-			name: "cluster-ingress-in-member",
-			gateways: &maistrav2.GatewaysConfig{
-				ClusterIngress: newClusterIngressGatewayConfig(memberNamespace, nil),
-			},
-			expectError: false,
-		},
-		{
-			name: "cluster-ingress-in-cp-namespace",
-			gateways: &maistrav2.GatewaysConfig{
-				ClusterIngress: newClusterIngressGatewayConfig(controlPlaneNamespace, nil),
-			},
-			expectError: false,
-		},
-
-		{
-			name: "cluster-egress-in-non-member",
-			gateways: &maistrav2.GatewaysConfig{
-				ClusterEgress: newEgressGatewayConfig("non-member-namespace", nil),
-			},
-			expectError: true,
-		},
-		{
-			name: "cluster-egress-in-non-member-but-disabled",
-			gateways: &maistrav2.GatewaysConfig{
-				ClusterEgress: newEgressGatewayConfig("non-member-namespace", pointer.BoolPtr(false)),
-			},
-			expectError: false,
-		},
-		{
-			name: "cluster-egress-in-member",
-			gateways: &maistrav2.GatewaysConfig{
-				ClusterEgress: newEgressGatewayConfig(memberNamespace, nil),
-			},
-			expectError: false,
-		},
-		{
-			name: "cluster-egress-in-cp-namespace",
-			gateways: &maistrav2.GatewaysConfig{
-				ClusterEgress: newEgressGatewayConfig(controlPlaneNamespace, nil),
-			},
-			expectError: false,
-		},
-
-		{
-			name: "additional-ingress-in-non-member",
-			gateways: &maistrav2.GatewaysConfig{
-				IngressGateways: map[string]*maistrav2.IngressGatewayConfig{
-					"additional-ingress": newIngressGatewayConfig("non-member-namespace", nil),
-				},
-			},
-			expectError: true,
-		},
-		{
-			name: "additional-ingress-in-non-member-but-disabled",
-			gateways: &maistrav2.GatewaysConfig{
-				IngressGateways: map[string]*maistrav2.IngressGatewayConfig{
-					"additional-ingress": newIngressGatewayConfig("non-member-namespace", pointer.BoolPtr(false)),
-				},
-			},
-			expectError: false,
-		},
-		{
-			name: "additional-ingress-in-member",
-			gateways: &maistrav2.GatewaysConfig{
-				IngressGateways: map[string]*maistrav2.IngressGatewayConfig{
-					"additional-ingress": newIngressGatewayConfig(memberNamespace, nil),
-				},
-			},
-			expectError: false,
-		},
-		{
-			name: "additional-ingress-in-cp-namespace",
-			gateways: &maistrav2.GatewaysConfig{
-				IngressGateways: map[string]*maistrav2.IngressGatewayConfig{
-					"additional-ingress": newIngressGatewayConfig(controlPlaneNamespace, nil),
-				},
-			},
-			expectError: false,
-		},
 		{
 			name: "additional-ingress-reserved-name",
 			gateways: &maistrav2.GatewaysConfig{
@@ -132,42 +36,6 @@ func TestValidateGateways(t *testing.T) {
 		},
 
 		{
-			name: "additional-egress-in-non-member",
-			gateways: &maistrav2.GatewaysConfig{
-				EgressGateways: map[string]*maistrav2.EgressGatewayConfig{
-					"additional-egress": newEgressGatewayConfig("non-member-namespace", nil),
-				},
-			},
-			expectError: true,
-		},
-		{
-			name: "additional-egress-in-non-member-but-disabled",
-			gateways: &maistrav2.GatewaysConfig{
-				EgressGateways: map[string]*maistrav2.EgressGatewayConfig{
-					"additional-egress": newEgressGatewayConfig("non-member-namespace", pointer.BoolPtr(false)),
-				},
-			},
-			expectError: false,
-		},
-		{
-			name: "additional-egress-in-member",
-			gateways: &maistrav2.GatewaysConfig{
-				EgressGateways: map[string]*maistrav2.EgressGatewayConfig{
-					"additional-egress": newEgressGatewayConfig(memberNamespace, nil),
-				},
-			},
-			expectError: false,
-		},
-		{
-			name: "additional-egress-in-cp-namespace",
-			gateways: &maistrav2.GatewaysConfig{
-				EgressGateways: map[string]*maistrav2.EgressGatewayConfig{
-					"additional-egress": newEgressGatewayConfig(controlPlaneNamespace, nil),
-				},
-			},
-			expectError: false,
-		},
-		{
 			name: "additional-egress-reserved-name",
 			gateways: &maistrav2.GatewaysConfig{
 				EgressGateways: map[string]*maistrav2.EgressGatewayConfig{
@@ -176,7 +44,6 @@ func TestValidateGateways(t *testing.T) {
 			},
 			expectError: true,
 		},
-
 		{
 			name: "duplicate-gateway-name",
 			gateways: &maistrav2.GatewaysConfig{


### PR DESCRIPTION
Removes the namespace validation we put in place for gateways from the ValidatingWebhook. It's still there in the reconciler, so you can't just deploy to namespaces you should not have access to (ie they have to be configured as mesh members first, which still does the SAR check if you have access to the namespace).

This also removes the checks in the SMMR/SMM controllers whether their respective SMCP has been fully reconciled. I don't think we need that check- in fact, it is unhelpful for GitOps-style deployments, where users deploy all resources at the same time. I don't think there's a strong reason why we should not configure a namespace to be part of a mesh that is still being reconciled.

Happy to be convinced otherwise, though. @luksa, any thoughts? Marking this as WIP so we can have a discussion.
