### PR TITLE
OSSM-1634 - OSSM 2.3 will install Kiali v1.57.

### DIFF
--- a/resources/helm/overlays/istio-telemetry/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/overlays/istio-telemetry/kiali/templates/kiali-cr.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.kiali.resourceName | default "kiali" }}
   namespace: {{ .Release.Namespace }}
 spec:
-  version: "default"
+  version: "v1.57"
   installation_tag: "Kiali [{{ .Release.Namespace }}]"
   istio_namespace: "{{ .Release.Namespace }}"
 

--- a/resources/helm/v2.3/istio-telemetry/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/v2.3/istio-telemetry/kiali/templates/kiali-cr.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ .Values.kiali.resourceName | default "kiali" }}
   namespace: {{ .Release.Namespace }}
 spec:
-  version: "default"
+  version: "v1.57"
   installation_tag: "Kiali [{{ .Release.Namespace }}]"
   istio_namespace: "{{ .Release.Namespace }}"
 


### PR DESCRIPTION
This makes sure the Maistra operator creates the Kial CR with spec.version of v1.57.

(this updates what we did in https://github.com/maistra/istio-operator/pull/986 / https://issues.redhat.com/browse/OSSM-1958)