### PR TITLE
OSSM-2073: Add integration tests for checking sidecar injection in KinD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,3 +244,11 @@ image: check-image-var build collect-resources
 	${CONTAINER_CLI} build --no-cache -t "${IMAGE}" -f ${SOURCE_DIR}/build/Dockerfile --build-arg build_type=${BUILD_TYPE} .
 
 .DEFAULT_GOAL := build
+
+################################################################################
+# run an integration test in KinD
+################################################################################
+.PHONY: test.integration.kind
+test.integration.kind:
+	${SOURCE_DIR}/tests/integration/operator-integ-suite-kind.sh
+

--- a/deploy/examples/maistra_v2_servicemeshcontrolplane_cr_minimal.yaml
+++ b/deploy/examples/maistra_v2_servicemeshcontrolplane_cr_minimal.yaml
@@ -17,7 +17,8 @@ spec:
       name: kiali
       enabled: false
       install: {}
-
+    prometheus:
+      enabled: false
 ---
 
 apiVersion: maistra.io/v1

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,31 @@
+# Maistra Istio Operator Integration Test
+
+This integration test suite is similar to the upstream Istio integration tests. The scripts `lib.sh`, `kind_provisioner.sh` and `istio-integ-suite-kind.sh` are copied from `github.com/maistra/istio` repo.
+
+## How to Run it Manually
+
+1. Create a builder container:
+
+```
+$ docker pull quay.io/maistra-dev/maistra-builder:2.4
+$ docker run -d -t --rm \
+    --name test \
+    --privileged \
+    -v /var/lib/docker \
+    quay.io/maistra-dev/maistra-builder:2.4 \
+    entrypoint tail -f /dev/null
+```
+
+2. Copy this istio-operator source code into the container
+
+```
+$ cd $(git rev-parse --show-toplevel)
+$ docker cp . test:/work
+```
+
+3. Run `operator-integ-suite-kind.sh` in the builder container
+
+```
+$ docker exec -it test /bin/bash
+(root@) make test.integration.kind
+```

--- a/tests/integration/build-operator.sh
+++ b/tests/integration/build-operator.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+
+# Copyright 2022 Red Hat, Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Exit immediately for non zero status
+set -e
+# Check unset variables
+set -u
+# Print commands
+set -x
+
+WD=$(dirname "$0")
+WD=$(cd "$WD"; pwd)
+
+# build and push operator image
+build_operator_image() { # compile operator source and push operator image
+    local TAG
+    TAG="${TAG:-$(git rev-parse HEAD)}"
+    local BUILDER_CLI="${BUILDER_CLI:-docker}"
+    # var name IMAGE is in kind provisioner
+    export OPERATOR_IMAGE="${OPERATOR_IMAGE:-localhost:5000/istio-operator-integ}:${TAG}"
+
+    echo "build and push operator image..."
+    echo
+    cd "$(git rev-parse --show-toplevel)"
+    make image \
+        IMAGE="${OPERATOR_IMAGE}"
+    "${BUILDER_CLI}" push "${OPERATOR_IMAGE}"
+    cd "$WD"
+}
+
+build_operator_image

--- a/tests/integration/config/default.yaml
+++ b/tests/integration/config/default.yaml
@@ -1,0 +1,35 @@
+# This configs KinD to spin up a k8s cluster with mixed protocol LB support and GRPCContainerProbe enabled
+# This should be used to create K8s clusters with versions >= 1.23
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+featureGates:
+  MixedProtocolLBService: true
+  GRPCContainerProbe: true
+kubeadmConfigPatches:
+  - |
+    apiVersion: kubeadm.k8s.io/v1beta2
+    kind: ClusterConfiguration
+    metadata:
+      name: config
+    etcd:
+      local:
+        # Run etcd in a tmpfs (in RAM) for performance improvements
+        dataDir: /tmp/kind-cluster-etcd
+    # We run single node, drop leader election to reduce overhead
+    controllerManagerExtraArgs:
+      leader-elect: "false"
+    schedulerExtraArgs:
+      leader-elect: "false"
+    apiServer:
+      extraArgs:
+        "service-account-issuer": "kubernetes.default.svc"
+        "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
+      endpoint = ["http://kind-registry:5000"]
+networking:
+  # MAISTRA specific:
+  # our prow cluster uses serviceSubnet 10.96.0.0/12, so the kind cluster must use other subnet to correctly route traffic;
+  # in this case, address 10.224.0.0 is chosen randomly from available set of subnets.
+  serviceSubnet: "10.224.0.0/12"

--- a/tests/integration/config/topology/singlecluster.json
+++ b/tests/integration/config/topology/singlecluster.json
@@ -1,0 +1,9 @@
+[
+  {
+    "kind": "Kubernetes",
+    "clusterName": "primary",
+    "podSubnet": "10.10.0.0/16",
+    "svcSubnet": "10.224.0.0/12",
+    "network": "network-1"
+  }
+]

--- a/tests/integration/deploy-operator.sh
+++ b/tests/integration/deploy-operator.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+
+# Copyright 2022 Red Hat, Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Exit immediately for non zero status
+set -e
+# Check unset variables
+set -u
+# Print commands
+set -x
+
+install-operator-k8s() { # installs istio-operator on kubernetes
+    local ROOT
+    ROOT="$(git rev-parse --show-toplevel)"
+    local TAG
+    TAG="${TAG:-$(git rev-parse HEAD)}"
+    local NS="${NS:-openshift-operators}"
+    # var name IMAGE is in kind provisioner
+    local OPERATOR_IMAGE="${OPERATOR_IMAGE:-localhost:5000/istio-operator-integ}:${TAG}"
+    local ISTIO_CNI_IMAGE_NAME="${ISTIO_CNI_IMAGE_NAME:-quay.io/maistra-dev/istio-cni-ubi8-integ:latest}"
+    local PILOT_IMAGE_NAME="${PILOT_IMAGE_NAME:-quay.io/maistra-dev/pilot-ubi8-integ:latest}"
+    local PROXY_IMAGE_NAME="${PROXY_IMAGE_NAME:-quay.io/maistra-dev/proxyv2-ubi8-integ:latest}"
+    # MAISTRA_VERSION value is in Makefile
+
+    echo "--------------------------------"
+    echo "Installing operator"
+    echo "Using image $OPERATOR_IMAGE"
+    echo "--------------------------------"
+
+    kubectl get ns "$NS" >/dev/null 2>&1 || kubectl create namespace "$NS"
+
+    kubectl apply -f "${ROOT}/manifests-maistra/${MAISTRA_VERSION}/servicemeshcontrolplanes.crd.yaml"
+    kubectl apply -f "${ROOT}/manifests-maistra/${MAISTRA_VERSION}/servicemeshmemberrolls.crd.yaml"
+    kubectl apply -f "${ROOT}/manifests-maistra/${MAISTRA_VERSION}/servicemeshmembers.crd.yaml"
+
+    sed -e "s/namespace: istio-operator/namespace: $NS/g" "${ROOT}/deploy/src/rbac.yaml" | kubectl apply -n "$NS" -f -
+    sed -e "s/namespace: istio-operator/namespace: $NS/g" "${ROOT}/deploy/src/serviceaccount.yaml" | kubectl apply -n "$NS" -f -
+    sed -e "s/namespace: istio-operator/namespace: $NS/g" "${ROOT}/deploy/src/service.yaml" | kubectl apply -n "$NS" -f -
+
+    openssl req -x509 -newkey rsa:4096 -keyout /tmp/key.pem -out /tmp/cert.pem -sha256 -days 365 -nodes -subj "/CN=istio-operator" -addext "subjectAltName = DNS:maistra-admission-controller.$NS.svc"
+
+    kubectl create -n "$NS" secret tls maistra-operator-serving-cert --key=/tmp/key.pem --cert=/tmp/cert.pem
+    kubectl create -n "$NS" configmap maistra-operator-cabundle --from-file=service-ca.crt=/tmp/cert.pem
+
+    sed -e "s@quay.io/maistra/istio-ubi8-operator:${MAISTRA_VERSION}@${OPERATOR_IMAGE}@g" \
+        -e "s@namespace: istio-operator@namespace: $NS@g" \
+        -e "s@quay.io/maistra/istio-cni-ubi8:${MAISTRA_VERSION}@${ISTIO_CNI_IMAGE_NAME}@g" \
+        -e "s@quay.io/maistra/pilot-ubi8:${MAISTRA_VERSION}@${PILOT_IMAGE_NAME}@g" \
+        -e "s@quay.io/maistra/proxyv2-ubi8:${MAISTRA_VERSION}@${PROXY_IMAGE_NAME}@g" \
+        "${ROOT}/deploy/src/deployment-maistra.yaml" \
+        | tee "/tmp/deployment.yaml"
+        kubectl apply -f /tmp/deployment.yaml
+
+    # check istio-operator pod running
+    kubectl wait --for condition=Ready -n "${NS}" pod -l name=istio-operator --timeout 180s
+}
+
+install-operator-k8s

