### PR TITLE
OSSM-3398 Replace caRootCertConfigMap with caCertConfigMapName

### DIFF
--- a/resources/helm/overlays/global.yaml
+++ b/resources/helm/overlays/global.yaml
@@ -315,7 +315,7 @@ global:
   # CSR clients such as the Istio Agent and ingress gateways can use this to specify the CA endpoint.
   caAddress: ""
 
-  caRootCertConfigMap: "istio-ca-root-cert"
+  caCertConfigMapName: "istio-ca-root-cert"
 
   # Configure the mesh networks to be used by the Split Horizon EDS.
   #

--- a/resources/helm/overlays/istio-telemetry/prometheus/templates/deployment.yaml
+++ b/resources/helm/overlays/istio-telemetry/prometheus/templates/deployment.yaml
@@ -297,7 +297,7 @@ spec:
       - name: istiod-ca-cert
         configMap:
           defaultMode: 420
-          name: istio-ca-root-cert
+          name: {{ .Values.global.caCertConfigMapName }}
         {{- end }}
 {{- end }}
 

--- a/resources/helm/v2.3/global.yaml
+++ b/resources/helm/v2.3/global.yaml
@@ -315,8 +315,6 @@ global:
   # CSR clients such as the Istio Agent and ingress gateways can use this to specify the CA endpoint.
   caAddress: ""
 
-  caRootCertConfigMap: "istio-ca-root-cert"
-
   # Configure the mesh networks to be used by the Split Horizon EDS.
   #
   # The following example defines two networks with different endpoints association methods.
@@ -454,7 +452,3 @@ telemetry:
       # To reduce the number of successful logs, default log window duration is
       # set to 12 hours.
       logWindowDuration: "43200s"
-
-gatewayAPI:
-  enabled: false
-  controllerMode: false

--- a/resources/helm/v2.4/gateways/istio-egress/templates/deployment.yaml
+++ b/resources/helm/v2.4/gateways/istio-egress/templates/deployment.yaml
@@ -374,7 +374,7 @@ spec:
 {{- if eq .Values.global.pilotCertProvider "istiod" }}
       - name: istiod-ca-cert
         configMap:
-          name: "{{ .Values.global.caRootCertConfigMap }}"
+          name: {{ .Values.global.caCertConfigMapName }}
 {{- end }}
       - name: podinfo
         downwardAPI:

--- a/resources/helm/v2.4/gateways/istio-egress/values.yaml
+++ b/resources/helm/v2.4/gateways/istio-egress/values.yaml
@@ -212,6 +212,9 @@ global:
   # CSR clients such as the Istio Agent and ingress gateways can use this to specify the CA endpoint.
   caAddress: ""
 
+  # The name of the ConfigMap that stores the CA Root Certificate
+  caCertConfigMapName: "istio-ca-root-cert"
+
   # Used to locate istiod.
   istioNamespace: istio-system
 

--- a/resources/helm/v2.4/gateways/istio-ingress/templates/deployment.yaml
+++ b/resources/helm/v2.4/gateways/istio-ingress/templates/deployment.yaml
@@ -374,7 +374,7 @@ spec:
 {{- if eq .Values.global.pilotCertProvider "istiod" }}
       - name: istiod-ca-cert
         configMap:
-          name: "{{ .Values.global.caRootCertConfigMap }}"
+          name: {{ .Values.global.caCertConfigMapName }}
 {{- end }}
       - name: podinfo
         downwardAPI:

--- a/resources/helm/v2.4/gateways/istio-ingress/values.yaml
+++ b/resources/helm/v2.4/gateways/istio-ingress/values.yaml
@@ -237,6 +237,9 @@ global:
   # CSR clients such as the Istio Agent and ingress gateways can use this to specify the CA endpoint.
   caAddress: ""
 
+  # The name of the ConfigMap that stores the CA Root Certificate
+  caCertConfigMapName: "istio-ca-root-cert"
+
   # Used to locate istiod.
   istioNamespace: istio-system
 

--- a/resources/helm/v2.4/global.yaml
+++ b/resources/helm/v2.4/global.yaml
@@ -315,7 +315,7 @@ global:
   # CSR clients such as the Istio Agent and ingress gateways can use this to specify the CA endpoint.
   caAddress: ""
 
-  caRootCertConfigMap: "istio-ca-root-cert"
+  caCertConfigMapName: "istio-ca-root-cert"
 
   # Configure the mesh networks to be used by the Split Horizon EDS.
   #

--- a/resources/helm/v2.4/istio-control/istio-discovery/files/gateway-injection-template.yaml
+++ b/resources/helm/v2.4/istio-control/istio-discovery/files/gateway-injection-template.yaml
@@ -205,7 +205,7 @@ spec:
   {{- if eq .Values.global.pilotCertProvider "istiod" }}
   - name: istiod-ca-cert
     configMap:
