### PR TITLE
Remove duplicated rules from istiod-clusterrole-istio-system

### DIFF
--- a/build/patch-charts.sh
+++ b/build/patch-charts.sh
@@ -120,13 +120,6 @@ function patchGalley() {
 
   # multitenant
   sed_wrap -i -e '/^---/i \
-  # Maistra specific\
-  - apiGroups: ["maistra.io"]\
-    resources: ["servicemeshmemberrolls"]\
-    verbs: ["get", "list", "watch"]\
-  - apiGroups: ["route.openshift.io"]\
-    resources: ["routes", "routes/custom-host"]\
-    verbs: ["get", "list", "watch", "create", "delete", "update"]\
   # Allow use of blockOwnerDeletion in ownerReferences pointing to Pods (see OSSM-1321)\
   - apiGroups: [""]\
     resources: ["pods/finalizers"]\

--- a/resources/helm/v2.3/istio-control/istio-discovery/templates/clusterrole.yaml
+++ b/resources/helm/v2.3/istio-control/istio-discovery/templates/clusterrole.yaml
@@ -107,13 +107,6 @@ rules:
   - apiGroups: ["{{ $mcsAPIGroup }}"]
     resources: ["serviceimports"]
     verbs: ["get", "watch", "list"]
-  # Maistra specific
-  - apiGroups: ["maistra.io"]
-    resources: ["servicemeshmemberrolls"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["route.openshift.io"]
-    resources: ["routes", "routes/custom-host"]
-    verbs: ["get", "list", "watch", "create", "delete", "update"]
   # Allow use of blockOwnerDeletion in ownerReferences pointing to Pods (see OSSM-1321)
   - apiGroups: [""]
     resources: ["pods/finalizers"]


### PR DESCRIPTION
I noticed that we add rules for SMMR and Route resources to `istiod-clusterrole-istio-system` which already exist in [templates from maistra/istio](https://github.com/maistra/istio/blob/maistra-2.3/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml#L113) and as a result we have duplicated rules in this cluster role.
```
# Maistra specific
- apiGroups: ["maistra.io"]
  resources: ["servicemeshmemberrolls"]
  verbs: ["get", "list", "watch"]
- apiGroups: ["route.openshift.io"]
  resources: ["routes", "routes/custom-host"]
  verbs: ["get", "list", "watch", "create", "delete", "update"]
```