### PR TITLE
OSSM-1928 Remove erroneous maistra-version label from chart overlays [maistra-2.3]

### DIFF
--- a/resources/helm/overlays/istio-init/files/servicemeshpolicies.authentication.maistra.io.crd.yaml
+++ b/resources/helm/overlays/istio-init/files/servicemeshpolicies.authentication.maistra.io.crd.yaml
@@ -7,7 +7,6 @@ metadata:
     app: istio-citadel
     chart: istio
     heritage: Tiller
-    maistra-version: 1.1.6
     release: istio
   name: servicemeshpolicies.authentication.maistra.io
 spec:

--- a/resources/helm/overlays/istio-init/files/servicemeshrbacconfigs.rbac.maistra.io.crd.yaml
+++ b/resources/helm/overlays/istio-init/files/servicemeshrbacconfigs.rbac.maistra.io.crd.yaml
@@ -7,7 +7,6 @@ metadata:
     app: istio-pilot
     heritage: Tiller
     istio: rbac
-    maistra-version: 1.1.6
     release: istio
   name: servicemeshrbacconfigs.rbac.maistra.io
 spec:

--- a/resources/helm/v2.3/istio-init/files/servicemeshpolicies.authentication.maistra.io.crd.yaml
+++ b/resources/helm/v2.3/istio-init/files/servicemeshpolicies.authentication.maistra.io.crd.yaml
@@ -8,7 +8,6 @@ metadata:
     app: istio-citadel
     chart: istio
     heritage: Tiller
-    maistra-version: 1.1.6
     release: istio
   name: servicemeshpolicies.authentication.maistra.io
 spec:

--- a/resources/helm/v2.3/istio-init/files/servicemeshrbacconfigs.rbac.maistra.io.crd.yaml
+++ b/resources/helm/v2.3/istio-init/files/servicemeshrbacconfigs.rbac.maistra.io.crd.yaml
@@ -8,7 +8,6 @@ metadata:
     app: istio-pilot
     heritage: Tiller
     istio: rbac
-    maistra-version: 1.1.6
     release: istio
   name: servicemeshrbacconfigs.rbac.maistra.io
 spec:


### PR DESCRIPTION
This label gets added when the chart is copied from the overlay dir to the final dir.