### PR TITLE
OSSM-1968 Move 2.3 CNI container into separate DaemonSets

### DIFF
--- a/pkg/bootstrap/cni.go
+++ b/pkg/bootstrap/cni.go
@@ -21,19 +21,13 @@ import (
 
 // InstallCNI makes sure all Istio CNI resources have been created.  CRDs are located from
 // files in controller.HelmDir/istio-init/files
+// ver is from a SMCP spec version
 func InstallCNI(ctx context.Context, cl client.Client, config cni.Config, dc discovery.DiscoveryInterface, ver versions.Version) error {
-	// ver is from a SMCP spec version
-	if ver == nil {
-		ver = versions.DefaultVersion.Version()
-	}
 	// we should run through this each reconcile to make sure it's there
 	return internalInstallCNI(ctx, cl, config, dc, ver)
 }
 
 func internalInstallCNI(ctx context.Context, cl client.Client, config cni.Config, dc discovery.DiscoveryInterface, ver versions.Version) error {
-	if ver == nil {
-		ver = versions.DefaultVersion.Version()
-	}
 	renderings, err := internalRenderCNI(ctx, cl, config, dc, versions.GetSupportedVersions(), ver)
 	if err != nil {
 		return err
@@ -67,7 +61,7 @@ func internalRenderCNI(ctx context.Context, cl client.Client, config cni.Config,
 	cni["configMap_v2_0"] = "cni_network_config_v2_0"
 	cni["configMap_v2_1"] = "cni_network_config_v2_1"
 	cni["configMap_v2_2"] = "cni_network_config_v2_2"
-	cni["configMap_v2_3"] = "cni_network_config_v2_3"
+	cni["configMap_v2_3"] = "cni_network_config"
 
 	cni["chained"] = !config.UseMultus
 	if config.UseMultus {
@@ -92,9 +86,6 @@ func internalRenderCNI(ctx context.Context, cl client.Client, config cni.Config,
 	cni["supportedReleases"] = releases
 	// v2.3 render the required cni daemonset,
 	// instanceVersion is from a SMCP spec version
-	if ver == nil {
-		ver = versions.DefaultVersion.Version()
-	}
 	cni["instanceVersion"] = ver.String()
 
 	values := make(map[string]interface{})

--- a/pkg/bootstrap/cni_test.go
+++ b/pkg/bootstrap/cni_test.go
@@ -26,36 +26,49 @@ func TestCNISupportedVersionRendering(t *testing.T) {
 	testCases := []struct {
 		name              string
 		supportedVersions []versions.Version
+		instanceVersion   versions.Version
 		containerNames    []string
 	}{
 		{
-			name:              "Default Supported Versions",
+			name:              "Default Supported Versions v2.2",
 			supportedVersions: versions.GetSupportedVersions(),
-			containerNames:    []string{"install-cni-v1-1", "install-cni-v2-0", "install-cni-v2-1", "install-cni-v2-2", "install-cni-v2-3"},
+			instanceVersion:   versions.V2_2.Version(),
+			containerNames:    []string{"install-cni-v1-1", "install-cni-v2-0", "install-cni-v2-1", "install-cni-v2-2"},
+		},
+		{
+			name:              "Default Supported Versions v2.3",
+			supportedVersions: versions.GetSupportedVersions(),
+			instanceVersion:   versions.V2_3.Version(),
+			containerNames:    []string{"install-cni-v2-3"},
 		},
 		{
 			name:              "v1.1 only",
 			supportedVersions: []versions.Version{versions.V1_1},
+			instanceVersion:   versions.V1_1.Version(),
 			containerNames:    []string{"install-cni-v1-1"},
 		},
 		{
 			name:              "v2.0 only",
 			supportedVersions: []versions.Version{versions.V2_0},
+			instanceVersion:   versions.V2_0.Version(),
 			containerNames:    []string{"install-cni-v2-0"},
 		},
 		{
 			name:              "v2.1 only",
 			supportedVersions: []versions.Version{versions.V2_1},
+			instanceVersion:   versions.V2_1.Version(),
 			containerNames:    []string{"install-cni-v2-1"},
 		},
 		{
 			name:              "v2.2 only",
 			supportedVersions: []versions.Version{versions.V2_2},
+			instanceVersion:   versions.V2_2.Version(),
 			containerNames:    []string{"install-cni-v2-2"},
 		},
 		{
 			name:              "v2.3 only",
 			supportedVersions: []versions.Version{versions.V2_3},
+			instanceVersion:   versions.V2_3.Version(),
 			containerNames:    []string{"install-cni-v2-3"},
 		},
 	}
@@ -67,7 +80,7 @@ func TestCNISupportedVersionRendering(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cl, _ := test.CreateClient()
-			renderings, err := internalRenderCNI(ctx, cl, config, tc.supportedVersions)
+			renderings, err := internalRenderCNI(ctx, cl, config, tc.supportedVersions, tc.instanceVersion)
 			assert.Success(err, "internalRenderCNI", t)
 			assert.True(renderings != nil, "renderings should not be nil", t)
 			cniManifests := renderings["istio_cni"]

--- a/pkg/bootstrap/cni_test.go
+++ b/pkg/bootstrap/cni_test.go
@@ -29,48 +29,56 @@ func TestCNISupportedVersionRendering(t *testing.T) {
 		supportedVersions []versions.Version
 		instanceVersion   versions.Version
 		containerNames    []string
+		daemonsetName     string
 	}{
 		{
-			name:              "Default Supported Versions v2.2",
+			name:              "Default Supported Versions SMCP v2.2",
 			supportedVersions: versions.GetSupportedVersions(),
 			instanceVersion:   versions.V2_2.Version(),
 			containerNames:    []string{"install-cni-v1-1", "install-cni-v2-0", "install-cni-v2-1", "install-cni-v2-2"},
+			daemonsetName:     "istio-cni-node",
 		},
 		{
-			name:              "Default Supported Versions v2.3",
+			name:              "Default Supported Versions SMCP v2.3",
 			supportedVersions: versions.GetSupportedVersions(),
 			instanceVersion:   versions.V2_3.Version(),
-			containerNames:    []string{"install-cni-v2-3"},
+			containerNames:    []string{"install-cni"},
+			daemonsetName:     "istio-cni-node-v2-3",
 		},
 		{
 			name:              "v1.1 only",
 			supportedVersions: []versions.Version{versions.V1_1},
 			instanceVersion:   versions.V1_1.Version(),
 			containerNames:    []string{"install-cni-v1-1"},
+			daemonsetName:     "istio-cni-node",
 		},
 		{
 			name:              "v2.0 only",
 			supportedVersions: []versions.Version{versions.V2_0},
 			instanceVersion:   versions.V2_0.Version(),
 			containerNames:    []string{"install-cni-v2-0"},
+			daemonsetName:     "istio-cni-node",
 		},
 		{
 			name:              "v2.1 only",
 			supportedVersions: []versions.Version{versions.V2_1},
 			instanceVersion:   versions.V2_1.Version(),
 			containerNames:    []string{"install-cni-v2-1"},
+			daemonsetName:     "istio-cni-node",
 		},
 		{
 			name:              "v2.2 only",
 			supportedVersions: []versions.Version{versions.V2_2},
 			instanceVersion:   versions.V2_2.Version(),
 			containerNames:    []string{"install-cni-v2-2"},
+			daemonsetName:     "istio-cni-node",
 		},
 		{
 			name:              "v2.3 only",
 			supportedVersions: []versions.Version{versions.V2_3},
 			instanceVersion:   versions.V2_3.Version(),
-			containerNames:    []string{"install-cni-v2-3"},
+			containerNames:    []string{"install-cni"},
+			daemonsetName:     "istio-cni-node-v2-3",
 		},
 	}
 
@@ -98,6 +106,11 @@ func TestCNISupportedVersionRendering(t *testing.T) {
 					resource := &unstructured.Unstructured{}
 					_, _, err = unstructured.UnstructuredJSONScheme.Decode(json, nil, resource)
 					assert.Success(err, "resource decoding", t)
+
+					dsName, found, err := unstructured.NestedString(resource.UnstructuredContent(), "metadata", "name")
+					assert.Success(err, "unstructured.NestedString", t)
+					assert.True(found, "Could not find metadata name", t)
+					assert.DeepEquals(dsName, tc.daemonsetName, "Unexpected daemonset name found", t)
 
 					containers, found, err := unstructured.NestedSlice(resource.UnstructuredContent(), "spec", "template", "spec", "containers")
 					assert.Success(err, "unstructured.NestedSlice", t)

--- a/pkg/controller/servicemesh/controlplane/integration_test.go
+++ b/pkg/controller/servicemesh/controlplane/integration_test.go
@@ -75,7 +75,7 @@ func TestBootstrapping(t *testing.T) {
 		controlPlaneNamespace = "test"
 		smcpName              = "test"
 		cniDaemonSetNamev2    = "istio-cni-node"
-		cniDaemonSetNamev2_3  = "istio-cni-node-v2.3" // introduced a new cniDaemonSet in v2.3
+		cniDaemonSetNamev2_3  = "istio-cni-node-v2-3" // introduced a new cniDaemonSet in v2.3
 	)
 
 	var (

--- a/pkg/controller/servicemesh/controlplane/reconciler.go
+++ b/pkg/controller/servicemesh/controlplane/reconciler.go
@@ -209,7 +209,7 @@ func (r *controlPlaneInstanceReconciler) Reconcile(ctx context.Context) (result 
 
 		// Ensure Istio CNI is installed
 		if r.cniConfig.Enabled {
-			if err = bootstrap.InstallCNI(ctx, r.Client, r.cniConfig); err != nil {
+			if err = bootstrap.InstallCNI(ctx, r.Client, r.cniConfig, version); err != nil {
 				reconciliationReason = status.ConditionReasonReconcileError
 				reconciliationMessage = "Failed to install/update Istio CNI"
 				log.Error(err, reconciliationMessage)

--- a/resources/helm/overlays/istio_cni/templates/configmap-v2.3.yaml
+++ b/resources/helm/overlays/istio_cni/templates/configmap-v2.3.yaml
@@ -1,0 +1,26 @@
+{{ if .Values.cni.enabled }}
+{{- if and (has "v2.3" .Values.cni.supportedReleases) (eq .Values.cni.instanceVersion "v2.3") }}
+# This ConfigMap is used to configure a self-hosted Istio CNI installation.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: istio-cni-config-v2-3
+  namespace: {{ .Release.Namespace }}
+data:
+  # The CNI network configuration to add to the plugin chain on each node.  The special
+  # values in this config will be automatically populated.
+  cni_network_config: |-
+    {
+      "cniVersion": "0.3.1",
+      "name": "v2-3-istio-cni",
+      "type": "v2-3-istio-cni",
+      "log_level": {{ quote .Values.cni.logLevel }},
+      "log_uds_address": "__LOG_UDS_ADDRESS__",
+      "kubernetes": {
+          "kubeconfig": "__KUBECONFIG_FILEPATH__",
+          "cni_bin_dir": "{{ default "/opt/cni/bin" .Values.cni.cniBinDir }}",
+          "exclude_namespaces": [ "{{ .Release.Namespace }}" ]
+      }
+    }
+{{- end }}
+{{ end }}

--- a/resources/helm/overlays/istio_cni/templates/configmap.yaml
+++ b/resources/helm/overlays/istio_cni/templates/configmap.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.cni.enabled }}
+{{- if or (eq .Values.cni.instanceVersion "v1.1") (eq .Values.cni.instanceVersion "v2.0") (eq .Values.cni.instanceVersion "v2.1") (eq .Values.cni.instanceVersion "v2.2")}}
 # This ConfigMap is used to configure a self-hosted Istio CNI installation.
 kind: ConfigMap
 apiVersion: v1
@@ -60,17 +61,5 @@ data:
           "exclude_namespaces": [ "{{ .Release.Namespace }}" ]
       }
     }
-  cni_network_config_v2_3: |-
-    {
-      "cniVersion": "0.3.1",
-      "name": "v2-3-istio-cni",
-      "type": "v2-3-istio-cni",
-      "log_level": {{ quote .Values.cni.logLevel }},
-      "log_uds_address": "__LOG_UDS_ADDRESS__",
-      "kubernetes": {
-          "kubeconfig": "__KUBECONFIG_FILEPATH__",
-          "cni_bin_dir": "{{ default "/opt/cni/bin" .Values.cni.cniBinDir }}",
-          "exclude_namespaces": [ "{{ .Release.Namespace }}" ]
-      }
-    }
+{{- end }}
 {{ end }}

--- a/resources/helm/overlays/istio_cni/templates/daemonset-v2.3.yaml
+++ b/resources/helm/overlays/istio_cni/templates/daemonset-v2.3.yaml
@@ -1,12 +1,12 @@
 {{ if .Values.cni.enabled }}
-{{- if and (.Values.cni.supportedReleases) (eq .Values.cni.instanceVersion "v2.3") }}
+{{- if and (has "v2.3" .Values.cni.supportedReleases) (eq .Values.cni.instanceVersion "v2.3") }}
 # This manifest installs the Istio install-cni container, as well
 # as the Istio CNI plugin and config on
 # each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
-  name: istio-cni-node-v2.3
+  name: istio-cni-node-v2-3
   namespace: {{ .Release.Namespace }}
   labels:
     k8s-app: istio-cni-node-v2-3
@@ -56,7 +56,7 @@ spec:
       containers:
         # This container installs the Istio CNI binaries
         # and CNI network config file on each node.
-        - name: install-cni-v2-3
+        - name: install-cni
           image: "{{ .Values.cni.image_v2_3 }}"
           imagePullPolicy: {{ .Values.cni.imagePullPolicy }}
           livenessProbe:
@@ -81,7 +81,7 @@ spec:
             - name: CNI_NETWORK_CONFIG
               valueFrom:
                 configMapKeyRef:
-                  name: istio-cni-config
+                  name: istio-cni-config-v2-3
                   key: "{{ default "cni_network_config" .Values.cni.configMap_v2_3 }}"
             - name: CNI_NET_DIR
               value: {{ default "/etc/cni/net.d" .Values.cni.cniConfDir }}

--- a/resources/helm/overlays/istio_cni/templates/daemonset-v2.3.yaml
+++ b/resources/helm/overlays/istio_cni/templates/daemonset-v2.3.yaml
@@ -1,0 +1,128 @@
+{{ if .Values.cni.enabled }}
+{{- if and (.Values.cni.supportedReleases) (eq .Values.cni.instanceVersion "v2.3") }}
+# This manifest installs the Istio install-cni container, as well
+# as the Istio CNI plugin and config on
+# each master and worker node in a Kubernetes cluster.
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: istio-cni-node-v2.3
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: istio-cni-node-v2-3
+    release: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      k8s-app: istio-cni-node-v2-3
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: istio-cni-node-v2-3
+        release: {{ .Release.Name }}
+      annotations:
+        sidecar.istio.io/inject: "false"
+        # Custom annotations
+        {{- if .Values.cni.podAnnotations }}
+{{ toYaml .Values.cni.podAnnotations | indent 8 }}
+        {{- end }}
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        # Make sure istio-cni-node gets scheduled on all nodes.
+        - effect: NoSchedule
+          operator: Exists
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+      priorityClassName: system-node-critical
+      serviceAccountName: istio-cni
+      # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
+      # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
+      terminationGracePeriodSeconds: 5
+{{- if .Values.cni.imagePullSecrets }}
+      imagePullSecrets:
+{{- range .Values.cni.imagePullSecrets }}
+      - name: {{ . }}
+{{- end }}
+{{- end }}
+      containers:
+        # This container installs the Istio CNI binaries
+        # and CNI network config file on each node.
+        - name: install-cni-v2-3
+          image: "{{ .Values.cni.image_v2_3 }}"
+          imagePullPolicy: {{ .Values.cni.imagePullPolicy }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8000
+          initialDelaySeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8000
+          command: ["install-cni"]
+          securityContext:
+            privileged: true
+          env:
+{{- if .Values.cni.cniConfFileName_v2_3 }}
+            # Name of the CNI config file to create.
+            - name: CNI_CONF_NAME
+              value: "{{ .Values.cni.cniConfFileName_v2_3 }}"
+{{- end }}
+            # The CNI network config to install on each node.
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: istio-cni-config
+                  key: "{{ default "cni_network_config" .Values.cni.configMap_v2_3 }}"
+            - name: CNI_NET_DIR
+              value: {{ default "/etc/cni/net.d" .Values.cni.cniConfDir }}
+            # Deploy as a standalone CNI plugin or as chained?
+            - name: CHAINED_CNI_PLUGIN
+              value: "{{ .Values.cni.chained }}"
+            # Directory in which the CNI config file should be created (host path mounted in the container)
+            - name: MOUNTED_CNI_NET_DIR
+              value: {{ default "/host/etc/cni/net.d" .Values.cni.mountedCniConfDir }}
+            # Name of the kubeconfig file used by CNI agent
+            - name: KUBECFG_FILE_NAME
+              value: "v2-3-istio-cni.kubeconfig"
+            # The prefix to add when installing the CNI binaries to the node
+            - name: CNI_BINARIES_PREFIX
+              value: "v2-3-"
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/
+              name: etc-cni-dir
+            - mountPath: /var/run/istio-cni
+              name: cni-log-dir
+          resources:
+{{- if .Values.cni.resources }}
+{{ toYaml .Values.cni.resources | indent 12 }}
+{{- else }}
+            requests:
+              cpu: 10m
+              memory: 100Mi
+{{- end }}
+      volumes:
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: {{ default "/opt/cni/bin" .Values.cni.cniBinDir }}
+        - name: etc-cni-dir
+          hostPath:
+            path: /etc/cni
+        # Used for UDS log
+        - name: cni-log-dir
+          hostPath:
+            path: /var/run/istio-cni
+{{- end }}
+{{ end }}

--- a/resources/helm/overlays/istio_cni/templates/daemonset.yaml
+++ b/resources/helm/overlays/istio_cni/templates/daemonset.yaml
@@ -1,4 +1,6 @@
 {{ if .Values.cni.enabled }}
+{{- if (.Values.cni.supportedReleases) }}
+{{- if or (eq .Values.cni.instanceVersion "v1.1") (eq .Values.cni.instanceVersion "v2.0") (eq .Values.cni.instanceVersion "v2.1") (eq .Values.cni.instanceVersion "v2.2")}}
 # This manifest installs the Istio install-cni container, as well
 # as the Istio CNI plugin and config on
 # each master and worker node in a Kubernetes cluster.
@@ -252,64 +254,6 @@ spec:
               memory: 100Mi
 {{- end }}
 {{- end }}
-{{- if and (.Values.cni.supportedReleases) (has "v2.3" .Values.cni.supportedReleases) }}
-        - name: install-cni-v2-3
-          image: "{{ .Values.cni.image_v2_3 }}"
-          imagePullPolicy: {{ .Values.cni.imagePullPolicy }}
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 8000
-          initialDelaySeconds: 5
-          readinessProbe:
-            httpGet:
-              path: /readyz
-              port: 8000
-          command: ["install-cni"]
-          securityContext:
-            privileged: true
-          env:
-{{- if .Values.cni.cniConfFileName_v2_3 }}
-            # Name of the CNI config file to create.
-            - name: CNI_CONF_NAME
-              value: "{{ .Values.cni.cniConfFileName_v2_3 }}"
-{{- end }}
-            # The CNI network config to install on each node.
-            - name: CNI_NETWORK_CONFIG
-              valueFrom:
-                configMapKeyRef:
-                  name: istio-cni-config
-                  key: "{{ default "cni_network_config" .Values.cni.configMap_v2_3 }}"
-            - name: CNI_NET_DIR
-              value: {{ default "/etc/cni/net.d" .Values.cni.cniConfDir }}
-            # Deploy as a standalone CNI plugin or as chained?
-            - name: CHAINED_CNI_PLUGIN
-              value: "{{ .Values.cni.chained }}"
-            # Directory in which the CNI config file should be created (host path mounted in the container)
-            - name: MOUNTED_CNI_NET_DIR
-              value: {{ default "/host/etc/cni/net.d" .Values.cni.mountedCniConfDir }}
-            # Name of the kubeconfig file used by CNI agent
-            - name: KUBECFG_FILE_NAME
-              value: "v2-3-istio-cni.kubeconfig"
-            # The prefix to add when installing the CNI binaries to the node
-            - name: CNI_BINARIES_PREFIX
-              value: "v2-3-"
-          volumeMounts:
-            - mountPath: /host/opt/cni/bin
-              name: cni-bin-dir
-            - mountPath: /host/etc/cni/
-              name: etc-cni-dir
-            - mountPath: /var/run/istio-cni
-              name: cni-log-dir
-          resources:
-{{- if .Values.cni.resources }}
-{{ toYaml .Values.cni.resources | indent 12 }}
-{{- else }}
-            requests:
-              cpu: 10m
-              memory: 100Mi
-{{- end }}
-{{- end }}
       volumes:
         # Used to install CNI.
         - name: cni-bin-dir
@@ -322,4 +266,6 @@ spec:
         - name: cni-log-dir
           hostPath:
             path: /var/run/istio-cni
+{{- end }}
+{{- end }}
 {{ end }}

--- a/resources/helm/overlays/istio_cni/templates/daemonset.yaml
+++ b/resources/helm/overlays/istio_cni/templates/daemonset.yaml
@@ -1,5 +1,4 @@
 {{ if .Values.cni.enabled }}
-{{- if (.Values.cni.supportedReleases) }}
 {{- if or (eq .Values.cni.instanceVersion "v1.1") (eq .Values.cni.instanceVersion "v2.0") (eq .Values.cni.instanceVersion "v2.1") (eq .Values.cni.instanceVersion "v2.2")}}
 # This manifest installs the Istio install-cni container, as well
 # as the Istio CNI plugin and config on
@@ -266,6 +265,5 @@ spec:
         - name: cni-log-dir
           hostPath:
             path: /var/run/istio-cni
-{{- end }}
 {{- end }}
 {{ end }}

--- a/resources/helm/v2.3/istio_cni/templates/configmap-v2.3.yaml
+++ b/resources/helm/v2.3/istio_cni/templates/configmap-v2.3.yaml
@@ -1,0 +1,28 @@
+{{ if .Values.cni.enabled }}
+{{- if and (has "v2.3" .Values.cni.supportedReleases) (eq .Values.cni.instanceVersion "v2.3") }}
+# This ConfigMap is used to configure a self-hosted Istio CNI installation.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    maistra-version: "2.3.0"
+  name: istio-cni-config-v2-3
+  namespace: {{ .Release.Namespace }}
+data:
+  # The CNI network configuration to add to the plugin chain on each node.  The special
+  # values in this config will be automatically populated.
+  cni_network_config: |-
+    {
+      "cniVersion": "0.3.1",
+      "name": "v2-3-istio-cni",
+      "type": "v2-3-istio-cni",
+      "log_level": {{ quote .Values.cni.logLevel }},
+      "log_uds_address": "__LOG_UDS_ADDRESS__",
+      "kubernetes": {
+          "kubeconfig": "__KUBECONFIG_FILEPATH__",
+          "cni_bin_dir": "{{ default "/opt/cni/bin" .Values.cni.cniBinDir }}",
+          "exclude_namespaces": [ "{{ .Release.Namespace }}" ]
+      }
+    }
+{{- end }}
+{{ end }}

--- a/resources/helm/v2.3/istio_cni/templates/configmap.yaml
+++ b/resources/helm/v2.3/istio_cni/templates/configmap.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.cni.enabled }}
+{{- if or (eq .Values.cni.instanceVersion "v1.1") (eq .Values.cni.instanceVersion "v2.0") (eq .Values.cni.instanceVersion "v2.1") (eq .Values.cni.instanceVersion "v2.2")}}
 # This ConfigMap is used to configure a self-hosted Istio CNI installation.
 kind: ConfigMap
 apiVersion: v1
@@ -62,17 +63,5 @@ data:
           "exclude_namespaces": [ "{{ .Release.Namespace }}" ]
       }
     }
-  cni_network_config_v2_3: |-
-    {
-      "cniVersion": "0.3.1",
-      "name": "v2-3-istio-cni",
-      "type": "v2-3-istio-cni",
-      "log_level": {{ quote .Values.cni.logLevel }},
-      "log_uds_address": "__LOG_UDS_ADDRESS__",
-      "kubernetes": {
-          "kubeconfig": "__KUBECONFIG_FILEPATH__",
-          "cni_bin_dir": "{{ default "/opt/cni/bin" .Values.cni.cniBinDir }}",
-          "exclude_namespaces": [ "{{ .Release.Namespace }}" ]
-      }
-    }
+{{- end }}
 {{ end }}

--- a/resources/helm/v2.3/istio_cni/templates/daemonset-v2.3.yaml
+++ b/resources/helm/v2.3/istio_cni/templates/daemonset-v2.3.yaml
@@ -1,12 +1,12 @@
 {{ if .Values.cni.enabled }}
-{{- if and (.Values.cni.supportedReleases) (eq .Values.cni.instanceVersion "v2.3") }}
+{{- if and (has "v2.3" .Values.cni.supportedReleases) (eq .Values.cni.instanceVersion "v2.3") }}
 # This manifest installs the Istio install-cni container, as well
 # as the Istio CNI plugin and config on
 # each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
-  name: istio-cni-node-v2.3
+  name: istio-cni-node-v2-3
   namespace: {{ .Release.Namespace }}
   labels:
     maistra-version: "2.3.0"
@@ -57,7 +57,7 @@ spec:
       containers:
         # This container installs the Istio CNI binaries
         # and CNI network config file on each node.
-        - name: install-cni-v2-3
+        - name: install-cni
           image: "{{ .Values.cni.image_v2_3 }}"
           imagePullPolicy: {{ .Values.cni.imagePullPolicy }}
           livenessProbe:
@@ -82,7 +82,7 @@ spec:
             - name: CNI_NETWORK_CONFIG
               valueFrom:
                 configMapKeyRef:
-                  name: istio-cni-config
+                  name: istio-cni-config-v2-3
                   key: "{{ default "cni_network_config" .Values.cni.configMap_v2_3 }}"
             - name: CNI_NET_DIR
               value: {{ default "/etc/cni/net.d" .Values.cni.cniConfDir }}

--- a/resources/helm/v2.3/istio_cni/templates/daemonset-v2.3.yaml
+++ b/resources/helm/v2.3/istio_cni/templates/daemonset-v2.3.yaml
@@ -1,0 +1,129 @@
+{{ if .Values.cni.enabled }}
+{{- if and (.Values.cni.supportedReleases) (eq .Values.cni.instanceVersion "v2.3") }}
+# This manifest installs the Istio install-cni container, as well
+# as the Istio CNI plugin and config on
+# each master and worker node in a Kubernetes cluster.
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: istio-cni-node-v2.3
+  namespace: {{ .Release.Namespace }}
+  labels:
+    maistra-version: "2.3.0"
+    k8s-app: istio-cni-node-v2-3
+    release: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      k8s-app: istio-cni-node-v2-3
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: istio-cni-node-v2-3
+        release: {{ .Release.Name }}
+      annotations:
+        sidecar.istio.io/inject: "false"
+        # Custom annotations
+        {{- if .Values.cni.podAnnotations }}
+{{ toYaml .Values.cni.podAnnotations | indent 8 }}
+        {{- end }}
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        # Make sure istio-cni-node gets scheduled on all nodes.
+        - effect: NoSchedule
+          operator: Exists
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+      priorityClassName: system-node-critical
+      serviceAccountName: istio-cni
+      # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
+      # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
+      terminationGracePeriodSeconds: 5
+{{- if .Values.cni.imagePullSecrets }}
+      imagePullSecrets:
+{{- range .Values.cni.imagePullSecrets }}
+      - name: {{ . }}
+{{- end }}
+{{- end }}
+      containers:
+        # This container installs the Istio CNI binaries
+        # and CNI network config file on each node.
+        - name: install-cni-v2-3
+          image: "{{ .Values.cni.image_v2_3 }}"
+          imagePullPolicy: {{ .Values.cni.imagePullPolicy }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8000
+          initialDelaySeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8000
+          command: ["install-cni"]
+          securityContext:
+            privileged: true
+          env:
+{{- if .Values.cni.cniConfFileName_v2_3 }}
+            # Name of the CNI config file to create.
+            - name: CNI_CONF_NAME
+              value: "{{ .Values.cni.cniConfFileName_v2_3 }}"
+{{- end }}
+            # The CNI network config to install on each node.
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: istio-cni-config
+                  key: "{{ default "cni_network_config" .Values.cni.configMap_v2_3 }}"
+            - name: CNI_NET_DIR
+              value: {{ default "/etc/cni/net.d" .Values.cni.cniConfDir }}
+            # Deploy as a standalone CNI plugin or as chained?
+            - name: CHAINED_CNI_PLUGIN
+              value: "{{ .Values.cni.chained }}"
+            # Directory in which the CNI config file should be created (host path mounted in the container)
+            - name: MOUNTED_CNI_NET_DIR
+              value: {{ default "/host/etc/cni/net.d" .Values.cni.mountedCniConfDir }}
+            # Name of the kubeconfig file used by CNI agent
+            - name: KUBECFG_FILE_NAME
+              value: "v2-3-istio-cni.kubeconfig"
+            # The prefix to add when installing the CNI binaries to the node
+            - name: CNI_BINARIES_PREFIX
+              value: "v2-3-"
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/
+              name: etc-cni-dir
+            - mountPath: /var/run/istio-cni
+              name: cni-log-dir
+          resources:
+{{- if .Values.cni.resources }}
+{{ toYaml .Values.cni.resources | indent 12 }}
+{{- else }}
+            requests:
+              cpu: 10m
+              memory: 100Mi
+{{- end }}
+      volumes:
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: {{ default "/opt/cni/bin" .Values.cni.cniBinDir }}
+        - name: etc-cni-dir
+          hostPath:
+            path: /etc/cni
+        # Used for UDS log
+        - name: cni-log-dir
+          hostPath:
+            path: /var/run/istio-cni
+{{- end }}
+{{ end }}

--- a/resources/helm/v2.3/istio_cni/templates/daemonset.yaml
+++ b/resources/helm/v2.3/istio_cni/templates/daemonset.yaml
@@ -1,5 +1,4 @@
 {{ if .Values.cni.enabled }}
-{{- if (.Values.cni.supportedReleases) }}
 {{- if or (eq .Values.cni.instanceVersion "v1.1") (eq .Values.cni.instanceVersion "v2.0") (eq .Values.cni.instanceVersion "v2.1") (eq .Values.cni.instanceVersion "v2.2")}}
 # This manifest installs the Istio install-cni container, as well
 # as the Istio CNI plugin and config on
@@ -267,6 +266,5 @@ spec:
         - name: cni-log-dir
           hostPath:
             path: /var/run/istio-cni
-{{- end }}
 {{- end }}
 {{ end }}

--- a/resources/helm/v2.3/istio_cni/templates/daemonset.yaml
+++ b/resources/helm/v2.3/istio_cni/templates/daemonset.yaml
@@ -1,4 +1,6 @@
 {{ if .Values.cni.enabled }}
+{{- if (.Values.cni.supportedReleases) }}
+{{- if or (eq .Values.cni.instanceVersion "v1.1") (eq .Values.cni.instanceVersion "v2.0") (eq .Values.cni.instanceVersion "v2.1") (eq .Values.cni.instanceVersion "v2.2")}}
 # This manifest installs the Istio install-cni container, as well
 # as the Istio CNI plugin and config on
 # each master and worker node in a Kubernetes cluster.
@@ -253,64 +255,6 @@ spec:
               memory: 100Mi
 {{- end }}
 {{- end }}
-{{- if and (.Values.cni.supportedReleases) (has "v2.3" .Values.cni.supportedReleases) }}
-        - name: install-cni-v2-3
-          image: "{{ .Values.cni.image_v2_3 }}"
-          imagePullPolicy: {{ .Values.cni.imagePullPolicy }}
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 8000
-          initialDelaySeconds: 5
-          readinessProbe:
-            httpGet:
-              path: /readyz
-              port: 8000
-          command: ["install-cni"]
-          securityContext:
-            privileged: true
-          env:
-{{- if .Values.cni.cniConfFileName_v2_3 }}
-            # Name of the CNI config file to create.
-            - name: CNI_CONF_NAME
-              value: "{{ .Values.cni.cniConfFileName_v2_3 }}"
-{{- end }}
-            # The CNI network config to install on each node.
-            - name: CNI_NETWORK_CONFIG
-              valueFrom:
-                configMapKeyRef:
-                  name: istio-cni-config
-                  key: "{{ default "cni_network_config" .Values.cni.configMap_v2_3 }}"
-            - name: CNI_NET_DIR
-              value: {{ default "/etc/cni/net.d" .Values.cni.cniConfDir }}
-            # Deploy as a standalone CNI plugin or as chained?
-            - name: CHAINED_CNI_PLUGIN
-              value: "{{ .Values.cni.chained }}"
-            # Directory in which the CNI config file should be created (host path mounted in the container)
-            - name: MOUNTED_CNI_NET_DIR
-              value: {{ default "/host/etc/cni/net.d" .Values.cni.mountedCniConfDir }}
-            # Name of the kubeconfig file used by CNI agent
-            - name: KUBECFG_FILE_NAME
-              value: "v2-3-istio-cni.kubeconfig"
-            # The prefix to add when installing the CNI binaries to the node
-            - name: CNI_BINARIES_PREFIX
-              value: "v2-3-"
-          volumeMounts:
-            - mountPath: /host/opt/cni/bin
-              name: cni-bin-dir
-            - mountPath: /host/etc/cni/
-              name: etc-cni-dir
-            - mountPath: /var/run/istio-cni
-              name: cni-log-dir
-          resources:
-{{- if .Values.cni.resources }}
-{{ toYaml .Values.cni.resources | indent 12 }}
-{{- else }}
-            requests:
-              cpu: 10m
-              memory: 100Mi
-{{- end }}
-{{- end }}
       volumes:
         # Used to install CNI.
         - name: cni-bin-dir
@@ -323,4 +267,6 @@ spec:
         - name: cni-log-dir
           hostPath:
             path: /var/run/istio-cni
+{{- end }}
+{{- end }}
 {{ end }}


### PR DESCRIPTION
Signed-off-by: Yuanlin <yuanlin.xu@redhat.com>

This PR replaces the cni template daemonset.yaml with separated ones: daemonset-v2.0.yaml, daemonset-v2.1.yaml, daemonset-v2.2.yaml and daemonset-v2.3.yaml

I use the existing cni.supportedReleases values to filter a SMCP controller version, because there is no direct mapping between cni bootstrap and a controller spec version. 

In upgrade case, the new boostrap code will check and delete the existing "istio-node" and "istio-cni-node" DaemonSets if they exist.

