### PR TITLE
OSSM-2241: remove 2.0 as a control plane option

### DIFF
--- a/build/manifest-templates/clusterserviceversion.yaml
+++ b/build/manifest-templates/clusterserviceversion.yaml
@@ -203,7 +203,6 @@ __DEPLOYMENT_SPEC__
           - 'urn:alm:descriptor:com.tectonic.ui:select:v2.3'
           - 'urn:alm:descriptor:com.tectonic.ui:select:v2.2'
           - 'urn:alm:descriptor:com.tectonic.ui:select:v2.1'
-          - 'urn:alm:descriptor:com.tectonic.ui:select:v2.0'
       - displayName: Control Plane Security
         description: Enable mTLS for communication between control plane components
         path: security.controlPlane.mtls

--- a/manifests-maistra/2.3.0/maistraoperator.v2.3.0.clusterserviceversion.yaml
+++ b/manifests-maistra/2.3.0/maistraoperator.v2.3.0.clusterserviceversion.yaml
@@ -15,7 +15,7 @@ metadata:
       The Maistra Operator enables you to install, configure, and manage an instance of Maistra service mesh. Maistra is based on the open source Istio project.
 
     containerImage: quay.io/maistra/istio-ubi8-operator:2.3.0
-    createdAt: 2022-10-14T13:24:19EDT
+    createdAt: 2022-11-17T16:55:08EST
     support: Red Hat, Inc. 
     olm.skipRange: ">=1.0.2 <2.3.0-0"
     operators.openshift.io/infrastructure-features: '[]'
@@ -623,7 +623,6 @@ spec:
           - 'urn:alm:descriptor:com.tectonic.ui:select:v2.3'
           - 'urn:alm:descriptor:com.tectonic.ui:select:v2.2'
           - 'urn:alm:descriptor:com.tectonic.ui:select:v2.1'
-          - 'urn:alm:descriptor:com.tectonic.ui:select:v2.0'
       - displayName: Control Plane Security
         description: Enable mTLS for communication between control plane components
         path: security.controlPlane.mtls

--- a/manifests-servicemesh/2.3.0/servicemeshoperator.v2.3.0.clusterserviceversion.yaml
+++ b/manifests-servicemesh/2.3.0/servicemeshoperator.v2.3.0.clusterserviceversion.yaml
@@ -17,7 +17,7 @@ metadata:
       The OpenShift Service Mesh Operator enables you to install, configure, and manage an instance of Red Hat OpenShift Service Mesh. OpenShift Service Mesh is based on the open source Istio project.
 
     containerImage: ${OSSM_OPERATOR_IMAGE}
-    createdAt: 2022-10-14T13:24:21EDT
+    createdAt: 2022-11-17T16:55:08EST
     support: Red Hat, Inc. 
     olm.skipRange: ">=1.0.2 <2.3.0-0"
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
@@ -621,7 +621,6 @@ spec:
           - 'urn:alm:descriptor:com.tectonic.ui:select:v2.3'
           - 'urn:alm:descriptor:com.tectonic.ui:select:v2.2'
           - 'urn:alm:descriptor:com.tectonic.ui:select:v2.1'
-          - 'urn:alm:descriptor:com.tectonic.ui:select:v2.0'
       - displayName: Control Plane Security
         description: Enable mTLS for communication between control plane components
         path: security.controlPlane.mtls


### PR DESCRIPTION
https://issues.redhat.com/browse/OSSM-2241

one-liner, removing 2.0 as an option in the dropdown menu when creating an SMCP. 

Going to open an issue similar to OSSM-1872 (PR #1003) to more thoroughly deprecate 2.0 references in the operator.