### PR TITLE
[wip] OSSM-3248 Use a single global NetworkAttachmentDefinition

### DIFF
--- a/pkg/controller/servicemesh/controlplane/reconciler.go
+++ b/pkg/controller/servicemesh/controlplane/reconciler.go
@@ -433,7 +433,7 @@ func (r *controlPlaneInstanceReconciler) validateManifests(ctx context.Context) 
 				if err != nil || obj.GetNamespace() == "" {
 					continue
 				}
-				if !meshNamespaces.Has(obj.GetNamespace()) {
+				if obj.GetNamespace() != "default" && !meshNamespaces.Has(obj.GetNamespace()) {
 					allErrors = append(allErrors, fmt.Errorf("%s: namespace of manifest %s/%s not in mesh", manifestBundle.Name, obj.GetNamespace(), obj.GetName()))
 				}
 			}

--- a/pkg/controller/versions/versions.go
+++ b/pkg/controller/versions/versions.go
@@ -71,7 +71,7 @@ func init() {
 		V2_1:           "v2-1-istio-cni",
 		V2_2:           "v2-2-istio-cni",
 		V2_3:           "v2-3-istio-cni",
-		V2_4:           "v2-4-istio-cni",
+		V2_4:           "default/v2-4-istio-cni",
 	}
 
 	for v, str := range versionToString {

--- a/resources/helm/overlays/istio-control/istio-discovery/templates/networkattachmentdefinition.yaml
+++ b/resources/helm/overlays/istio-control/istio-discovery/templates/networkattachmentdefinition.yaml
@@ -1,0 +1,5 @@
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: v2-4-istio-cni
+  namespace: default


### PR DESCRIPTION
I implemented this as an experiment for cluster-wide mode, but have decided not to include this change in 2.4. Nevertheless, I'm creating this PR so that we don't lose this work, since we might want this change to go into maistra-next.