### PR TITLE
OSSM-3468 Don't create RoleBindings in member namespace in ClusterWide mode

### DIFF
--- a/pkg/controller/servicemesh/member/controller_test.go
+++ b/pkg/controller/servicemesh/member/controller_test.go
@@ -677,9 +677,9 @@ type fakeNamespaceReconcilerFactory struct {
 }
 
 func (rf *fakeNamespaceReconcilerFactory) newReconciler(ctx context.Context, cl client.Client,
-	meshNamespace string, meshVersion versions.Version, isCNIEnabled bool,
+	meshNamespace string, meshVersion versions.Version, clusterWideMode, isCNIEnabled bool,
 ) (NamespaceReconciler, error) {
-	delegate, err := newNamespaceReconciler(ctx, cl, meshNamespace, meshVersion, isCNIEnabled)
+	delegate, err := newNamespaceReconciler(ctx, cl, meshNamespace, meshVersion, clusterWideMode, isCNIEnabled)
 	rf.reconciler.delegate = delegate
 	return rf.reconciler, err
 }

--- a/pkg/controller/servicemesh/member/namespace_reconciler_test.go
+++ b/pkg/controller/servicemesh/member/namespace_reconciler_test.go
@@ -272,7 +272,7 @@ func TestOtherResourcesArePreserved(t *testing.T) {
 }
 
 func setupReconciledNamespace(t *testing.T, cl client.Client, namespace string) {
-	reconciler, err := newNamespaceReconciler(ctx, cl, controlPlaneNamespace, versions.DefaultVersion, true)
+	reconciler, err := newNamespaceReconciler(ctx, cl, controlPlaneNamespace, versions.DefaultVersion, false, true)
 	if err != nil {
 		t.Fatalf("Error creating namespace reconciler: %v", err)
 	}
@@ -291,7 +291,7 @@ func assertNotFound(err error, message string, t *testing.T) {
 }
 
 func assertReconcileNamespaceSucceeds(t *testing.T, cl client.Client, networkStrategy NamespaceReconciler) {
-	reconciler, err := newNamespaceReconciler(ctx, cl, controlPlaneNamespace, versions.DefaultVersion, true)
+	reconciler, err := newNamespaceReconciler(ctx, cl, controlPlaneNamespace, versions.DefaultVersion, false, true)
 	if err != nil {
 		t.Fatalf("Error creating namespace reconciler: %v", err)
 	}
@@ -306,7 +306,7 @@ func assertReconcileNamespaceSucceeds(t *testing.T, cl client.Client, networkStr
 }
 
 func assertRemoveNamespaceSucceeds(t *testing.T, cl client.Client, networkStrategy NamespaceReconciler) {
-	reconciler, err := newNamespaceReconciler(ctx, cl, controlPlaneNamespace, versions.DefaultVersion, true)
+	reconciler, err := newNamespaceReconciler(ctx, cl, controlPlaneNamespace, versions.DefaultVersion, false, true)
 	if err != nil {
 		t.Fatalf("Error creating namespace reconciler: %v", err)
 	}
@@ -321,7 +321,7 @@ func assertRemoveNamespaceSucceeds(t *testing.T, cl client.Client, networkStrate
 }
 
 func assertReconcileNamespaceFails(t *testing.T, cl client.Client) {
-	reconciler, err := newNamespaceReconciler(ctx, cl, controlPlaneNamespace, versions.DefaultVersion, true)
+	reconciler, err := newNamespaceReconciler(ctx, cl, controlPlaneNamespace, versions.DefaultVersion, false, true)
 	if err != nil {
 		t.Fatalf("Error creating namespace reconciler: %v", err)
 	}
@@ -332,7 +332,7 @@ func assertReconcileNamespaceFails(t *testing.T, cl client.Client) {
 }
 
 func assertRemoveNamespaceFails(t *testing.T, cl client.Client) {
-	reconciler, err := newNamespaceReconciler(ctx, cl, controlPlaneNamespace, versions.DefaultVersion, true)
+	reconciler, err := newNamespaceReconciler(ctx, cl, controlPlaneNamespace, versions.DefaultVersion, false, true)
 	if err != nil {
 		t.Fatalf("Error creating namespace reconciler: %v", err)
 	}


### PR DESCRIPTION
The RoleBinding isn't required, since istiod already has a ClusterRoleBinding that gives it the same privileges.