### PR TITLE
OSSM-3372: Document cert-manager configuration in the default profile

### DIFF
--- a/deploy/examples/cert-manager/smcp-2.3.1.yaml
+++ b/deploy/examples/cert-manager/smcp-2.3.1.yaml
@@ -3,8 +3,13 @@ kind: ServiceMeshControlPlane
 metadata:
   name: basic
 spec:
-  profiles:
-  - small
+  addons:
+    grafana:
+      enabled: false
+    kiali:
+      enabled: false
+    prometheus:
+      enabled: false
   security:
     certificateAuthority:
       cert-manager:
@@ -14,6 +19,8 @@ spec:
       type: cert-manager
     dataPlane:
       mtls: true
+    identity:
+      type: ThirdParty
   tracing:
     type: None
   version: v2.3

--- a/deploy/examples/cert-manager/smcp.yaml
+++ b/deploy/examples/cert-manager/smcp.yaml
@@ -3,8 +3,13 @@ kind: ServiceMeshControlPlane
 metadata:
   name: basic
 spec:
-  profiles:
-  - small
+  addons:
+    grafana:
+      enabled: false
+    kiali:
+      enabled: false
+    prometheus:
+      enabled: false
   security:
     certificateAuthority:
       cert-manager:
@@ -12,6 +17,8 @@ spec:
       type: cert-manager
     dataPlane:
       mtls: true
+    identity:
+      type: ThirdParty
   tracing:
     type: None
   version: v2.3


### PR DESCRIPTION
Signed-off-by: Jacek Ewertowski <jewertow@redhat.com>

When SMCP is deployed in profile `small`, proxies use `third-party-jwt` tokens, which are required by istio-csr. Otherwise, istio-proxies will not be able to obtain certificates and will not start. To make this more clear, I changed profile to `default`.