-      name: "{{ .Values.global.caRootCertConfigMap }}"
+      name: {{ .Values.global.caCertConfigMapName }}
   {{- end }}
   {{- if .Values.global.mountMtlsCerts }}
   # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/resources/helm/v2.4/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/resources/helm/v2.4/istio-control/istio-discovery/files/gen-istio.yaml
@@ -77,6 +77,7 @@ data:
         },
         "autoscalingv2API": true,
         "caAddress": "",
+        "caCertConfigMapName": "istio-ca-root-cert",
         "caName": "",
         "configCluster": false,
         "defaultNodeSelector": {},
@@ -692,7 +693,7 @@ data:
           {{- if eq .Values.global.pilotCertProvider "istiod" }}
           - name: istiod-ca-cert
             configMap:
-              name: istio-ca-root-cert
+              name: {{ .Values.global.caCertConfigMapName }}
           {{- end }}
           {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
           - name: kube-ca-cert
@@ -939,7 +940,7 @@ data:
           {{- if eq .Values.global.pilotCertProvider "istiod" }}
           - name: istiod-ca-cert
             configMap:
-              name: istio-ca-root-cert
+              name: {{ .Values.global.caCertConfigMapName }}
           {{- end }}
           {{- if .Values.global.mountMtlsCerts }}
           # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/resources/helm/v2.4/istio-control/istio-discovery/files/injection-template.yaml
+++ b/resources/helm/v2.4/istio-control/istio-discovery/files/injection-template.yaml
@@ -364,7 +364,7 @@ spec:
   {{- if eq .Values.global.pilotCertProvider "istiod" }}
   - name: istiod-ca-cert
     configMap:
-      name: "{{ .Values.global.caRootCertConfigMap }}"
+      name: {{ .Values.global.caCertConfigMapName }}
   {{- end }}
   {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
   - name: kube-ca-cert

--- a/resources/helm/v2.4/istio-control/istio-discovery/templates/deployment.yaml
+++ b/resources/helm/v2.4/istio-control/istio-discovery/templates/deployment.yaml
@@ -144,7 +144,7 @@ spec:
           - name: ENABLE_IOR
             value: "{{ $iorEnabled }}"
           - name: PILOT_CA_CERT_CONFIG_MAP_NAME
-            value: "{{ .Values.global.caRootCertConfigMap }}"
+            value: "{{ .Values.global.caCertConfigMapName }}"
 {{- if .Values.gatewayAPI.enabled }}
           - name: PILOT_ENABLE_GATEWAY_API
             value: "true"
@@ -327,7 +327,7 @@ spec:
           optional: true
       - name: istio-csr-ca-configmap
         configMap:
-          name: "{{ .Values.global.caRootCertConfigMap }}"
+          name: "{{ .Values.global.caCertConfigMapName }}"
           defaultMode: 420
           optional: true
   {{- if .Values.pilot.jwksResolverExtraRootCA }}

--- a/resources/helm/v2.4/istio-control/istio-discovery/values.yaml
+++ b/resources/helm/v2.4/istio-control/istio-discovery/values.yaml
@@ -400,6 +400,9 @@ global:
   # If not set explicitly, default to the Istio discovery address.
   caAddress: ""
 
+  # The name of the ConfigMap that stores the CA Root Certificate
+  caCertConfigMapName: "istio-ca-root-cert"
+
   # Configure a remote cluster data plane controlled by an external istiod.
   # When set to true, istiod is not deployed locally and only a subset of the other
   # discovery charts are enabled.

--- a/resources/helm/v2.4/istio-telemetry/prometheus/templates/deployment.yaml
+++ b/resources/helm/v2.4/istio-telemetry/prometheus/templates/deployment.yaml
@@ -299,7 +299,7 @@ spec:
       - name: istiod-ca-cert
         configMap:
           defaultMode: 420
-          name: istio-ca-root-cert
+          name: {{ .Values.global.caCertConfigMapName }}
         {{- end }}
 {{- end }}
 

--- a/resources/smcp-templates/v2.4/gateway-controller
+++ b/resources/smcp-templates/v2.4/gateway-controller
@@ -14,7 +14,7 @@ spec:
     type: None
   techPreview:
     global:
-      caRootCertConfigMap: ossm-ca-root-cert
+      caCertConfigMapName: ossm-ca-root-cert
     controlPlaneMode: ClusterScoped
     gatewayAPI:
       enabled: true


### PR DESCRIPTION
In maistra/istio, we use the name caCertConfigMapName. In maistra/istio-operator, we use caRootCertConfigMap in some places. As these two values are equivalent, I've updated the code to use caCertConfigMapName everywhere.