### PR TITLE
OSSM-1094 Use bcrypt for htpasswd, stop mounting rawpassword

### DIFF
--- a/pkg/controller/servicemesh/controlplane/htpasswd.go
+++ b/pkg/controller/servicemesh/controlplane/htpasswd.go
@@ -5,14 +5,13 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
-	"golang.org/x/crypto/bcrypt"
 	"regexp"
 
+	"github.com/maistra/istio-operator/pkg/controller/common"
+	"golang.org/x/crypto/bcrypt"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/maistra/istio-operator/pkg/controller/common"
 )
 
 func (r *controlPlaneInstanceReconciler) patchHtpasswdSecret(ctx context.Context, object *unstructured.Unstructured) error {

--- a/pkg/controller/servicemesh/controlplane/htpasswd.go
+++ b/pkg/controller/servicemesh/controlplane/htpasswd.go
@@ -7,11 +7,12 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/maistra/istio-operator/pkg/controller/common"
 	"golang.org/x/crypto/bcrypt"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/maistra/istio-operator/pkg/controller/common"
 )
 
 func (r *controlPlaneInstanceReconciler) patchHtpasswdSecret(ctx context.Context, object *unstructured.Unstructured) error {

--- a/resources/helm/overlays/istio-telemetry/grafana/templates/deployment.yaml
+++ b/resources/helm/overlays/istio-telemetry/grafana/templates/deployment.yaml
@@ -194,6 +194,9 @@ spec:
       - name: secret-htpasswd
         secret:
           defaultMode: 420
+          items:
+            - key: auth
+              path: auth
           secretName: htpasswd
       - name: secret-grafana-proxy
         secret:

--- a/resources/helm/overlays/istio-telemetry/prometheus/templates/deployment.yaml
+++ b/resources/helm/overlays/istio-telemetry/prometheus/templates/deployment.yaml
@@ -252,6 +252,9 @@ spec:
       - name: secret-htpasswd
         secret:
           defaultMode: 420
+          items:
+            - key: auth
+              path: auth
           secretName: htpasswd
       - name: secret-prometheus-proxy
         secret:

--- a/resources/helm/v2.3/istio-telemetry/grafana/templates/deployment.yaml
+++ b/resources/helm/v2.3/istio-telemetry/grafana/templates/deployment.yaml
@@ -196,6 +196,9 @@ spec:
       - name: secret-htpasswd
         secret:
           defaultMode: 420
+          items:
+            - key: auth
+              path: auth
           secretName: htpasswd
       - name: secret-grafana-proxy
         secret:

--- a/resources/helm/v2.3/istio-telemetry/prometheus/templates/deployment.yaml
+++ b/resources/helm/v2.3/istio-telemetry/prometheus/templates/deployment.yaml
@@ -254,6 +254,9 @@ spec:
       - name: secret-htpasswd
         secret:
           defaultMode: 420
+          items:
+            - key: auth
+              path: auth
           secretName: htpasswd
       - name: secret-prometheus-proxy
         secret:

--- a/resources/smcp-templates/v2.3/maistra
+++ b/resources/smcp-templates/v2.3/maistra
@@ -29,7 +29,7 @@ spec:
         container:
           imageRegistry: quay.io/openshift
           imageName: origin-oauth-proxy
-          imageTag: "4.4"
+          imageTag: "4.9"
           imagePullPolicy: IfNotPresent
       rateLimiting.rls:
         container:


### PR DESCRIPTION
Changes:

-  Change to using bcrypt instead of SHA-1 for htpasswd. 

- Update the oauth-proxy version from 4.4 -> 4.9 (first version to support bcrypt)

- Stop mounting the raw htpasswd in our grafana-proxy and prometheus-proxy containers. 

Tested:
- OpenShift upgrading from operator 2.2 to 2.3 with this change and it worked as expected (keeping SHA-1 but nothing breaks) 
- Fresh install of this operator with SMCP 2.3 where it generates a bcrypt password, doesn't mount in prometheus-proxy and grafana-proxy as intended.