### PR TITLE
OSSM-1958 Update Kiali CR spec.version so it can run the latest builds of Kiali

### DIFF
--- a/resources/helm/overlays/istio-telemetry/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/overlays/istio-telemetry/kiali/templates/kiali-cr.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.kiali.resourceName | default "kiali" }}
   namespace: {{ .Release.Namespace }}
 spec:
-  version: "v1.48"
+  version: "default"
   installation_tag: "Kiali [{{ .Release.Namespace }}]"
   istio_namespace: "{{ .Release.Namespace }}"
 
@@ -26,7 +26,8 @@ spec:
 {{- end }}
 {{- if .Values.kiali.ingress }}
 {{- if .Values.kiali.ingress.enabled }}
-    ingress_enabled: {{ .Values.kiali.ingress.enabled }}
+    ingress:
+      enabled: {{ .Values.kiali.ingress.enabled }}
 {{- end }}
 {{- end }}
     namespace: "{{ .Release.Namespace }}"

--- a/resources/helm/v2.3/istio-telemetry/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/v2.3/istio-telemetry/kiali/templates/kiali-cr.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ .Values.kiali.resourceName | default "kiali" }}
   namespace: {{ .Release.Namespace }}
 spec:
-  version: "v1.48"
+  version: "default"
   installation_tag: "Kiali [{{ .Release.Namespace }}]"
   istio_namespace: "{{ .Release.Namespace }}"
 
@@ -28,7 +28,8 @@ spec:
 {{- end }}
 {{- if .Values.kiali.ingress }}
 {{- if .Values.kiali.ingress.enabled }}
-    ingress_enabled: {{ .Values.kiali.ingress.enabled }}
+    ingress:
+      enabled: {{ .Values.kiali.ingress.enabled }}
 {{- end }}
 {{- end }}
     namespace: "{{ .Release.Namespace }}"


### PR DESCRIPTION
Also updates the Kiali CR ingress setting since it has slightly changed - the old way is deprecated.
see: https://issues.redhat.com/browse/OSSM-1958

(this PR follows the pattern from the last time we updated the Kiali CR here: https://github.com/maistra/istio-operator/pull/911)