### PR TITLE
Fix generate-manifests.sh so it recognizes yq-python correctly

### DIFF
--- a/build/generate-manifests.sh
+++ b/build/generate-manifests.sh
@@ -65,9 +65,12 @@ function checkDependencies() {
     echo "Please install the python yq package, e.g. 'pip install --user yq'"
     exit 1
   else
-    s="yq 2.*"
-    if ! [[ $(${YQ} --version) =~ $s ]]; then
-      echo "Install the correct (python) yq package, e.g. 'pip install --user yq'"
+    # check if yq is go or python-based (note: the go version of yq prints
+    # "yq version x.y.z", whereas the python version prints "yq x.y.z")
+    goPythonRegex="yq version .*"
+    ver=$(${YQ} --version)
+    if [[ $ver =~ $goPythonRegex ]]; then
+      echo "Install the correct (python) yq package, e.g. 'pip install --user yq'; current version: $ver"
       exit 1
     fi
   fi


### PR DESCRIPTION
The yq-python version in the builder image used to be 2.x, but is now 3.x, causing the generate-manifests.sh script to complain. This commit changes how the script determines whether the yq tool is go- or python-based.