### PR TITLE
[OSSM-2221 | OSSM-2340] Ensure injection in SMCP ns disabled below v2.4

### DIFF
--- a/pkg/controller/servicemesh/controlplane/deleter.go
+++ b/pkg/controller/servicemesh/controlplane/deleter.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/maistra/istio-operator/pkg/controller/versions"
-
 	errors "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -15,6 +13,7 @@ import (
 	maistrav2 "github.com/maistra/istio-operator/pkg/apis/maistra/v2"
 	"github.com/maistra/istio-operator/pkg/controller/common"
 	"github.com/maistra/istio-operator/pkg/controller/hacks"
+	"github.com/maistra/istio-operator/pkg/controller/versions"
 )
 
 func (r *controlPlaneInstanceReconciler) Delete(ctx context.Context) error {

--- a/pkg/controller/servicemesh/controlplane/deleter.go
+++ b/pkg/controller/servicemesh/controlplane/deleter.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/maistra/istio-operator/pkg/controller/versions"
+
 	errors "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -50,9 +52,17 @@ func (r *controlPlaneInstanceReconciler) Delete(ctx context.Context) error {
 			fmt.Sprintf("Error deleting service mesh resources: %s", err))
 	}
 
+	// get smcp version for ns label deletion.
+	var version versions.Version
+	version, err = versions.ParseVersion(r.Instance.Spec.Version)
+	if err != nil {
+		log.Error(err, "invalid version specified")
+		return nil
+	}
+
 	// remove namespace labels
 	if err == nil {
-		err = removeNamespaceLabels(ctx, r.Client, r.Instance.Namespace)
+		err = removeNamespaceLabels(ctx, r.Client, r.Instance.Namespace, version)
 	}
 
 	// update SMCP status and stop reconciling if there was an error

--- a/pkg/controller/servicemesh/controlplane/namespace_labels.go
+++ b/pkg/controller/servicemesh/controlplane/namespace_labels.go
@@ -18,11 +18,11 @@ func addNamespaceLabels(ctx context.Context, cl client.Client, namespace string,
 			common.IgnoreNamespaceKey: "ignore",  // ensures injection is disabled for the control plane
 			common.MemberOfKey:        namespace, // ensures networking works correctly
 		})
-	} else { // if 2.4 and above, allow for injection in smcp ns.
-		return setNamespaceLabels(ctx, cl, namespace, map[string]string{
-			common.MemberOfKey: namespace, // ensures networking works correctly
-		})
 	}
+	// if 2.4 and above, allow for injection in smcp ns.
+	return setNamespaceLabels(ctx, cl, namespace, map[string]string{
+		common.MemberOfKey: namespace, // ensures networking works correctly
+	})
 }
 
 func removeNamespaceLabels(ctx context.Context, cl client.Client, namespace string, version versions.Version) error {
@@ -31,11 +31,11 @@ func removeNamespaceLabels(ctx context.Context, cl client.Client, namespace stri
 			common.IgnoreNamespaceKey: "",
 			common.MemberOfKey:        "",
 		})
-	} else { // if 2.4 and above, no need to remove Ignore label.
-		return setNamespaceLabels(ctx, cl, namespace, map[string]string{
-			common.MemberOfKey: "",
-		})
 	}
