### PR TITLE
Revert "OSSM-2221 remove ignorenamespace label from control plane ns [maistra-2.3]"

### DIFF
--- a/pkg/controller/servicemesh/controlplane/namespace_labels.go
+++ b/pkg/controller/servicemesh/controlplane/namespace_labels.go
@@ -13,13 +13,15 @@ import (
 
 func addNamespaceLabels(ctx context.Context, cl client.Client, namespace string) error {
 	return setNamespaceLabels(ctx, cl, namespace, map[string]string{
-		common.MemberOfKey: namespace, // ensures networking works correctly
+		common.IgnoreNamespaceKey: "ignore",  // ensures injection is disabled for the control plane
+		common.MemberOfKey:        namespace, // ensures networking works correctly
 	})
 }
 
 func removeNamespaceLabels(ctx context.Context, cl client.Client, namespace string) error {
 	return setNamespaceLabels(ctx, cl, namespace, map[string]string{
-		common.MemberOfKey: "",
+		common.IgnoreNamespaceKey: "",
+		common.MemberOfKey:        "",
 	})
 }
 

--- a/pkg/controller/servicemesh/controlplane/reconciler_test.go
+++ b/pkg/controller/servicemesh/controlplane/reconciler_test.go
@@ -665,7 +665,8 @@ func TestNamespaceLabels(t *testing.T) {
 	ns := &corev1.Namespace{}
 	test.GetObject(ctx, cl, types.NamespacedName{Namespace: "", Name: controlPlaneNamespace}, ns)
 	assert.DeepEquals(ns.Labels, map[string]string{
-		common.MemberOfKey: controlPlaneNamespace,
+		common.IgnoreNamespaceKey: "ignore",
+		common.MemberOfKey:        controlPlaneNamespace,
 	}, "Expected reconciler to add namespace labels", t)
 
 	test.PanicOnError(cl.Get(ctx, types.NamespacedName{Namespace: controlPlaneNamespace, Name: controlPlaneName}, smcp))


### PR DESCRIPTION
Reverts maistra/istio-operator#1060, we are pushing this change from 2.3.1 to 2.4. 