### PR TITLE
OSSM-2084: Set namespace_label for kiali dashboards

### DIFF
--- a/resources/helm/overlays/istio-telemetry/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/overlays/istio-telemetry/kiali/templates/kiali-cr.yaml
@@ -85,6 +85,8 @@ spec:
 {{- end }}
 
   external_services:
+    custom_dashboards:
+      namespace_label: kubernetes_namespace
     istio:
       config_map_name: istio-{{ .Values.revision | default "default" }}
       url_service_version: http://istiod-{{ .Values.revision | default "default" }}.{{ .Release.Namespace }}:15014/version

--- a/resources/helm/v2.3/istio-telemetry/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/v2.3/istio-telemetry/kiali/templates/kiali-cr.yaml
@@ -87,6 +87,8 @@ spec:
 {{- end }}
 
   external_services:
+    custom_dashboards:
+      namespace_label: kubernetes_namespace
     istio:
       config_map_name: istio-{{ .Values.revision | default "default" }}
       url_service_version: http://istiod-{{ .Values.revision | default "default" }}.{{ .Release.Namespace }}:15014/version


### PR DESCRIPTION
Settings this label is necessary for the envoy metrics dashboard to display in Kiali for Prometheus instances older than 2.31.