### PR TITLE
OSSM-2053 Don't remove configured (but out-of-date) members from SMMR.status.configuredMembers

### DIFF
--- a/pkg/controller/servicemesh/memberroll/controller_test.go
+++ b/pkg/controller/servicemesh/memberroll/controller_test.go
@@ -215,9 +215,7 @@ func TestReconcileCreatesMember(t *testing.T) {
 			name: "member-exists-but-points-to-different-control-plane",
 			existingObjects: []runtime.Object{
 				newNamespace(appNamespace),
-				markMemberReconciled(
-					newMemberWithRef("other-mesh", "other-mesh-namespace"),
-					1, 1, 1, operatorVersionDefault),
+				markMemberReconciled(newMemberWithRef("other-mesh", "other-mesh-namespace"), 1, operatorVersionDefault),
 			},
 			specMembers:            []string{appNamespace},
 			expectedStatusMembers:  []string{appNamespace},
@@ -319,7 +317,7 @@ func TestReconcileDeletesMemberWhenRemovedFromSpecMembers(t *testing.T) {
 			markControlPlaneReconciled(controlPlane)
 
 			member := newMember()
-			markMemberReconciled(member, 1, 1, controlPlane.Status.ObservedGeneration, controlPlane.Status.OperatorVersion)
+			markMemberReconciled(member, controlPlane.Status.ObservedGeneration, controlPlane.Status.OperatorVersion)
 			if tc.initMemberFunc != nil {
 				tc.initMemberFunc(member)
 			}
@@ -406,7 +404,7 @@ func TestReconcileUpdatesMembersInStatusWhenMemberIsDeleted(t *testing.T) {
 	kialiReconciler.assertInvokedWith(t, appNamespace)
 }
 
-func TestReconcileClearsConfigureMembersWhenSMCPDeleted(t *testing.T) {
+func TestReconcileClearsConfiguredMembersWhenSMCPDeleted(t *testing.T) {
 	roll := newMemberRoll(1)
 	roll.Spec.Members = []string{appNamespace}
 	roll.Status.Members = []string{appNamespace}
@@ -437,6 +435,39 @@ func TestReconcileClearsConfigureMembersWhenSMCPDeleted(t *testing.T) {
 		[]string{appNamespace}, // pending
 		[]string{},             // configured
 		[]string{},             // terminating
+		t)
+}
+
+func TestReconcileAddsMembersToCorrectStatusField(t *testing.T) {
+	smcp := newControlPlane()
+	markControlPlaneReconciled(smcp)
+
+	smmr := newMemberRoll(1)
+	smmr.Spec.Members = []string{"unconfigured", "out-of-date", "up-to-date", "terminating"}
+
+	unconfigured := newMemberWithNamespace("unconfigured")
+
+	configuredButOutOfDate := newMemberWithNamespace("out-of-date")
+	markMemberReconciled(configuredButOutOfDate, smcp.ObjectMeta.Generation-1, smcp.Status.OperatorVersion)
+
+	configuredAndUpToDate := newMemberWithNamespace("up-to-date")
+	markMemberReconciled(configuredAndUpToDate, smcp.ObjectMeta.Generation, smcp.Status.OperatorVersion)
+
+	terminating := newMemberWithNamespace("terminating")
+	markMemberReconciled(configuredAndUpToDate, smcp.ObjectMeta.Generation, smcp.Status.OperatorVersion)
+	terminating.ObjectMeta.DeletionTimestamp = &oneMinuteAgo
+
+	cl, _, r, _ := createClientAndReconciler(smcp, smmr, unconfigured, configuredButOutOfDate, configuredAndUpToDate, terminating,
+		newNamespace("unconfigured"), newNamespace("out-of-date"), newNamespace("up-to-date"), newNamespace("terminating"))
+
+	assertReconcileSucceeds(r, t)
+
+	updatedRoll := test.GetUpdatedObject(ctx, cl, smmr.ObjectMeta, &maistrav1.ServiceMeshMemberRoll{}).(*maistrav1.ServiceMeshMemberRoll)
+	assertStatusMembers(updatedRoll,
+		[]string{"out-of-date", "terminating", "unconfigured", "up-to-date"}, // members
+		[]string{"out-of-date", "unconfigured"},                              // pending
+		[]string{"out-of-date", "up-to-date"},                                // configured
+		[]string{"terminating"},                                              // terminating
 		t)
 }
 
@@ -581,6 +612,12 @@ func TestClientReturnsErrorWhenRemovingFinalizer(t *testing.T) {
 	}
 }
 
+func newMemberWithNamespace(ns string) *maistrav1.ServiceMeshMember {
+	member := newMemberWithRef(controlPlaneName, controlPlaneNamespace)
+	member.Namespace = ns
+	return member
+}
+
 func newMember() *maistrav1.ServiceMeshMember {
 	return newMemberWithRef(controlPlaneName, controlPlaneNamespace)
 }
@@ -601,13 +638,11 @@ func newMemberWithRef(controlPlaneName, controlPlaneNamespace string) *maistrav1
 	}
 }
 
-func markMemberReconciled(member *maistrav1.ServiceMeshMember, generation, observedGeneration, observedMeshGeneration int64,
-	operatorVersion string,
-) *maistrav1.ServiceMeshMember {
+func markMemberReconciled(member *maistrav1.ServiceMeshMember, observedMeshGeneration int64, operatorVersion string) *maistrav1.ServiceMeshMember {
 	member.Finalizers = []string{common.FinalizerName}
-	member.Generation = generation
+	member.Generation = 1
 	member.UID = memberUID
-	member.Status.ObservedGeneration = observedGeneration
+	member.Status.ObservedGeneration = 1
 	member.Status.ServiceMeshGeneration = observedMeshGeneration
 	member.Status.ServiceMeshReconciledVersion = status.ComposeReconciledVersion(operatorVersion, observedMeshGeneration)
 
@@ -704,7 +739,6 @@ func newControlPlane() *maistrav2.ServiceMeshControlPlane {
 }
 
 func markControlPlaneReconciled(controlPlane *maistrav2.ServiceMeshControlPlane) *maistrav2.ServiceMeshControlPlane {
-	controlPlane.Status.ObservedGeneration = controlPlane.GetGeneration()
 	controlPlane.Status.Conditions = []status.Condition{
 		{
 			Type:   status.ConditionTypeReconciled,


### PR DESCRIPTION
After an SMCP is updated, the previously configured members should never disappear from the SMMR.status.configuredMembers list, since this causes istiod to push empty configs to the proxies. These namespaces should still be considered configured, even though they might not be up-to-date with the SMCP until the member controller reconciles them.

Here, we ensure that a namespace that was previously configured successfully, but is now out-of-date with regard to the SMCP, appears in both the configuredMembers and the pendingMembers list.