### PR TITLE
OSSM-2187 Allow usage of spec.proxy.networking.protocol.autoDetect

### DIFF
--- a/pkg/apis/maistra/conversion/proxy.go
+++ b/pkg/apis/maistra/conversion/proxy.go
@@ -138,9 +138,6 @@ func populateProxyValues(in *v2.ControlPlaneSpec, values map[string]interface{})
 		if proxy.Networking.Protocol != nil && proxy.Networking.Protocol.AutoDetect != nil {
 			autoDetect := proxy.Networking.Protocol.AutoDetect
 			if autoDetect.Timeout != "" {
-				if err := setHelmStringValue(proxyValues, "protocolDetectionTimeout", autoDetect.Timeout); err != nil {
-					return err
-				}
 				if err := setHelmStringValue(meshConfigValues, "protocolDetectionTimeout", autoDetect.Timeout); err != nil {
 					return err
 				}

--- a/pkg/apis/maistra/conversion/proxy_test.go
+++ b/pkg/apis/maistra/conversion/proxy_test.go
@@ -398,11 +398,6 @@ func proxyTestCasesV2(version versions.Version) []conversionTestCase {
 				},
 			},
 			isolatedIstio: v1.NewHelmValues(map[string]interface{}{
-				"global": map[string]interface{}{
-					"proxy": map[string]interface{}{
-						"protocolDetectionTimeout": "500ms",
-					},
-				},
 				"meshConfig": map[string]interface{}{
 					"protocolDetectionTimeout": "500ms",
 				},

--- a/pkg/controller/versions/strategy_v2_2.go
+++ b/pkg/controller/versions/strategy_v2_2.go
@@ -140,27 +140,11 @@ func (v *versionStrategyV2_2) ValidateV2(ctx context.Context, cl client.Client, 
 	allErrors = validateGateways(ctx, meta, spec, cl, allErrors)
 	allErrors = validatePolicyType(spec, v.Ver, allErrors)
 	allErrors = validateTelemetryType(spec, v.Ver, allErrors)
-	allErrors = v.validateProtocolDetection(spec, allErrors)
+	allErrors = validateProtocolDetection(spec, allErrors)
 	allErrors = v.validateRuntime(spec, allErrors)
 	allErrors = v.validateMixerDisabled(spec, allErrors)
 	allErrors = v.validateAddons(spec, allErrors)
 	return NewValidationError(allErrors...)
-}
-
-func (v *versionStrategyV2_2) validateProtocolDetection(spec *v2.ControlPlaneSpec, allErrors []error) []error {
-	if spec.Proxy == nil || spec.Proxy.Networking == nil || spec.Proxy.Networking.Protocol == nil || spec.Proxy.Networking.Protocol.AutoDetect == nil {
-		return allErrors
-	}
-	autoDetect := spec.Proxy.Networking.Protocol.AutoDetect
-	if autoDetect.Inbound != nil && *autoDetect.Inbound {
-		allErrors = append(allErrors, fmt.Errorf("automatic protocol detection is not supported in %s; "+
-			"if specified, spec.proxy.networking.protocol.autoDetect.inbound must be set to false", v.String()))
-	}
-	if autoDetect.Outbound != nil && *autoDetect.Outbound {
-		allErrors = append(allErrors, fmt.Errorf("automatic protocol detection is not supported in %s; "+
-			"if specified, spec.proxy.networking.protocol.autoDetect.outbound must be set to false", v.String()))
-	}
-	return allErrors
 }
 
 func (v *versionStrategyV2_2) validateRuntime(spec *v2.ControlPlaneSpec, allErrors []error) []error {

--- a/pkg/controller/versions/strategy_v2_3.go
+++ b/pkg/controller/versions/strategy_v2_3.go
@@ -126,7 +126,7 @@ func (v *versionStrategyV2_3) ValidateV2(ctx context.Context, cl client.Client, 
 	allErrors = validateGateways(ctx, meta, spec, cl, allErrors)
 	allErrors = validatePolicyType(spec, v.Ver, allErrors)
 	allErrors = validateTelemetryType(spec, v.Ver, allErrors)
-	allErrors = v.validateProtocolDetection(spec, allErrors)
+	allErrors = validateProtocolDetection(spec, allErrors)
 	allErrors = v.validateRuntime(spec, allErrors)
 	allErrors = v.validateMixerDisabled(spec, allErrors)
 	allErrors = v.validateAddons(spec, allErrors)
@@ -163,22 +163,6 @@ func validateGlobal(ctx context.Context, meta *metav1.ObjectMeta, spec *v2.Contr
 					fmt.Errorf("no other SMCPs may be created when a cluster-scoped SMCP exists"))
 			}
 		}
-	}
-	return allErrors
-}
-
-func (v *versionStrategyV2_3) validateProtocolDetection(spec *v2.ControlPlaneSpec, allErrors []error) []error {
-	if spec.Proxy == nil || spec.Proxy.Networking == nil || spec.Proxy.Networking.Protocol == nil || spec.Proxy.Networking.Protocol.AutoDetect == nil {
-		return allErrors
-	}
-	autoDetect := spec.Proxy.Networking.Protocol.AutoDetect
-	if autoDetect.Inbound != nil && *autoDetect.Inbound {
-		allErrors = append(allErrors, fmt.Errorf("automatic protocol detection is not supported in %s; "+
-			"if specified, spec.proxy.networking.protocol.autoDetect.inbound must be set to false", v.String()))
-	}
-	if autoDetect.Outbound != nil && *autoDetect.Outbound {
-		allErrors = append(allErrors, fmt.Errorf("automatic protocol detection is not supported in %s; "+
-			"if specified, spec.proxy.networking.protocol.autoDetect.outbound must be set to false", v.String()))
 	}
 	return allErrors
 }


### PR DESCRIPTION
This removes the 'validation' that was effectively removing support for protocol sniffing and allows usage of the fields in 2.2 and 2.3 control planes. [We previously removed this feature from OSSM 2.0](https://github.com/maistra/istio-operator/pull/614/commits/31bb5cb9b1d335196086baedd24c2d00a3da5a61) because of security concerns, however I cannot find any documentation of these concerns and upstream has been enabling it by default since Istio 1.6, so I consider it safe enough to allow usage. Note that we will still default to disabling it in order not to change behavior in any existing deployments.

We might want to discuss enabling it by default in 2.4
