### PR TITLE
OSSM-2190 OSSM-2232 OSSM-2189 Don't reconcile invalid objects

### DIFF
--- a/pkg/apis/maistra/status/status.go
+++ b/pkg/apis/maistra/status/status.go
@@ -55,7 +55,7 @@ func NewStatus() StatusType {
 }
 
 type ComponentStatusList struct {
-	//+optional
+	// +optional
 	ComponentStatus []ComponentStatus `json:"components,omitempty"`
 }
 
@@ -134,6 +134,8 @@ const (
 	ConditionReasonReconcileSuccessful ConditionReason = "ReconcileSuccessful"
 	// ConditionReasonValidationError ...
 	ConditionReasonValidationError ConditionReason = "ValidationError"
+	// ConditionReasonValidationError ...
+	ConditionReasonMultipleSMCPs ConditionReason = "ErrMultipleSMCPs"
 	// ConditionReasonDependencyMissingError ...
 	ConditionReasonDependencyMissingError ConditionReason = "DependencyMissingError"
 	// ConditionReasonReconcileError ...

--- a/pkg/apis/maistra/v1/servicemeshmember_types.go
+++ b/pkg/apis/maistra/v1/servicemeshmember_types.go
@@ -126,6 +126,7 @@ const (
 	ConditionReasonMemberNamespaceNotExists              ServiceMeshMemberConditionReason = "NamespaceNotExists"
 	ConditionReasonMemberReferencesDifferentControlPlane ServiceMeshMemberConditionReason = "ReferencesDifferentControlPlane"
 	ConditionReasonMemberTerminating                     ServiceMeshMemberConditionReason = "Terminating"
+	ConditionReasonMemberNameInvalid                     ServiceMeshMemberConditionReason = "InvalidName"
 )
 
 // Condition represents a specific condition on a resource

--- a/pkg/apis/maistra/v1/servicemeshmemberroll_types.go
+++ b/pkg/apis/maistra/v1/servicemeshmemberroll_types.go
@@ -152,6 +152,8 @@ const (
 	ConditionReasonSMCPMissing ServiceMeshMemberRollConditionReason = "ErrSMCPMissing"
 	// ConditionReasonMultipleSMCP indicates that multiple ServiceMeshControlPlane resources exist in the namespace
 	ConditionReasonMultipleSMCP ServiceMeshMemberRollConditionReason = "ErrMultipleSMCPs"
+	// ConditionReasonInvalidName indicates that the ServiceMeshMemberRoll name is invalid (only "default" is allowed)
+	ConditionReasonInvalidName ServiceMeshMemberRollConditionReason = "ErrInvalidName"
 	// ConditionReasonSMCPNotReconciled indicates that reconciliation of the SMMR was skipped because the SMCP has not been reconciled
 	ConditionReasonSMCPNotReconciled ServiceMeshMemberRollConditionReason = "SMCPReconciling"
 )

--- a/pkg/controller/servicemesh/controlplane/controller_test.go
+++ b/pkg/controller/servicemesh/controlplane/controller_test.go
@@ -38,7 +38,8 @@ var (
 		},
 	}
 
-	oneMinuteAgo = metav1.NewTime(time.Now().Add(-time.Minute))
+	now          = metav1.NewTime(time.Now().Truncate(time.Second))
+	oneMinuteAgo = metav1.NewTime(time.Now().Truncate(time.Second).Add(-time.Minute))
 
 	instanceReconciler *fakeInstanceReconciler
 )

--- a/pkg/controller/servicemesh/member/controller.go
+++ b/pkg/controller/servicemesh/member/controller.go
@@ -196,6 +196,12 @@ func (r *MemberReconciler) Reconcile(request reconcile.Request) (reconcile.Resul
 
 func (r *MemberReconciler) reconcileObject(ctx context.Context, member *maistrav1.ServiceMeshMember) (reconcile.Result, error) {
 	log := common.LogFromContext(ctx)
+
+	if member.Name != common.MemberName {
+		return reconcile.Result{}, r.reportError(ctx, member, maistrav1.ConditionReasonMemberNameInvalid,
+			fmt.Errorf("the ServiceMeshMember name is invalid; must be %q", common.MemberName))
+	}
+
 	if member.Namespace == member.Spec.ControlPlaneRef.Namespace {
 		return reconcile.Result{}, nil
 	}

--- a/pkg/controller/servicemesh/memberroll/controller.go
+++ b/pkg/controller/servicemesh/memberroll/controller.go
@@ -247,6 +247,13 @@ func (r *MemberRollReconciler) reconcileObject(ctx context.Context, roll *maistr
 
 	meshNamespace := roll.Namespace
 
+	if roll.Name != common.MemberRollName {
+		log.Info("Skipping reconciliation of SMMR with invalid name", "project", meshNamespace, "name", roll.Name)
+		setReadyCondition(roll, false, maistrav1.ConditionReasonInvalidName,
+			fmt.Sprintf("the ServiceMeshMemberRoll name is invalid; must be %q", common.MemberRollName))
+		return reconcile.Result{}, r.updateStatus(ctx, roll)
+	}
+
 	// 1. gather status of all members that belong to this roll
 	members := &maistrav1.ServiceMeshMemberList{}
 	err := r.Client.List(ctx, members, client.MatchingFields{"spec.controlPlaneRef.namespace": meshNamespace})


### PR DESCRIPTION
These three commits ensure that the three controllers (SMCP, SMMR, and SMM) don't reconcile objects that shouldn't even exist. 

The validation webhook prevents the creation of these objects, but you can create them if you first delete the webhook. If this happens, the controller must ignore them.