### PR TITLE
[WIP]Deprecate fields pilotSecretName and rootCAConfigMapName in cert-mang config

### DIFF
--- a/deploy/maistra-operator.yaml
+++ b/deploy/maistra-operator.yaml
@@ -4922,9 +4922,9 @@ spec:
                         properties:
                           address:
                             type: string
-                          pilotSecretName:
+                          pilotSecretName: istiod-tls
                             type: string
-                          rootCAConfigMapName:
+                          rootCAConfigMapName: istio-ca-root-cert
                             type: string
                         type: object
                       custom:
@@ -9800,9 +9800,9 @@ spec:
                             properties:
                               address:
                                 type: string
-                              pilotSecretName:
+                              pilotSecretName: istiod-tls
                                 type: string
-                              rootCAConfigMapName:
+                              rootCAConfigMapName: istio-ca-root-cert
                                 type: string
                             type: object
                           custom:

--- a/deploy/src/crd.yaml
+++ b/deploy/src/crd.yaml
@@ -4921,9 +4921,9 @@ spec:
                         properties:
                           address:
                             type: string
-                          pilotSecretName:
+                          pilotSecretName: istiod-tls
                             type: string
-                          rootCAConfigMapName:
+                          rootCAConfigMapName: istio-ca-root-cert
                             type: string
                         type: object
                       custom:
@@ -9799,9 +9799,9 @@ spec:
                             properties:
                               address:
                                 type: string
-                              pilotSecretName:
+                              pilotSecretName: istiod-tls
                                 type: string
-                              rootCAConfigMapName:
+                              rootCAConfigMapName: istio-ca-root-cert
                                 type: string
                             type: object
                           custom:

--- a/manifests-maistra/2.3.0/servicemeshcontrolplanes.crd.yaml
+++ b/manifests-maistra/2.3.0/servicemeshcontrolplanes.crd.yaml
@@ -4921,9 +4921,9 @@ spec:
                         properties:
                           address:
                             type: string
-                          pilotSecretName:
+                          pilotSecretName: istiod-tls
                             type: string
-                          rootCAConfigMapName:
+                          rootCAConfigMapName: istio-ca-root-cert
                             type: string
                         type: object
                       custom:
@@ -9799,9 +9799,9 @@ spec:
                             properties:
                               address:
                                 type: string
-                              pilotSecretName:
+                              pilotSecretName: istiod-tls
                                 type: string
-                              rootCAConfigMapName:
+                              rootCAConfigMapName: istio-ca-root-cert
                                 type: string
                             type: object
                           custom:

--- a/manifests-maistra/2.3.1/servicemeshcontrolplanes.crd.yaml
+++ b/manifests-maistra/2.3.1/servicemeshcontrolplanes.crd.yaml
@@ -4921,9 +4921,9 @@ spec:
                         properties:
                           address:
                             type: string
-                          pilotSecretName:
+                          pilotSecretName: istiod-tls
                             type: string
-                          rootCAConfigMapName:
+                          rootCAConfigMapName: istio-ca-root-cert
                             type: string
                         type: object
                       custom:
@@ -9799,9 +9799,9 @@ spec:
                             properties:
                               address:
                                 type: string
-                              pilotSecretName:
+                              pilotSecretName: istiod-tls
                                 type: string
-                              rootCAConfigMapName:
+                              rootCAConfigMapName: istio-ca-root-cert
                                 type: string
                             type: object
                           custom:

--- a/manifests-maistra/2.4.0/servicemeshcontrolplanes.crd.yaml
+++ b/manifests-maistra/2.4.0/servicemeshcontrolplanes.crd.yaml
@@ -4921,9 +4921,9 @@ spec:
                         properties:
                           address:
                             type: string
-                          pilotSecretName:
+                          pilotSecretName: istiod-tls
                             type: string
-                          rootCAConfigMapName:
+                          rootCAConfigMapName: istio-ca-root-cert
                             type: string
                         type: object
                       custom:
@@ -9799,9 +9799,9 @@ spec:
                             properties:
                               address:
                                 type: string
-                              pilotSecretName:
+                              pilotSecretName: istiod-tls
                                 type: string
-                              rootCAConfigMapName:
+                              rootCAConfigMapName: istio-ca-root-cert
                                 type: string
                             type: object
                           custom:

--- a/manifests-servicemesh/2.2.0/servicemeshcontrolplanes.crd.yaml
+++ b/manifests-servicemesh/2.2.0/servicemeshcontrolplanes.crd.yaml
@@ -4919,9 +4919,9 @@ spec:
                         properties:
                           address:
                             type: string
-                          pilotSecretName:
+                          pilotSecretName: istiod-tls
                             type: string
-                          rootCAConfigMapName:
+                          rootCAConfigMapName: istio-ca-root-cert
                             type: string
                         type: object
                       custom:
@@ -9797,9 +9797,9 @@ spec:
                             properties:
                               address:
                                 type: string
-                              pilotSecretName:
+                              pilotSecretName: istiod-tls
                                 type: string
-                              rootCAConfigMapName:
+                              rootCAConfigMapName: istio-ca-root-tls
                                 type: string
                             type: object
                           custom:

--- a/manifests-servicemesh/2.2.0/servicemeshcontrolplanes.crd.yaml
+++ b/manifests-servicemesh/2.2.0/servicemeshcontrolplanes.crd.yaml
@@ -9799,7 +9799,7 @@ spec:
                                 type: string
                               pilotSecretName: istiod-tls
                                 type: string
-                              rootCAConfigMapName: istio-ca-root-tls
+                              rootCAConfigMapName: istio-ca-root-cert
                                 type: string
                             type: object
                           custom:


### PR DESCRIPTION
https://issues.redhat.com/browse/OSSM-3376