### PR TITLE
OSSM-1330: Use well known paths for TLS certificates

### DIFF
--- a/pkg/apis/maistra/conversion/security.go
+++ b/pkg/apis/maistra/conversion/security.go
@@ -155,6 +155,20 @@ func populateSecurityValues(in *v2.ControlPlaneSpec, values map[string]interface
 
 			addEnvToComponent(in, "pilot", "ENABLE_CA_SERVER", "false")
 
+			// Istio 1.16+ has configured optional volumes and volume mounts for TLS certs provided by istio-csr
+			// and there is no need to configure them when "well known" paths are used.
+			if version.Compare(versions.V2_4) >= 0 {
+				extraArgs := []string{
+					"--tlsCertFile=/var/run/secrets/istiod/tls/tls.crt",
+					"--tlsKeyFile=/var/run/secrets/istiod/tls/tls.key",
+					"--caCertFile=/var/run/secrets/istiod/ca/root-cert.pem",
+				}
+				if err := setHelmStringSliceValue(values, "pilot.extraArgs", extraArgs); err != nil {
+					return fmt.Errorf("cert-manager ca config: failed setting extra args in helm chart : %s", err.Error())
+				}
+				break
+			}
+
 			extraArgs := []string{
 				"--tlsCertFile=/etc/cert-manager/tls/tls.crt",
 				"--tlsKeyFile=/etc/cert-manager/tls/tls.key",


### PR DESCRIPTION
Istio 1.16+ has configured optional volumes and volume mounts for TLS certs provided by istio-csr and there is no need to configure them when "well known" paths are used.

Signed-off-by: Jacek Ewertowski <jewertow@redhat.com>