### PR TITLE
Fix common.GetOperatorNamespace() to work in a OCP env

### DIFF
--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -130,13 +130,14 @@ var (
 func GetOperatorNamespace() string {
 	initOperatorNamespace.Do(func() {
 		var err error
+
+		// Check for this variable before calling k8sutil.GetOperatorNamespace()
+		// This variable is set in unit tests - and potentially in dev debugging sessions
+		if operatorNamespace = os.Getenv("POD_NAMESPACE"); operatorNamespace != "" {
+			return
+		}
+
 		if operatorNamespace, err = k8sutil.GetOperatorNamespace(); err != nil {
-			if err == k8sutil.ErrNoNamespace || err == k8sutil.ErrRunLocal {
-				// see if dev is manually specifying this during debugging
-				if operatorNamespace = os.Getenv("POD_NAMESPACE"); operatorNamespace != "" {
-					return
-				}
-			}
 			panic(err)
 		}
 	})


### PR DESCRIPTION
This fixes an issue with the tests when run in openshift CI, as the
`k8sutil.GetOperatorNamespace()` always return something. Because
the tests rely on the POD_NAMESPACE variable they fail because this
env variable is never checked.
    
Swapping the order the check is made fixes the problem.

