### PR TITLE
OSSM-2221 remove ignorenamespace label from control plane ns [maistra-2.3]

### DIFF
--- a/pkg/controller/servicemesh/controlplane/namespace_labels.go
+++ b/pkg/controller/servicemesh/controlplane/namespace_labels.go
@@ -13,15 +13,13 @@ import (
 
 func addNamespaceLabels(ctx context.Context, cl client.Client, namespace string) error {
 	return setNamespaceLabels(ctx, cl, namespace, map[string]string{
-		common.IgnoreNamespaceKey: "ignore",  // ensures injection is disabled for the control plane
-		common.MemberOfKey:        namespace, // ensures networking works correctly
+		common.MemberOfKey: namespace, // ensures networking works correctly
 	})
 }
 
 func removeNamespaceLabels(ctx context.Context, cl client.Client, namespace string) error {
 	return setNamespaceLabels(ctx, cl, namespace, map[string]string{
-		common.IgnoreNamespaceKey: "",
-		common.MemberOfKey:        "",
+		common.MemberOfKey: "",
 	})
 }
 

--- a/pkg/controller/servicemesh/controlplane/reconciler_test.go
+++ b/pkg/controller/servicemesh/controlplane/reconciler_test.go
@@ -607,8 +607,7 @@ func TestNamespaceLabels(t *testing.T) {
 	ns := &corev1.Namespace{}
 	test.GetObject(ctx, cl, types.NamespacedName{Namespace: "", Name: controlPlaneNamespace}, ns)
 	assert.DeepEquals(ns.Labels, map[string]string{
-		common.IgnoreNamespaceKey: "ignore",
-		common.MemberOfKey:        controlPlaneNamespace,
+		common.MemberOfKey: controlPlaneNamespace,
 	}, "Expected reconciler to add namespace labels", t)
 
 	test.PanicOnError(cl.Get(ctx, types.NamespacedName{Namespace: controlPlaneNamespace, Name: controlPlaneName}, smcp))


### PR DESCRIPTION
https://issues.redhat.com/browse/OSSM-2221

Remove the ignorenamespace label from the namespace the SMCP is deployed in, allowing for gateways to be injected in the control plane namespace.

### tested using:

- OpenShift w/ 2.3 SMCP in a control plane namespace **without** the `istio-injection` label enabled.
- OpenShift  w/ 2.3 SMCP in a control plane namespace **with** the `istio-injection` label enabled.

In both cases gateway injection was possible, and control plane components did not have sidecars injected.  