### PR TITLE
OSSM-1805: Requeue patching Kiali if Kiali resource is not available

### DIFF
--- a/pkg/controller/servicemesh/controlplane/addons_test.go
+++ b/pkg/controller/servicemesh/controlplane/addons_test.go
@@ -467,6 +467,14 @@ func TestPatchAddonsResult(t *testing.T) {
 			},
 			expectedReconciliationResult: requeueWithTimeout,
 		},
+		{
+			name:                         "should requeue reconciliation with timeout when Kiali is enabled, but does not exist",
+			kialiEnabled:                 true,
+			grafanaEnabled:               false,
+			jaegerEnabled:                false,
+			objects:                      []runtime.Object{},
+			expectedReconciliationResult: requeueWithTimeout,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
While testing #910, I observed that the operator skips patching Kiali if this resource does not exist, but it may occur temporarily, so I think we should requeue reconciliation to wait for Kiali and patch it properly.

Signed-off-by: Jacek Ewertowski <jewertow@redhat.com>