### PR TITLE
OSSM-1094 Use SHA-256 for htpasswd

### DIFF
--- a/pkg/controller/servicemesh/controlplane/htpasswd.go
+++ b/pkg/controller/servicemesh/controlplane/htpasswd.go
@@ -34,7 +34,7 @@ func (r *controlPlaneInstanceReconciler) patchHtpasswdSecret(ctx context.Context
 		}
 		h := sha256.New()
 		h.Write([]byte(rawPassword))
-		auth = "internal:{SHA}" + base64.StdEncoding.EncodeToString(h.Sum(nil))
+		auth = "internal:{SHA-2}" + base64.StdEncoding.EncodeToString(h.Sum(nil))
 	}
 
 	b64Password := base64.StdEncoding.EncodeToString([]byte(rawPassword))

--- a/pkg/controller/servicemesh/controlplane/htpasswd.go
+++ b/pkg/controller/servicemesh/controlplane/htpasswd.go
@@ -3,7 +3,7 @@ package controlplane
 import (
 	"context"
 	"crypto/rand"
-	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"regexp"
@@ -32,7 +32,7 @@ func (r *controlPlaneInstanceReconciler) patchHtpasswdSecret(ctx context.Context
 			log.Error(err, "failed to generate the HTPasswd password")
 			return err
 		}
-		h := sha1.New()
+		h := sha256.New()
 		h.Write([]byte(rawPassword))
 		auth = "internal:{SHA}" + base64.StdEncoding.EncodeToString(h.Sum(nil))
 	}


### PR DESCRIPTION
Update htpasswd secret to be created with SHA-256 rather than SHA-1. 

Tested with SMCP versions 2.1, 2.2, 2.3 using [this bookinfo test  ](https://istio.io/latest/docs/tasks/observability/metrics/querying-metrics/).