### PR TITLE
feat(make): simplifies targets for creating charts and other resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ SUPPORTED_VERSIONS := 2.0 2.1 2.2 2.3
 
 $(addprefix update-remote-maistra-,$(SUPPORTED_VERSIONS)): update-remote-maistra-%:
 	$(eval version:=$*)
-	@ if [[ ${OFFLINE_BUILD} == "false" || ${MAISTRA_VERSION} == ${version}* ]]; \
+	@ if [[ ${OFFLINE_BUILD} == "false" || ${MAISTRA_VERSION} == ${version}.* ]]; \
 	then \
 		git remote set-branches --add ${GIT_UPSTREAM_REMOTE} maistra-${version}; \
 		git fetch ${GIT_UPSTREAM_REMOTE} maistra-${version}:maistra-${version}; \
@@ -101,7 +101,7 @@ $(addprefix update-charts-,$(SUPPORTED_VERSIONS)): update-charts-%:
 	$(eval version:=$*)
 	@# If we are calling make against current version - download charts.
 	@# Otherwise sync from previous branches and explicitly call dependent target with extracted version
-	@ if [[ ${MAISTRA_VERSION} == ${version}* ]]; \
+	@ if [[ ${MAISTRA_VERSION} == ${version}.* ]]; \
 	then \
 		HELM_DIR=${RESOURCES_DIR}/helm/v${version} ISTIO_VERSION=${ISTIO_VERSION} ${SOURCE_DIR}/build/download-charts.sh; \
 	else \

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ SUPPORTED_VERSIONS := 2.0 2.1 2.2 2.3
 
 $(addprefix update-remote-maistra-,$(SUPPORTED_VERSIONS)): update-remote-maistra-%:
 	$(eval version:=$*)
-	@ if [[ ${OFFLINE_BUILD} == "false" || ${MAISTRA_VERSION} != ${version}.* ]]; \
+	@ if [[ ${OFFLINE_BUILD} == "false" && ${MAISTRA_VERSION} != ${version}.* ]]; \
 	then \
 		git remote set-branches --add ${GIT_UPSTREAM_REMOTE} maistra-${version}; \
 		git fetch ${GIT_UPSTREAM_REMOTE} maistra-${version}:maistra-${version}; \

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ test:
 ################################################################################
 .PHONY: update-remote-maistra-%
 update-remote-maistra-%:
-	$(eval version:=$(subst update-remote-maistra-,,$@))
+	$(eval version:=$*)
 ifeq "${OFFLINE_BUILD}" "false"
 	git remote set-branches --add ${GIT_UPSTREAM_REMOTE} maistra-${version}
 	git fetch ${GIT_UPSTREAM_REMOTE} maistra-${version}:maistra-${version}
@@ -96,7 +96,7 @@ endif
 
 .PHONY: update-charts-%
 update-charts-%:
-	$(eval version:=$(subst update-charts-,,$@))
+	$(eval version:=$*)
 	# If we are calling make against current version - download charts.
 	# Otherwise sync from previous branches and explicitly call dependent target with extracted version
 	@ if [[ ${MAISTRA_VERSION} == ${version}* ]]; \
@@ -110,7 +110,7 @@ update-charts-%:
 
 .PHONY: update-templates-%
 update-templates-%:
-	$(eval version:=$(subst update-templates-,,$@))
+	$(eval version:=$*)
 	# Has to explicitly call dependent target with extracted version
 	@$(MAKE) -f $(THIS_FILE) update-remote-maistra-${version}
 	git checkout ${GIT_UPSTREAM_REMOTE}/maistra-${version} -- ${SOURCE_DIR}/resources/smcp-templates/v${version}
@@ -118,13 +118,13 @@ update-templates-%:
 
 .PHONY: collect-charts-%
 collect-charts-%:
-	$(eval version:=$(subst collect-charts-,,$@))
+	$(eval version:=$*)
 	mkdir -p ${HELM_OUT_DIR}
 	cp -rf ${RESOURCES_DIR}/helm/v${version} ${HELM_OUT_DIR}
 
 .PHONY: collect-templates-%
 collect-templates-%:
-	$(eval version:=$(subst collect-templates-,,$@))
+	$(eval version:=$*)
 	mkdir -p ${TEMPLATES_OUT_DIR}/v${version}
 	cp ${RESOURCES_DIR}/smcp-templates/v${version}/${BUILD_TYPE} ${TEMPLATES_OUT_DIR}/v${version}/default
 	find ${RESOURCES_DIR}/smcp-templates/v${version}/ -maxdepth 1 -type f ! -name "maistra" ! -name "servicemesh" | xargs cp -t ${TEMPLATES_OUT_DIR}/v${version}

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,6 @@ update-charts-%:
 	# Otherwise sync from previous branches and explicitly call dependent target with extracted version
 	@ if [[ ${MAISTRA_VERSION} == ${version}* ]]; \
 	then \
-		echo "test"; \
 		HELM_DIR=${RESOURCES_DIR}/helm/v${version} ISTIO_VERSION=${ISTIO_VERSION} ${SOURCE_DIR}/build/download-charts.sh; \
 	else \
 		$(MAKE) -f $(THIS_FILE) update-remote-maistra-${version}; \

--- a/Makefile
+++ b/Makefile
@@ -91,10 +91,11 @@ SUPPORTED_VERSIONS := 2.0 2.1 2.2 2.3
 
 $(addprefix update-remote-maistra-,$(SUPPORTED_VERSIONS)): update-remote-maistra-%:
 	$(eval version:=$*)
-ifeq "${OFFLINE_BUILD}" "false"
-	git remote set-branches --add ${GIT_UPSTREAM_REMOTE} maistra-${version}
-	git fetch ${GIT_UPSTREAM_REMOTE} maistra-${version}:maistra-${version}
-endif
+	@ if [[ ${OFFLINE_BUILD} == "false" || ${MAISTRA_VERSION} == ${version}* ]]; \
+	then \
+		git remote set-branches --add ${GIT_UPSTREAM_REMOTE} maistra-${version}; \
+		git fetch ${GIT_UPSTREAM_REMOTE} maistra-${version}:maistra-${version}; \
+	fi
 
 $(addprefix update-charts-,$(SUPPORTED_VERSIONS)): update-charts-%:
 	$(eval version:=$*)

--- a/Makefile
+++ b/Makefile
@@ -97,8 +97,8 @@ endif
 .PHONY: update-charts-%
 update-charts-%:
 	$(eval version:=$*)
-	# If we are calling make against current version - download charts.
-	# Otherwise sync from previous branches and explicitly call dependent target with extracted version
+	@# If we are calling make against current version - download charts.
+	@# Otherwise sync from previous branches and explicitly call dependent target with extracted version
 	@ if [[ ${MAISTRA_VERSION} == ${version}* ]]; \
 	then \
 		HELM_DIR=${RESOURCES_DIR}/helm/v${version} ISTIO_VERSION=${ISTIO_VERSION} ${SOURCE_DIR}/build/download-charts.sh; \
@@ -109,10 +109,8 @@ update-charts-%:
 	fi
 
 .PHONY: update-templates-%
-update-templates-%:
+update-templates-%: update-remote-maistra-%
 	$(eval version:=$*)
-	# Has to explicitly call dependent target with extracted version
-	@$(MAKE) -f $(THIS_FILE) update-remote-maistra-${version}
 	git checkout ${GIT_UPSTREAM_REMOTE}/maistra-${version} -- ${SOURCE_DIR}/resources/smcp-templates/v${version}
 	git reset HEAD ${SOURCE_DIR}/resources/smcp-templates/v${version}
 


### PR DESCRIPTION
Instead of duplicating targets for each major version it uses target template where any version can be passed as target's suffix. It also honors special case for creating charts for current version.