+	// if 2.4 and above, no need to remove Ignore label.
+	return setNamespaceLabels(ctx, cl, namespace, map[string]string{
+		common.MemberOfKey: "",
+	})
 }
 
 func setNamespaceLabels(ctx context.Context, cl client.Client, namespace string, labels map[string]string) error {

--- a/pkg/controller/servicemesh/controlplane/reconciler.go
+++ b/pkg/controller/servicemesh/controlplane/reconciler.go
@@ -175,7 +175,7 @@ func (r *controlPlaneInstanceReconciler) Reconcile(ctx context.Context) (result 
 		// e.g. spec.pilot.enabled || spec.mixer.enabled || spec.galley.enabled || spec.sidecarInjectorWebhook.enabled || ....
 		// which is all we're supporting atm.  if the scope expands to allow
 		// installing custom gateways, etc., we should revisit this.
-		err = addNamespaceLabels(ctx, r.Client, r.Instance.Namespace)
+		err = addNamespaceLabels(ctx, r.Client, r.Instance.Namespace, version)
 		if err != nil {
 			// bail if there was an error updating the namespace
 			r.renderings = nil

--- a/pkg/controller/servicemesh/controlplane/reconciler_test.go
+++ b/pkg/controller/servicemesh/controlplane/reconciler_test.go
@@ -648,9 +648,9 @@ func TestMultipleSMCP(t *testing.T) {
 	}
 }
 
-// tests if the reconciler adds the necessary labels to the SMCP namespace when
+// tests if the reconciler adds the necessary labels to the 2.0 SMCP namespace when
 // it first reconciles the SMCP and also removes them when the SMCP is deleted
-func TestNamespaceLabels(t *testing.T) {
+func TestOldNamespaceLabels(t *testing.T) {
 	smcp := newControlPlane()
 	smcp.Spec = maistrav2.ControlPlaneSpec{
 		Version:  versions.V2_0.String(),
@@ -666,8 +666,43 @@ func TestNamespaceLabels(t *testing.T) {
 	ns := &corev1.Namespace{}
 	test.GetObject(ctx, cl, types.NamespacedName{Namespace: "", Name: controlPlaneNamespace}, ns)
 	assert.DeepEquals(ns.Labels, map[string]string{
-		common.MemberOfKey: controlPlaneNamespace,
+		common.IgnoreNamespaceKey: "ignore",
+		common.MemberOfKey:        controlPlaneNamespace,
 	}, "Expected reconciler to add namespace labels", t)
+
+	test.PanicOnError(cl.Get(ctx, types.NamespacedName{Namespace: controlPlaneNamespace, Name: controlPlaneName}, smcp))
+	smcp.DeletionTimestamp = &oneMinuteAgo
+	test.PanicOnError(cl.Update(ctx, smcp))
+
+	// 2. run Delete() to remove labels
+	assertDeleteSucceeds(r, t) // this only initializes the SMCP status
+	assertDeleteSucceeds(r, t) // this does the actual work
+
+	ns = &corev1.Namespace{}
+	test.GetObject(ctx, cl, types.NamespacedName{Namespace: "", Name: controlPlaneNamespace}, ns)
+	assert.DeepEquals(ns.Labels, map[string]string(nil), "Namespace labels weren't removed", t)
+}
+
+// tests if the reconciler adds the necessary label to the 2.4 SMCP namespace when
+// it first reconciles the SMCP and also removes the label when the SMCP is deleted
+func TestNewNamespaceLabels(t *testing.T) {
+	smcp := newControlPlane()
+	smcp.Spec = maistrav2.ControlPlaneSpec{
+		Version:  versions.V2_4.String(),
+		Profiles: []string{"maistra"},
+	}
+
+	cl, _, r := newReconcilerTestFixture(smcp)
+
+	// 1. run Reconcile() to add labels
+	assertInstanceReconcilerSucceeds(r, t) // this only initializes the SMCP status
+	assertInstanceReconcilerSucceeds(r, t) // this does the actual work
+
+	ns := &corev1.Namespace{}
+	test.GetObject(ctx, cl, types.NamespacedName{Namespace: "", Name: controlPlaneNamespace}, ns)
+	assert.DeepEquals(ns.Labels, map[string]string{
+		common.MemberOfKey: controlPlaneNamespace,
+	}, "Expected reconciler to add namespace label", t)
 
 	test.PanicOnError(cl.Get(ctx, types.NamespacedName{Namespace: controlPlaneNamespace, Name: controlPlaneName}, smcp))
 	smcp.DeletionTimestamp = &oneMinuteAgo

--- a/resources/helm/overlays/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/resources/helm/overlays/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -48,18 +48,22 @@ webhooks:
         - disabled
       - key: istio-env
         operator: DoesNotExist
-{{- if .Values.sidecarInjectorWebhook.objectSelector.enabled }}
   objectSelector:
     matchExpressions:
+      - key: app
+        operator: NotIn
+        values:
+          - "istiod"
+{{- if .Values.sidecarInjectorWebhook.objectSelector.enabled }}
 {{- if eq .Values.global.proxy.autoInject "enabled" }}
-    - key: "sidecar.istio.io/inject"
-      operator: NotIn
-      values:
-      - "false"
+- key: "sidecar.istio.io/inject"
+  operator: NotIn
+  values:
+    - "false"
 {{- else }}
-    - key: "sidecar.istio.io/inject"
-      operator: In
-      values:
-      - "true"
+- key: "sidecar.istio.io/inject"
+  operator: In
+  values:
+    - "true"
 {{- end }}
 {{- end }}

--- a/resources/helm/overlays/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/resources/helm/overlays/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -56,14 +56,14 @@ webhooks:
           - "istiod"
 {{- if .Values.sidecarInjectorWebhook.objectSelector.enabled }}
 {{- if eq .Values.global.proxy.autoInject "enabled" }}
-- key: "sidecar.istio.io/inject"
-  operator: NotIn
-  values:
-    - "false"
+      - key: "sidecar.istio.io/inject"
+        operator: NotIn
+        values:
+          - "false"
 {{- else }}
-- key: "sidecar.istio.io/inject"
-  operator: In
-  values:
-    - "true"
+      - key: "sidecar.istio.io/inject"
+        operator: In
+        values:
+          - "true"
 {{- end }}
 {{- end }}

--- a/resources/helm/overlays/istio-telemetry/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/overlays/istio-telemetry/kiali/templates/kiali-cr.yaml
@@ -64,6 +64,9 @@ spec:
     {{- end }}
 {{- end }}
 
+    pod_labels:
+      sidecar.istio.io/inject: "false"
+
 {{- if or .Values.kiali.affinity .Values.kiali.deployment_affinity }}
     affinity:
     {{- if .Values.kiali.affinity }}

--- a/resources/helm/v2.4/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/resources/helm/v2.4/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -57,14 +57,14 @@ webhooks:
           - "istiod"
 {{- if .Values.sidecarInjectorWebhook.objectSelector.enabled }}
 {{- if eq .Values.global.proxy.autoInject "enabled" }}
-- key: "sidecar.istio.io/inject"
-  operator: NotIn
-  values:
-    - "false"
+      - key: "sidecar.istio.io/inject"
+        operator: NotIn
+        values:
+          - "false"
 {{- else }}
-- key: "sidecar.istio.io/inject"
-  operator: In
-  values:
-    - "true"
+      - key: "sidecar.istio.io/inject"
+        operator: In
+        values:
+          - "true"
 {{- end }}
 {{- end }}

--- a/resources/helm/v2.4/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/resources/helm/v2.4/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -49,18 +49,22 @@ webhooks:
         - disabled
       - key: istio-env
         operator: DoesNotExist
-{{- if .Values.sidecarInjectorWebhook.objectSelector.enabled }}
   objectSelector:
     matchExpressions:
+      - key: app
+        operator: NotIn
+        values:
+          - "istiod"
+{{- if .Values.sidecarInjectorWebhook.objectSelector.enabled }}
 {{- if eq .Values.global.proxy.autoInject "enabled" }}
-    - key: "sidecar.istio.io/inject"
-      operator: NotIn
-      values:
-      - "false"
+- key: "sidecar.istio.io/inject"
+  operator: NotIn
+  values:
+    - "false"
 {{- else }}
-    - key: "sidecar.istio.io/inject"
-      operator: In
-      values:
-      - "true"
+- key: "sidecar.istio.io/inject"
+  operator: In
+  values:
+    - "true"
 {{- end }}
 {{- end }}

--- a/resources/helm/v2.4/istio-telemetry/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/v2.4/istio-telemetry/kiali/templates/kiali-cr.yaml
@@ -66,6 +66,9 @@ spec:
     {{- end }}
 {{- end }}
 
+    pod_labels:
+      sidecar.istio.io/inject: "false"
+
 {{- if or .Values.kiali.affinity .Values.kiali.deployment_affinity }}
     affinity:
     {{- if .Values.kiali.affinity }}


### PR DESCRIPTION
**This PR:** 

- Ensures that the ignore-namespace label is still applied to the SMCP namespace when creating SMCPs below version 2.4. 
- Modifies the v2.4 MutatingWebhook ObjectSelector to never attempt to inject into the istiod pod [OSSM-2340]
- Modifies the v2.4 kiali_cr to label the kiali pod to not inject, fixing the problem when an SMCP was created with auto-inject. 
- Adds another namespaceLabels unit test to test labels added/removed pre v2.4 and post v2.4. 

**Tested on CRC by:**
- Creating a v2.4 SMCP, deleting istiod pod and seeing it self heal.
- Creating a v2.4 SMCP with auto-inject enabled and seeing kiali created successfully with no proxy container.
- Creating v2.3, v2.2 SMCPs and making sure the ignore-namespace label is applied, and deleted when smcp is deleted.