--- a/tests/integration/istio-integ-suite-kind.sh
+++ b/tests/integration/istio-integ-suite-kind.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+
+
+# Copyright 2022 Red Hat, Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Usage: ./integ-suite-kind.sh TARGET
+
+WD=$(dirname "$0")
+WD=$(cd "$WD"; pwd)
+
+# Exit immediately for non zero status
+set -e
+# Check unset variables
+set -u
+# Print commands
+set -x
+
+# shellcheck source=tests/integration/lib.sh
+source "${WD}/lib.sh"
+setup_and_export_git_sha
+
+# shellcheck source=tests/integration/kind_provisioner.sh
+source "${WD}/kind_provisioner.sh"
+
+TOPOLOGY=SINGLE_CLUSTER
+NODE_IMAGE="gcr.io/istio-testing/kind-node:v1.24.0-0.13.0"
+KIND_CONFIG=""
+CLUSTER_TOPOLOGY_CONFIG_FILE="${WD}/config/topology/singlecluster.json"
+
+export FAST_VM_BUILDS=true
+export ISTIO_DOCKER_BUILDER=docker
+
+PARAMS=()
+
+while (( "$#" )); do
+  case "$1" in
+    # Node images can be found at https://github.com/kubernetes-sigs/kind/releases
+    # For example, kindest/node:v1.14.0
+    --node-image)
+      NODE_IMAGE=$2
+      shift 2
+    ;;
+    # Config for enabling different Kubernetes features in KinD (see prow/config{endpointslice.yaml,trustworthy-jwt.yaml}).
+    --kind-config)
+    KIND_CONFIG=$2
+    shift 2
+    ;;
+    --skip-setup)
+      SKIP_SETUP=true
+      shift
+    ;;
+    --skip-cleanup)
+      SKIP_CLEANUP=true
+      shift
+    ;;
+    --skip-build)
+      SKIP_BUILD=true
+      shift
+    ;;
+    --manual)
+      MANUAL=true
+      shift
+    ;;
+    --topology)
+      case $2 in
+        # TODO(landow) get rid of MULTICLUSTER_SINGLE_NETWORK after updating Prow job
+        SINGLE_CLUSTER | MULTICLUSTER_SINGLE_NETWORK | MULTICLUSTER )
+          TOPOLOGY=$2
+          echo "Running with topology ${TOPOLOGY}"
+          ;;
+        *)
+          echo "Error: Unsupported topology ${TOPOLOGY}" >&2
+          exit 1
+          ;;
+      esac
+      shift 2
+    ;;
+    -*)
+      echo "Error: Unsupported flag $1" >&2
+      exit 1
+      ;;
+    *) # preserve positional arguments
+      PARAMS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+echo "Checking CPU..."
+grep 'model' /proc/cpuinfo
+
+# Default IP family of the cluster is IPv4
+export IP_FAMILY="${IP_FAMILY:-ipv4}"
+
+# LoadBalancer in Kind is supported using metallb
+export TEST_ENV=kind-metallb
+
+# See https://kind.sigs.k8s.io/docs/user/quick-start/#loading-an-image-into-your-cluster
+export PULL_POLICY=IfNotPresent
+
+# We run a local-registry in a docker container that KinD nodes pull from
+# These values are must match what is in config/trustworthy-jwt.yaml
+export KIND_REGISTRY_NAME="kind-registry"
+export KIND_REGISTRY_PORT="5000"
+export KIND_REGISTRY="localhost:${KIND_REGISTRY_PORT}"
+
+export HUB=${HUB:-"istio-testing"}
+export TAG="${TAG:-"istio-testing"}"
+
+# If we're not intending to pull from an actual remote registry, use the local kind registry
+if [[ -z "${SKIP_BUILD:-}" ]]; then
+  HUB="${KIND_REGISTRY}"
+  export HUB
+fi
+
+# Setup junit report and verbose logging
+export T="${T:-"-v -count=1"}"
+export CI="true"
+
+export ARTIFACTS="${ARTIFACTS:-$(mktemp -d)}"
+#trace "init" make init
+
+if [[ -z "${SKIP_SETUP:-}" ]]; then
+  export DEFAULT_CLUSTER_YAML="${WD}/config/default.yaml"
+
+  if [[ "${TOPOLOGY}" == "SINGLE_CLUSTER" ]]; then
+    trace "setup kind cluster" setup_kind_cluster_retry "${CLUSTER_NAME}" "${NODE_IMAGE}" "${KIND_CONFIG}"
+  else
+    trace "load cluster topology" load_cluster_topology "${CLUSTER_TOPOLOGY_CONFIG_FILE}"
+    trace "setup kind clusters" setup_kind_clusters "${NODE_IMAGE}" "${IP_FAMILY}"
+
+    TOPOLOGY_JSON=$(cat "${CLUSTER_TOPOLOGY_CONFIG_FILE}")
+    for i in $(seq 0 $((${#CLUSTER_NAMES[@]} - 1))); do
+      CLUSTER="${CLUSTER_NAMES[i]}"
+      KCONFIG="${KUBECONFIGS[i]}"
+      TOPOLOGY_JSON=$(set_topology_value "${TOPOLOGY_JSON}" "${CLUSTER}" "meta.kubeconfig" "${KCONFIG}")
+    done
+    RUNTIME_TOPOLOGY_CONFIG_FILE="${ARTIFACTS}/topology-config.json"
+    echo "${TOPOLOGY_JSON}" > "${RUNTIME_TOPOLOGY_CONFIG_FILE}"
+
+    export INTEGRATION_TEST_TOPOLOGY_FILE
+    INTEGRATION_TEST_TOPOLOGY_FILE="${RUNTIME_TOPOLOGY_CONFIG_FILE}"
+
+    export INTEGRATION_TEST_KUBECONFIG
+    INTEGRATION_TEST_KUBECONFIG=NONE
+  fi
+fi
+
+if [[ -z "${SKIP_BUILD:-}" ]]; then
+  trace "setup kind registry" setup_kind_registry
+  ###trace "build images" build_images "${PARAMS[*]}"
+fi
+
+# If a variant is defined, update the tag accordingly
+if [[ -n "${VARIANT:-}" ]]; then
+  export TAG="${TAG}-${VARIANT}"
+fi
+
+# Run the test target if provided.
+if [[ -n "${PARAMS:-}" ]]; then
+  trace "test" make "${PARAMS[*]}"
+fi
+
+# Check if the user is running the clusters in manual mode.
+if [[ -n "${MANUAL:-}" ]]; then
+  echo "Running cluster(s) in manual mode. Press any key to shutdown and exit..."
+  read -rsn1
+  exit 0
+fi

--- a/tests/integration/kind_provisioner.sh
+++ b/tests/integration/kind_provisioner.sh
@@ -1,0 +1,435 @@
+#!/bin/bash
+
+# WARNING: DO NOT EDIT, THIS FILE IS PROBABLY A COPY
+#
+# The original version of this file is located in the https://github.com/istio/common-files repo.
+# If you're looking at this file in a different repo and want to make a change, please go to the
+# common-files repo, make the change there and check it in. Then come back to this repo and run
+# "make update-common".
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -x
+
+# The purpose of this file is to unify prow/lib.sh in both istio and istio.io
+# repos to avoid code duplication.
+
+####################################################################
+#################   COMMON SECTION   ###############################
+####################################################################
+
+# DEFAULT_KIND_IMAGE is used to set the Kubernetes version for KinD unless overridden in params to setup_kind_cluster(s)
+DEFAULT_KIND_IMAGE="gcr.io/istio-testing/kind-node:v1.21.1"
+
+# COMMON_SCRIPTS contains the directory this file is in.
+COMMON_SCRIPTS=$(dirname "${BASH_SOURCE:-$0}")
+
+function log() {
+  echo -e "$(date -u '+%Y-%m-%dT%H:%M:%S.%NZ')\t$*"
+}
+
+function retry() {
+  local n=1
+  local max=5
+  local delay=5
+  while true; do
+    "$@" && break
+    if [[ $n -lt $max ]]; then
+      ((n++))
+      log "Command failed. Attempt $n/$max:"
+      sleep $delay;
+    else
+      log "The command has failed after $n attempts."  >&2
+      return 2
+    fi
+  done
+}
+
+# load_cluster_topology function reads cluster configuration topology file and
+# sets up environment variables used by other functions. So this should be called
+# before anything else.
+#
+# Note: Cluster configuration topology file specifies basic configuration of each
+# KinD cluster like its name, pod and service subnets and network_id. If two cluster
+# have the same network_id then they belong to the same network and their pods can
+# talk to each other directly.
+#
+# [{ "cluster_name": "cluster1","pod_subnet": "10.10.0.0/16","svc_subnet": "10.255.10.0/24","network_id": "0" },
+#  { "cluster_name": "cluster2","pod_subnet": "10.20.0.0/16","svc_subnet": "10.255.20.0/24","network_id": "0" },
+#  { "cluster_name": "cluster3","pod_subnet": "10.30.0.0/16","svc_subnet": "10.255.30.0/24","network_id": "1" }]
+function load_cluster_topology() {
+  CLUSTER_TOPOLOGY_CONFIG_FILE="${1}"
+
+  if [[ ! -f "${CLUSTER_TOPOLOGY_CONFIG_FILE}" ]]; then
+    log 'cluster topology configuration file is not specified'
+    exit 1
+  fi
+
+  export CLUSTER_NAMES
+  export CLUSTER_POD_SUBNETS
+  export CLUSTER_SVC_SUBNETS
+  export CLUSTER_NETWORK_ID
+
+  KUBE_CLUSTERS=$(jq '.[] | select(.kind == "Kubernetes" or .kind == null)' "${CLUSTER_TOPOLOGY_CONFIG_FILE}")
+
+  while read -r value; do
+    CLUSTER_NAMES+=("$value")
+  done < <(echo "${KUBE_CLUSTERS}" | jq -r '.cluster_name // .clusterName')
+
+  while read -r value; do
+    CLUSTER_POD_SUBNETS+=("$value")
+  done < <(echo "${KUBE_CLUSTERS}" | jq -r '.pod_subnet // .podSubnet')
+
+  while read -r value; do
+    CLUSTER_SVC_SUBNETS+=("$value")
+  done < <(echo "${KUBE_CLUSTERS}" | jq -r '.svc_subnet // .svcSubnet')
+
+  while read -r value; do
+    CLUSTER_NETWORK_ID+=("$value")
+  done < <(echo "${KUBE_CLUSTERS}" | jq -r '.network_id // .network')
+
+  export NUM_CLUSTERS
+  NUM_CLUSTERS=$(echo "${KUBE_CLUSTERS}" | jq -s 'length')
+
+  echo "${CLUSTER_NAMES[@]}"
+  echo "${CLUSTER_POD_SUBNETS[@]}"
+  echo "${CLUSTER_SVC_SUBNETS[@]}"
+  echo "${CLUSTER_NETWORK_ID[@]}"
+  echo "${NUM_CLUSTERS}"
+}
+
+#####################################################################
+###################   SINGLE-CLUSTER SECTION   ######################
+#####################################################################
+
+# cleanup_kind_cluster takes a single parameter NAME
+# and deletes the KinD cluster with that name
+function cleanup_kind_cluster() {
+  echo "Test exited with exit code $?."
+  NAME="${1}"
+  kind export logs --name "${NAME}" "${ARTIFACTS}/kind" -v9 || true
+  if [[ -z "${SKIP_CLEANUP:-}" ]]; then
+    echo "Cleaning up kind cluster"
+    kind delete cluster --name "${NAME}" -v9 || true
+  fi
+}
+
+# check_default_cluster_yaml checks the presence of default cluster YAML
+# It returns 1 if it is not present
+function check_default_cluster_yaml() {
+  if [[ -z "${DEFAULT_CLUSTER_YAML}" ]]; then
+    echo 'DEFAULT_CLUSTER_YAML file must be specified. Exiting...'
+    return 1
+  fi
+}
+
+function setup_kind_cluster_retry() {
+  retry setup_kind_cluster "$@"
+}
+
+# setup_kind_cluster creates new KinD cluster with given name, image and configuration
+# 1. NAME: Name of the Kind cluster (optional)
+# 2. IMAGE: Node image used by KinD (optional)
+# 3. CONFIG: KinD cluster configuration YAML file. If not specified then DEFAULT_CLUSTER_YAML is used
+# 4. NOMETALBINSTALL: Dont install matllb if set.
+# This function returns 0 when everything goes well, or 1 otherwise
+# If Kind cluster was already created then it would be cleaned up in case of errors
+function setup_kind_cluster() {
+  NAME="${1:-istio-testing}"
+  IMAGE="${2:-"${DEFAULT_KIND_IMAGE}"}"
+  CONFIG="${3:-}"
+  NOMETALBINSTALL="${4:-}"
+
+  check_default_cluster_yaml
+
+  # Delete any previous KinD cluster
+  echo "Deleting previous KinD cluster with name=${NAME}"
+  if ! (kind delete cluster --name="${NAME}" -v9) > /dev/null; then
+    echo "No existing kind cluster with name ${NAME}. Continue..."
+  fi
+
+  # explicitly disable shellcheck since we actually want $NAME to expand now
+  # shellcheck disable=SC2064
+  trap "cleanup_kind_cluster ${NAME}" EXIT
+
+    # If config not explicitly set, then use defaults
+  if [[ -z "${CONFIG}" ]]; then
+    # Kubernetes 1.15+
+    CONFIG=${DEFAULT_CLUSTER_YAML}
+    # Configure the cluster IP Family only for default configs
+    if [ "${IP_FAMILY}" != "ipv4" ]; then
+      grep "ipFamily: ${IP_FAMILY}" "${CONFIG}" || \
+      cat <<EOF >> "${CONFIG}"
+networking:
+  ipFamily: ${IP_FAMILY}
+EOF
+    else
+      grep 'serviceSubnet:' "${CONFIG}" || \
+      cat <<EOF >> "${CONFIG}"
+networking:
+  # MAISTRA specific:
+  # our prow cluster uses serviceSubnet 10.96.0.0/12, so the kind cluster must use other subnet to correctly route traffic;
+  # in this case, address 10.224.0.0 is chosen randomly from available set of subnets.
+  serviceSubnet: "10.224.0.0/12"
+EOF
+    fi
+  fi
+
+  # Create KinD cluster
+  if ! (kind create cluster --name="${NAME}" --config "${CONFIG}" -v4 --retain --image "${IMAGE}" --wait=180s); then
+    echo "Could not setup KinD environment. Something wrong with KinD setup. Exporting logs."
+    return 9
+  fi
+  # Workaround kind issue causing taints to not be removed in 1.24
+  kubectl taint nodes "${NAME}"-control-plane node-role.kubernetes.io/control-plane- || true
+
+  # Install Metallb if not set to install explicitly
+  if [[ -z "${NOMETALBINSTALL}" ]]; then
+    retry install_metallb ""
+  fi
+
+  # IPv6 clusters need some CoreDNS changes in order to work in CI:
+  # Istio CI doesn't offer IPv6 connectivity, so CoreDNS should be configured
+  # to work in an offline environment:
+  # https://github.com/coredns/coredns/issues/2494#issuecomment-457215452
+  # CoreDNS should handle those domains and answer with NXDOMAIN instead of SERVFAIL
+  # otherwise pods stops trying to resolve the domain.
+  if [ "${IP_FAMILY}" = "ipv6" ] || [ "${IP_FAMILY}" = "dual" ]; then
+    # Get the current config
+    original_coredns=$(kubectl get -o yaml -n=kube-system configmap/coredns)
+    echo "Original CoreDNS config:"
+    echo "${original_coredns}"
+    # Patch it
+    fixed_coredns=$(
+      printf '%s' "${original_coredns}" | sed \
+        -e 's/^.*kubernetes cluster\.local/& internal/' \
+        -e '/^.*upstream$/d' \
+        -e '/^.*fallthrough.*$/d' \
+        -e '/^.*forward . \/etc\/resolv.conf$/d' \
+        -e '/^.*loop$/d' \
+    )
+    echo "Patched CoreDNS config:"
+    echo "${fixed_coredns}"
+    printf '%s' "${fixed_coredns}" | kubectl apply -f -
+  fi
+
+  # On Ubuntu Jammy, the trap runs when this function exits. Remove trap to prevent
+  # cluster shutdown here.
+  trap EXIT
+}
+
+###############################################################################
+####################    MULTICLUSTER SECTION    ###############################
+###############################################################################
+
+# Cleans up the clusters created by setup_kind_clusters
+# It expects CLUSTER_NAMES to be present which means that
+# load_cluster_topology must be called before invoking it
+function cleanup_kind_clusters() {
+  echo "Test exited with exit code $?."
+  for c in "${CLUSTER_NAMES[@]}"; do
+    cleanup_kind_cluster "${c}"
+  done
+}
+
+# setup_kind_clusters sets up a given number of kind clusters with given topology
+# as specified in cluster topology configuration file.
+# 1. IMAGE = docker image used as node by KinD
+# 2. IP_FAMILY = either ipv4 or ipv6
+#
+# NOTE: Please call load_cluster_topology before calling this method as it expects
+# cluster topology information to be loaded in advance
+function setup_kind_clusters() {
+  IMAGE="${1:-"${DEFAULT_KIND_IMAGE}"}"
+  KUBECONFIG_DIR="${ARTIFACTS:-$(mktemp -d)}/kubeconfig"
+  IP_FAMILY="${2:-ipv4}"
+
+  check_default_cluster_yaml
+
+  # Trap replaces any previous trap's, so we need to explicitly cleanup clusters here
+  trap cleanup_kind_clusters EXIT
+
+  function deploy_kind() {
+    IDX="${1}"
+    CLUSTER_NAME="${CLUSTER_NAMES[$IDX]}"
+    CLUSTER_POD_SUBNET="${CLUSTER_POD_SUBNETS[$IDX]}"
+    CLUSTER_SVC_SUBNET="${CLUSTER_SVC_SUBNETS[$IDX]}"
+    CLUSTER_YAML="${ARTIFACTS}/config-${CLUSTER_NAME}.yaml"
+    if [ ! -f "${CLUSTER_YAML}" ]; then
+      cp "${DEFAULT_CLUSTER_YAML}" "${CLUSTER_YAML}"
+      cat <<EOF >> "${CLUSTER_YAML}"
+networking:
+  podSubnet: ${CLUSTER_POD_SUBNET}
+  serviceSubnet: ${CLUSTER_SVC_SUBNET}
+EOF
+    fi
+
+    CLUSTER_KUBECONFIG="${KUBECONFIG_DIR}/${CLUSTER_NAME}"
+
+    # Create the clusters.
+    KUBECONFIG="${CLUSTER_KUBECONFIG}" setup_kind_cluster "${CLUSTER_NAME}" "${IMAGE}" "${CLUSTER_YAML}" "true"
+
+    # Kind currently supports getting a kubeconfig for internal or external usage. To simplify our tests,
+    # its much simpler if we have a single kubeconfig that can be used internally and externally.
+    # To do this, we can replace the server with the IP address of the docker container
+    # https://github.com/kubernetes-sigs/kind/issues/1558 tracks this upstream
+    CONTAINER_IP=$(docker inspect "${CLUSTER_NAME}-control-plane" --format "{{ .NetworkSettings.Networks.kind.IPAddress }}")
+    n=0
+    until [ $n -ge 10 ]; do
+      n=$((n+1))
+      kind get kubeconfig --name "${CLUSTER_NAME}" --internal | \
+        sed "s/${CLUSTER_NAME}-control-plane/${CONTAINER_IP}/g" > "${CLUSTER_KUBECONFIG}"
+      [ -s "${CLUSTER_KUBECONFIG}" ] && break
+      sleep 3
+    done
+
+    # Enable core dumps
+    retry docker exec "${CLUSTER_NAME}"-control-plane bash -c "sysctl -w kernel.core_pattern=/var/lib/istio/data/core.proxy && ulimit -c unlimited"
+  }
+
+  # Now deploy the specified number of KinD clusters and
+  # wait till they are provisioned successfully.
+  declare -a DEPLOY_KIND_JOBS
+  for i in "${!CLUSTER_NAMES[@]}"; do
+    deploy_kind "${i}" & DEPLOY_KIND_JOBS+=("${!}")
+  done
+
+  for pid in "${DEPLOY_KIND_JOBS[@]}"; do
+    wait "${pid}" || exit 1
+  done
+
+  # Install MetalLB for LoadBalancer support. Must be done synchronously since METALLB_IPS is shared.
+  # and keep track of the list of Kubeconfig files that will be exported later
+  export KUBECONFIGS
+  for CLUSTER_NAME in "${CLUSTER_NAMES[@]}"; do
+    KUBECONFIG_FILE="${KUBECONFIG_DIR}/${CLUSTER_NAME}"
+    if [[ ${NUM_CLUSTERS} -gt 1 ]]; then
+      retry install_metallb "${KUBECONFIG_FILE}"
+    fi
+    KUBECONFIGS+=("${KUBECONFIG_FILE}")
+  done
+
+  ITER_END=$((NUM_CLUSTERS-1))
+  for i in $(seq 0 "$ITER_END"); do
+    for j in $(seq 0 "$ITER_END"); do
+      if [[ "${j}" -gt "${i}" ]]; then
+        NETWORK_ID_I="${CLUSTER_NETWORK_ID[i]}"
+        NETWORK_ID_J="${CLUSTER_NETWORK_ID[j]}"
+        if [[ "$NETWORK_ID_I" == "$NETWORK_ID_J" ]]; then
+          POD_TO_POD_AND_SERVICE_CONNECTIVITY=1
+        else
+          POD_TO_POD_AND_SERVICE_CONNECTIVITY=0
+        fi
+        connect_kind_clusters \
+          "${CLUSTER_NAMES[i]}" "${KUBECONFIGS[i]}" \
+          "${CLUSTER_NAMES[j]}" "${KUBECONFIGS[j]}" \
+          "${POD_TO_POD_AND_SERVICE_CONNECTIVITY}"
+      fi
+    done
+  done
+}
+
+function connect_kind_clusters() {
+  C1="${1}"
+  C1_KUBECONFIG="${2}"
+  C2="${3}"
+  C2_KUBECONFIG="${4}"
+  POD_TO_POD_AND_SERVICE_CONNECTIVITY="${5}"
+
+  C1_NODE="${C1}-control-plane"
+  C2_NODE="${C2}-control-plane"
+  C1_DOCKER_IP=$(docker inspect -f "{{ .NetworkSettings.Networks.kind.IPAddress }}" "${C1_NODE}")
+  C2_DOCKER_IP=$(docker inspect -f "{{ .NetworkSettings.Networks.kind.IPAddress }}" "${C2_NODE}")
+  if [ "${POD_TO_POD_AND_SERVICE_CONNECTIVITY}" -eq 1 ]; then
+    # Set up routing rules for inter-cluster direct pod to pod & service communication
+    C1_POD_CIDR=$(KUBECONFIG="${C1_KUBECONFIG}" kubectl get node -ojsonpath='{.items[0].spec.podCIDR}')
+    C2_POD_CIDR=$(KUBECONFIG="${C2_KUBECONFIG}" kubectl get node -ojsonpath='{.items[0].spec.podCIDR}')
+    C1_SVC_CIDR=$(KUBECONFIG="${C1_KUBECONFIG}" kubectl cluster-info dump | sed -n 's/^.*--service-cluster-ip-range=\([^"]*\).*$/\1/p' | head -n 1)
+    C2_SVC_CIDR=$(KUBECONFIG="${C2_KUBECONFIG}" kubectl cluster-info dump | sed -n 's/^.*--service-cluster-ip-range=\([^"]*\).*$/\1/p' | head -n 1)
+    docker exec "${C1_NODE}" ip route add "${C2_POD_CIDR}" via "${C2_DOCKER_IP}"
+    docker exec "${C1_NODE}" ip route add "${C2_SVC_CIDR}" via "${C2_DOCKER_IP}"
+    docker exec "${C2_NODE}" ip route add "${C1_POD_CIDR}" via "${C1_DOCKER_IP}"
+    docker exec "${C2_NODE}" ip route add "${C1_SVC_CIDR}" via "${C1_DOCKER_IP}"
+  fi
+}
+
+function install_metallb() {
+  KUBECONFIG="${1}"
+  kubectl create ns metallb-system
+  kubectl apply --kubeconfig="$KUBECONFIG" -f "${COMMON_SCRIPTS}/metallb.yaml"
+  kubectl create --kubeconfig="$KUBECONFIG" secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
+
+  if [ -z "${METALLB_IPS4[*]}" ]; then
+    # Take IPs from the end of the docker kind network subnet to use for MetalLB IPs
+    DOCKER_KIND_SUBNET="$(docker inspect kind | jq '.[0].IPAM.Config[0].Subnet' -r)"
+    METALLB_IPS4=()
+    while read -r ip; do
+      METALLB_IPS4+=("$ip")
+    done < <(cidr_to_ips "$DOCKER_KIND_SUBNET" | tail -n 100)
+    METALLB_IPS6=()
+    if [[ "$(docker inspect kind | jq '.[0].IPAM.Config | length' -r)" == 2 ]]; then
+      # Two configs? Must be dual stack.
+      DOCKER_KIND_SUBNET="$(docker inspect kind | jq '.[0].IPAM.Config[1].Subnet' -r)"
+      while read -r ip; do
+        METALLB_IPS6+=("$ip")
+      done < <(cidr_to_ips "$DOCKER_KIND_SUBNET" | tail -n 100)
+    fi
+  fi
+
+  # Give this cluster of those IPs
+  RANGE="["
+  for i in {0..9}; do
+    RANGE+="${METALLB_IPS4[1]},"
+    METALLB_IPS4=("${METALLB_IPS4[@]:1}")
+    if [[ "${#METALLB_IPS6[@]}" != 0 ]]; then
+      RANGE+="${METALLB_IPS6[1]},"
+      METALLB_IPS6=("${METALLB_IPS6[@]:1}")
+    fi
+  done
+  RANGE="${RANGE%?}]"
+
+  echo 'apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses: '"$RANGE" | kubectl apply --kubeconfig="$KUBECONFIG" -f -
+}
+
+function cidr_to_ips() {
+    CIDR="$1"
+    # cidr_to_ips returns a list of single IPs from a CIDR. We skip 1000 (since they are likely to be allocated
+    # already to other services), then pick the next 100.
+    python3 - <<EOF
+from ipaddress import ip_network;
+from itertools import islice;
+[print(str(ip) + "/" + str(ip.max_prefixlen)) for ip in islice(ip_network('$CIDR').hosts(), 1000, 1100)]
+EOF
+}
+
+function ips_to_cidrs() {
+  IP_RANGE_START="$1"
+  IP_RANGE_END="$2"
+  python3 - <<EOF
+from ipaddress import summarize_address_range, IPv4Address
+[ print(n.compressed) for n in summarize_address_range(IPv4Address(u'$IP_RANGE_START'), IPv4Address(u'$IP_RANGE_END')) ]
+EOF
+}

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+
+# Copyright 2018 Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function date_cmd() {
+  case "$(uname)" in
+    "Darwin")
+      [ -z "$(which gdate)" ] && echo "gdate is required for OSX. Try installing coreutils from MacPorts or Brew."
+      gdate "$@"
+      ;;
+    *)
+      date "$@"
+      ;;
+  esac
+}
+
+# Output a message, with a timestamp matching istio log format
+function log() {
+  echo -e "$(date_cmd -u '+%Y-%m-%dT%H:%M:%S.%NZ')\t$*"
+}
+
+# Trace runs the provided command and records additional timing information
+# NOTE: to avoid spamming the logs, we disable xtrace and re-enable it before executing the function
+# and after completion. If xtrace was never set, this will result in xtrace being enabled.
+# Ideally we would restore the old xtrace setting, but I don't think its possible to do that without also log-spamming
+# If we need to call it from a context without xtrace we can just make a new function.
+function trace() {
+  { set +x; } 2>/dev/null
+  log "Running '${1}'"
+  start="$(date_cmd -u +%s.%N)"
+  { set -x; } 2>/dev/null
+
+  "${@:2}"
+
+  { set +x; } 2>/dev/null
+  elapsed=$(date_cmd +%s.%N --date="$start seconds ago" )
+  log "Command '${1}' complete in ${elapsed}s"
+  # Write to YAML file as well for easy reading by tooling
+  echo "'${1}': $elapsed" >> "${ARTIFACTS}/trace.yaml"
+  { set -x; } 2>/dev/null
+}
+
+function setup_gcloud_credentials() {
+  if [[ $(command -v gcloud) ]]; then
+    gcloud auth configure-docker -q
+  elif [[ $(command -v docker-credential-gcr) ]]; then
+    docker-credential-gcr configure-docker
+  else
+    echo "No credential helpers found, push to docker may not function properly"
+  fi
+}
+
+function setup_and_export_git_sha() {
+  if [[ -n "${CI:-}" ]]; then
+
+    if [ -z "${PULL_PULL_SHA:-}" ]; then
+      if [ -z "${PULL_BASE_SHA:-}" ]; then
+        GIT_SHA="$(git rev-parse --verify HEAD)"
+        export GIT_SHA
+      else
+        export GIT_SHA="${PULL_BASE_SHA}"
+      fi
+    else
+      export GIT_SHA="${PULL_PULL_SHA}"
+    fi
+  else
+    # Use the current commit.
+    GIT_SHA="$(git rev-parse --verify HEAD)"
+    export GIT_SHA
+  fi
+  GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+  export GIT_BRANCH
+  #setup_gcloud_credentials
+}
+
+# Download and unpack istio release artifacts.
+function download_untar_istio_release() {
+  local url_path=${1}
+  local tag=${2}
+  local dir=${3:-.}
+  # Download artifacts
+  LINUX_DIST_URL="${url_path}/istio-${tag}-linux.tar.gz"
+
+  wget  -q "${LINUX_DIST_URL}" -P "${dir}"
+  tar -xzf "${dir}/istio-${tag}-linux.tar.gz" -C "${dir}"
+}
+
+function buildx-create() {
+  export DOCKER_CLI_EXPERIMENTAL=enabled
+  if ! docker buildx ls | grep -q container-builder; then
+    docker buildx create --driver-opt network=host,image=gcr.io/istio-testing/buildkit:v0.9.2 --name container-builder --buildkitd-flags="--debug"
+    # Pre-warm the builder. If it fails, fetch logs, but continue
+    docker buildx inspect --bootstrap container-builder || docker logs buildx_buildkit_container-builder0 || true
+  fi
+  docker buildx use container-builder
+}
+
+function build_images() {
+  SELECT_TEST="${1}"
+
+  # Build just the images needed for tests
+  targets="docker.pilot docker.proxyv2 "
+
+  # use ubuntu:jammy to test vms by default
+  nonDistrolessTargets="docker.app docker.app_sidecar_centos_stream_8 docker.ext-authz "
+  if [[ "${JOB_TYPE:-presubmit}" == "postsubmit" ]]; then
+    # We run tests across all VM types only in postsubmit
+    nonDistrolessTargets+="docker.app_sidecar_ubuntu_xenial docker.app_sidecar_ubuntu_jammy docker.app_sidecar_debian_11 docker.app_sidecar_centos_7 "
+    # TODO(https://github.com/istio/istio/issues/38224)
+#    nonDistrolessTargets+="docker.app_sidecar_rockylinux_8 "
+  fi
+  if [[ "${SELECT_TEST}" == "test.integration.operator.kube" || "${SELECT_TEST}" == "test.integration.kube" || "${JOB_TYPE:-postsubmit}" == "postsubmit" ]]; then
+    targets+="docker.operator "
+  fi
+  targets+="docker.install-cni "
+  if [[ "${VARIANT:-default}" == "distroless" ]]; then
+    DOCKER_BUILD_VARIANTS="distroless" DOCKER_TARGETS="${targets}" make dockerx.pushx
+    DOCKER_BUILD_VARIANTS="default" DOCKER_TARGETS="${nonDistrolessTargets}" make dockerx.pushx
+  else
+    DOCKER_BUILD_VARIANTS="${VARIANT:-default}" DOCKER_TARGETS="${targets} ${nonDistrolessTargets}" make dockerx.pushx
+  fi
+}
+
+# Creates a local registry for kind nodes to pull images from. Expects that the "kind" network already exists.
+function setup_kind_registry() {
+  # create a registry container if it not running already
+  running="$(docker inspect -f '{{.State.Running}}' "${KIND_REGISTRY_NAME}" 2>/dev/null || true)"
+  if [[ "${running}" != 'true' ]]; then
+      docker run \
+        -d --restart=always -p "${KIND_REGISTRY_PORT}:5000" --name "${KIND_REGISTRY_NAME}" \
+        gcr.io/istio-testing/registry:2
+
+    # Allow kind nodes to reach the registry
+    docker network connect "kind" "${KIND_REGISTRY_NAME}"
+  fi
+
+  # https://docs.tilt.dev/choosing_clusters.html#discovering-the-registry
+  for cluster in $(kind get clusters); do
+    # TODO get context/config from existing variables
+    kind export kubeconfig --name="${cluster}"
+    for node in $(kind get nodes --name="${cluster}"); do
+      kubectl annotate node "${node}" "kind.x-k8s.io/registry=localhost:${KIND_REGISTRY_PORT}" --overwrite;
+    done
+  done
+}
+
+# setup_cluster_reg is used to set up a cluster registry for multicluster testing
+function setup_cluster_reg () {
+    MAIN_CONFIG=""
+    for context in "${CLUSTERREG_DIR}"/*; do
+        if [[ -z "${MAIN_CONFIG}" ]]; then
+            MAIN_CONFIG="${context}"
+        fi
+        export KUBECONFIG="${context}"
+        kubectl delete ns istio-system-multi --ignore-not-found
+        kubectl delete clusterrolebinding istio-multi-test --ignore-not-found
+        kubectl create ns istio-system-multi
+        kubectl create sa istio-multi-test -n istio-system-multi
+        kubectl create clusterrolebinding istio-multi-test --clusterrole=cluster-admin --serviceaccount=istio-system-multi:istio-multi-test
+        CLUSTER_NAME=$(kubectl config view --minify=true -o "jsonpath={.clusters[].name}")
+        gen_kubeconf_from_sa istio-multi-test "${context}"
+    done
+    export KUBECONFIG="${MAIN_CONFIG}"
+}
+
+function gen_kubeconf_from_sa () {
+    local service_account=$1
+    local filename=$2
+
+    SERVER=$(kubectl config view --minify=true -o "jsonpath={.clusters[].cluster.server}")
+    SECRET_NAME=$(kubectl get sa "${service_account}" -n istio-system-multi -o jsonpath='{.secrets[].name}')
+    CA_DATA=$(kubectl get secret "${SECRET_NAME}" -n istio-system-multi -o "jsonpath={.data['ca\\.crt']}")
+    TOKEN=$(kubectl get secret "${SECRET_NAME}" -n istio-system-multi -o "jsonpath={.data['token']}" | base64 --decode)
+
+    cat <<EOF > "${filename}"
+      apiVersion: v1
+      clusters:
+         - cluster:
+             certificate-authority-data: ${CA_DATA}
+             server: ${SERVER}
+           name: ${CLUSTER_NAME}
+      contexts:
+         - context:
+             cluster: ${CLUSTER_NAME}
+             user: ${CLUSTER_NAME}
+           name: ${CLUSTER_NAME}
+      current-context: ${CLUSTER_NAME}
+      kind: Config
+      preferences: {}
+      users:
+         - name: ${CLUSTER_NAME}
+           user:
+             token: ${TOKEN}
+EOF
+}
+
+# gives a copy of a given topology JSON editing the given key on the entry with the given cluster name
+function set_topology_value() {
+    local JSON="$1"
+    local CLUSTER_NAME="$2"
+    local KEY="$3"
+    local VALUE="$4"
+    VALUE=$(echo "${VALUE}" | awk '{$1=$1};1')
+
+    echo "${JSON}" | jq '(.[] | select(.clusterName =="'"${CLUSTER_NAME}"'") | .'"${KEY}"') |="'"${VALUE}"'"'
+}

--- a/tests/integration/metallb.yaml
+++ b/tests/integration/metallb.yaml
@@ -1,0 +1,399 @@
+# from https://github.com/metallb/metallb/tree/v0.9.3/manifests namespace.yaml and metallb.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metallb-system
+  labels:
+    app: metallb
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  labels:
+    app: metallb
+  name: controller
+  namespace: metallb-system
+spec:
+  allowPrivilegeEscalation: false
+  allowedCapabilities: []
+  allowedHostPaths: []
+  defaultAddCapabilities: []
+  defaultAllowPrivilegeEscalation: false
+  fsGroup:
+    ranges:
+      - max: 65535
+        min: 1
+    rule: MustRunAs
+  hostIPC: false
+  hostNetwork: false
+  hostPID: false
+  privileged: false
+  readOnlyRootFilesystem: true
+  requiredDropCapabilities:
+    - ALL
+  runAsUser:
+    ranges:
+      - max: 65535
+        min: 1
+    rule: MustRunAs
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+      - max: 65535
+        min: 1
+    rule: MustRunAs
+  volumes:
+    - configMap
+    - secret
+    - emptyDir
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  labels:
+    app: metallb
+  name: speaker
+  namespace: metallb-system
+spec:
+  allowPrivilegeEscalation: false
+  allowedCapabilities:
+    - NET_ADMIN
+    - NET_RAW
+    - SYS_ADMIN
+  allowedHostPaths: []
+  defaultAddCapabilities: []
+  defaultAllowPrivilegeEscalation: false
+  fsGroup:
+    rule: RunAsAny
+  hostIPC: false
+  hostNetwork: true
+  hostPID: false
+  hostPorts:
+    - max: 7472
+      min: 7472
+  privileged: true
+  readOnlyRootFilesystem: true
+  requiredDropCapabilities:
+    - ALL
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - configMap
+    - secret
+    - emptyDir
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: metallb
+  name: controller
+  namespace: metallb-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: metallb
+  name: speaker
+  namespace: metallb-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: metallb
+  name: metallb-system:controller
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - ''
+    resources:
+      - services/status
+    verbs:
+      - update
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - policy
+    resourceNames:
+      - controller
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: metallb
+  name: metallb-system:speaker
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - services
+      - endpoints
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - policy
+    resourceNames:
+      - speaker
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: metallb
+  name: config-watcher
+  namespace: metallb-system
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: metallb
+  name: pod-lister
+  namespace: metallb-system
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+    verbs:
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: metallb
+  name: metallb-system:controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metallb-system:controller
+subjects:
+  - kind: ServiceAccount
+    name: controller
+    namespace: metallb-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: metallb
+  name: metallb-system:speaker
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metallb-system:speaker
+subjects:
+  - kind: ServiceAccount
+    name: speaker
+    namespace: metallb-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: metallb
+  name: config-watcher
+  namespace: metallb-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: config-watcher
+subjects:
+  - kind: ServiceAccount
+    name: controller
+  - kind: ServiceAccount
+    name: speaker
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: metallb
+  name: pod-lister
+  namespace: metallb-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-lister
+subjects:
+  - kind: ServiceAccount
+    name: speaker
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: metallb
+    component: speaker
+  name: speaker
+  namespace: metallb-system
+spec:
+  selector:
+    matchLabels:
+      app: metallb
+      component: speaker
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: '7472'
+        prometheus.io/scrape: 'true'
+      labels:
+        app: metallb
+        component: speaker
+    spec:
+      containers:
+        - args:
+            - --port=7472
+            - --config=config
+          env:
+            - name: METALLB_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: METALLB_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: METALLB_ML_BIND_ADDR
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: METALLB_ML_LABELS
+              value: "app=metallb,component=speaker"
+            - name: METALLB_ML_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: METALLB_ML_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: memberlist
+                  key: secretkey
+          image: metallb/speaker:v0.9.3
+          imagePullPolicy: Always
+          name: speaker
+          ports:
+            - containerPort: 7472
+              name: monitoring
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              add:
+                - NET_ADMIN
+                - NET_RAW
+                - SYS_ADMIN
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+      hostNetwork: true
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      serviceAccountName: speaker
+      terminationGracePeriodSeconds: 2
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: metallb
+    component: controller
+  name: controller
+  namespace: metallb-system
+spec:
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: metallb
+      component: controller
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: '7472'
+        prometheus.io/scrape: 'true'
+      labels:
+        app: metallb
+        component: controller
+    spec:
+      containers:
+        - args:
+            - --port=7472
+            - --config=config
+          image: metallb/controller:v0.9.3
+          imagePullPolicy: Always
+          name: controller
+          ports:
+            - containerPort: 7472
+              name: monitoring
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - all
+            readOnlyRootFilesystem: true
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      serviceAccountName: controller
+      terminationGracePeriodSeconds: 0

--- a/tests/integration/operator-integ-suite-kind.sh
+++ b/tests/integration/operator-integ-suite-kind.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+
+# Copyright 2022 Red Hat, Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+WD=$(dirname "$0")
+WD=$(cd "$WD"; pwd)
+export CLUSTER_NAME
+CLUSTER_NAME="maistra-operator-$(date +%s)"
+
+# Exit immediately for non zero status
+set -e
+# Check unset variables
+set -u
+# Print commands
+set -x
+
+# cleanup_kind_cluster takes a single parameter CLUSTER_NAME
+# and deletes the KinD cluster with that name
+function cleanup_kind_cluster() {
+  echo "Test exited with exit code $?."
+  CLUSTER_NAME="${1}"
+  if [[ -z "${SKIP_CLEANUP:-}" ]]; then
+    echo "Cleaning up kind cluster"
+    kind delete cluster --name "${CLUSTER_NAME}" -v9 || true
+  fi
+}
+
+# explicitly disable shellcheck since we actually want $CLUSTER_NAME to expand now
+# shellcheck disable=SC2064
+trap "cleanup_kind_cluster ${CLUSTER_NAME}" EXIT
+
+# provision a kind cluster
+echo "--------------------------------"
+echo "Provision a kind cluster"
+echo "--------------------------------"
+"${WD}"/istio-integ-suite-kind.sh
+
+echo "--------------------------------"
+echo "Build an operator image"
+echo "--------------------------------"
+"${WD}"/build-operator.sh
+
+# deploy operator in kind
+echo "--------------------------------"
+echo "Deploy istio operator in kind"
+echo "--------------------------------"
+"${WD}"/deploy-operator.sh
+# wait for validation webhook
+echo "Wait 30s for validation webhook..."
+sleep 30
+
+# create a SMCP and test httpbin
+echo "--------------------------------"
+echo "Create a SMCP and test httpbin"
+echo "--------------------------------"
+"${WD}"/smcp-httpbin-test.sh
+
+# delete the kind cluster
+cleanup_kind_cluster "${CLUSTER_NAME}"

--- a/tests/integration/smcp-httpbin-test.sh
+++ b/tests/integration/smcp-httpbin-test.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+
+# Copyright 2022 Red Hat, Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Exit immediately for non zero status
+set -e
+# Check unset variables
+set -u
+# Print commands
+set -x
+
+set -o pipefail
+
+WD=$(dirname "$0")
+WD=$(cd "$WD"; pwd)
+ROOT="$(git rev-parse --show-toplevel)"
+CR="${ROOT}/deploy/examples/maistra_v2_servicemeshcontrolplane_cr_minimal.yaml"
+BRANCH="${BRANCH:-maistra-2.4}"
+HTTPBIN="https://raw.githubusercontent.com/maistra/istio/${BRANCH}/samples/httpbin/httpbin.yaml"
+SLEEP="https://raw.githubusercontent.com/maistra/istio/${BRANCH}/samples/sleep/sleep.yaml"
+MEMBER_NS="default"
+
+create-control-plane() { # creates a SMCP with a mini CR
+    local SMCP_NS="${SMCP_NS:-istio-system}"
+    kubectl get ns "${MEMBER_NS}" >/dev/null 2>&1 || kubectl create namespace "${MEMBER_NS}"
+    kubectl get ns "${SMCP_NS}" >/dev/null 2>&1 || kubectl create namespace "${SMCP_NS}"
+
+    # sets the ${MEMBER_NS} namespace as a member of a SMMR
+    sed "s:#- bookinfo:- ${MEMBER_NS}:g" "${CR}" | kubectl apply -n "${SMCP_NS}" -f -
+
+    kubectl wait --for condition=Ready -n "${SMCP_NS}" smcp/minimal --timeout 300s
+    kubectl wait --for condition=Ready -n "${SMCP_NS}" smmr/default --timeout 180s
+    kubectl get -n "${SMCP_NS}" smcp -o wide
+}
+
+create-httpbin() { # creates a httpbin app and injects sidecar proxy
+    kubectl apply -n "${MEMBER_NS}" -f "${HTTPBIN}"
+    kubectl apply -n "${MEMBER_NS}" -f "${SLEEP}"
+    kubectl wait --for condition=Ready -n "${MEMBER_NS}" pod -l app=httpbin --timeout 300s
+    kubectl wait --for condition=Ready -n "${MEMBER_NS}" pod -l app=sleep --timeout 180s
+}
+
+check-httpbin() {
+    # checks if a httpbin pod has two containers
+    echo "Check httpbin pod status:"
+    kubectl get -n "${MEMBER_NS}" pod
+    kubectl get -n "${MEMBER_NS}" pod -l app=httpbin \
+        -o=jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.containerStatuses[*].ready}{"\n"}{end}' \
+        | grep 'true true'
+
+    # TBD: KinD network issue
+    echo "Check if a request is routed through the proxy:"
+    kubectl exec -n "${MEMBER_NS}" deploy/sleep -c sleep \
+        -- curl --fail --retry 5 --retry-delay 3 -sS http://httpbin:8000/headers \
+        | grep "X-Envoy-Attempt-Count"
+}
+
+create-control-plane
+create-httpbin
+check-httpbin


### PR DESCRIPTION
Signed-off-by: Yuanlin <yuanlin.xu@redhat.com>

This PR is the first draft of adding an integration test suite in maistra/istio-operator.
This PR includes:
- Set up a Kind node in a builder container or a prow job
- Build and push istio-operator image to quay
- Deploy the new operator image in Kind
- Create a SMCP and test an application (More test cases TBD)

The current old operator sdk blocks me adding a new go package or lib. So I wrote this PR in bash.


PR in draft review, appreciate review questions and feedback.