### PR TITLE
Update README.md: Cert-Manager

### DIFF
--- a/deploy/examples/cert-manager/README.md
+++ b/deploy/examples/cert-manager/README.md
@@ -16,11 +16,11 @@
 
 2. Provision certificates:
 
-        kubectl apply -f selfsigned-ca.yaml -n istio-system
+        kubectl apply -f deploy/examples/cert-manager/selfsigned-ca.yaml -n istio-system
 
 3. Install cert-manager istio-csr Service:
 
-        helm install -n cert-manager cert-manager-istio-csr jetstack/cert-manager-istio-csr -f deploy-prototype/istio-csr-helm-values.yaml"
+        helm install -n cert-manager cert-manager-istio-csr jetstack/cert-manager-istio-csr -f deploy-prototype/istio-csr-helm-values.yaml
 
 ## Create Istio Control Plane
 


### PR DESCRIPTION
Please update these commands to find the YAML files in the folder.

Please verify this command, it is giving the error

```
helm install -n cert-manager cert-manager-istio-csr jetstack/cert-manager-istio-csr -f deploy/examples/cert-manager/istio-csr-helm-values.yaml

Error: template: cert-manager-istio-csr/templates/serviceaccount.yaml:3:7: executing "cert-manager-istio-csr/templates/serviceaccount.yaml" at <ne .Values.image.pullSecretName "">: error calling ne: incompatible types for comparison
```


