### PR TITLE
[ossm-2221] ensure we do not auto-inject into kiali

### DIFF
--- a/resources/helm/overlays/istio-telemetry/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/overlays/istio-telemetry/kiali/templates/kiali-cr.yaml
@@ -64,7 +64,10 @@ spec:
     {{- end }}
 {{- end }}
 
-{{- if or .Values.kiali.affinity .Values.kiali.deployment_affinity }}
+    pod_labels:
+      sidecar.istio.io/inject: "false"
+
+  {{- if or .Values.kiali.affinity .Values.kiali.deployment_affinity }}
     affinity:
     {{- if .Values.kiali.affinity }}
         {{- if .Values.kiali.affinity.nodeAffinity }}

--- a/resources/helm/v2.3/istio-telemetry/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/v2.3/istio-telemetry/kiali/templates/kiali-cr.yaml
@@ -66,7 +66,10 @@ spec:
     {{- end }}
 {{- end }}
 
-{{- if or .Values.kiali.affinity .Values.kiali.deployment_affinity }}
+    pod_labels:
+      sidecar.istio.io/inject: "false"
+
+  {{- if or .Values.kiali.affinity .Values.kiali.deployment_affinity }}
     affinity:
     {{- if .Values.kiali.affinity }}
         {{- if .Values.kiali.affinity.nodeAffinity }}


### PR DESCRIPTION
Now that we enable injection into the SMCP namespace, we must ensure that if a user has auto inject enabled, our SMCP related resources will not be injected into unintentionally. 

This PR ensures that if the user is installing kiali through our SMCP config, by default the kiali pod will be labeled with `sidecar.istio.io/inject="false"`.

