### PR TITLE
OSSM-3291: Allow to set `spec.extensionProviders` only in 2.4+

### DIFF
--- a/pkg/controller/versions/strategy_v2_0.go
+++ b/pkg/controller/versions/strategy_v2_0.go
@@ -143,6 +143,7 @@ func (v *versionStrategyV2_0) ValidateV1(ctx context.Context, cl client.Client, 
 func (v *versionStrategyV2_0) ValidateV2(ctx context.Context, cl client.Client, meta *metav1.ObjectMeta, spec *v2.ControlPlaneSpec) error {
 	var allErrors []error
 	allErrors = v.validateGlobal(spec, allErrors)
+	allErrors = validateUnsupportedAPIs(v.Version(), spec, allErrors)
 	allErrors = validateGateways(ctx, meta, spec, cl, allErrors)
 	allErrors = validatePolicyType(spec, v.Ver, allErrors)
 	allErrors = validateTelemetryType(spec, v.Ver, allErrors)

--- a/pkg/controller/versions/strategy_v2_0.go
+++ b/pkg/controller/versions/strategy_v2_0.go
@@ -143,7 +143,6 @@ func (v *versionStrategyV2_0) ValidateV1(ctx context.Context, cl client.Client, 
 func (v *versionStrategyV2_0) ValidateV2(ctx context.Context, cl client.Client, meta *metav1.ObjectMeta, spec *v2.ControlPlaneSpec) error {
 	var allErrors []error
 	allErrors = v.validateGlobal(spec, allErrors)
-	allErrors = validateUnsupportedAPIs(v.Version(), spec, allErrors)
 	allErrors = validateGateways(ctx, meta, spec, cl, allErrors)
 	allErrors = validatePolicyType(spec, v.Ver, allErrors)
 	allErrors = validateTelemetryType(spec, v.Ver, allErrors)
@@ -528,5 +527,6 @@ func (v *versionStrategyV2_0) GetTrustDomainFieldPath() string {
 }
 
 func (v *versionStrategyV2_0) validateGlobal(spec *v2.ControlPlaneSpec, allErrors []error) []error {
-	return checkControlPlaneModeNotSet(spec, allErrors)
+	allErrors = checkControlPlaneModeNotSet(spec, allErrors)
+	return checkExtensionProvidersNotSet(spec, allErrors)
 }

--- a/pkg/controller/versions/strategy_v2_1.go
+++ b/pkg/controller/versions/strategy_v2_1.go
@@ -141,7 +141,6 @@ func (v *versionStrategyV2_1) ValidateV1(ctx context.Context, cl client.Client, 
 func (v *versionStrategyV2_1) ValidateV2(ctx context.Context, cl client.Client, meta *metav1.ObjectMeta, spec *v2.ControlPlaneSpec) error {
 	var allErrors []error
 	allErrors = v.validateGlobal(spec, allErrors)
-	allErrors = validateUnsupportedAPIs(v.Version(), spec, allErrors)
 	allErrors = validateGateways(ctx, meta, spec, cl, allErrors)
 	allErrors = validatePolicyType(spec, v.Ver, allErrors)
 	allErrors = validateTelemetryType(spec, v.Ver, allErrors)
@@ -627,5 +626,6 @@ func validateAndConfigureRLS(spec *v1.HelmValues) error {
 }
 
 func (v *versionStrategyV2_1) validateGlobal(spec *v2.ControlPlaneSpec, allErrors []error) []error {
-	return checkControlPlaneModeNotSet(spec, allErrors)
+	allErrors = checkControlPlaneModeNotSet(spec, allErrors)
+	return checkExtensionProvidersNotSet(spec, allErrors)
 }

--- a/pkg/controller/versions/strategy_v2_1.go
+++ b/pkg/controller/versions/strategy_v2_1.go
@@ -141,6 +141,7 @@ func (v *versionStrategyV2_1) ValidateV1(ctx context.Context, cl client.Client, 
 func (v *versionStrategyV2_1) ValidateV2(ctx context.Context, cl client.Client, meta *metav1.ObjectMeta, spec *v2.ControlPlaneSpec) error {
 	var allErrors []error
 	allErrors = v.validateGlobal(spec, allErrors)
+	allErrors = validateUnsupportedAPIs(v.Version(), spec, allErrors)
 	allErrors = validateGateways(ctx, meta, spec, cl, allErrors)
 	allErrors = validatePolicyType(spec, v.Ver, allErrors)
 	allErrors = validateTelemetryType(spec, v.Ver, allErrors)

--- a/pkg/controller/versions/strategy_v2_2.go
+++ b/pkg/controller/versions/strategy_v2_2.go
@@ -142,7 +142,6 @@ func (v *versionStrategyV2_2) ValidateV1(ctx context.Context, cl client.Client, 
 func (v *versionStrategyV2_2) ValidateV2(ctx context.Context, cl client.Client, meta *metav1.ObjectMeta, spec *v2.ControlPlaneSpec) error {
 	var allErrors []error
 	allErrors = v.validateGlobal(spec, allErrors)
-	allErrors = validateUnsupportedAPIs(v.Version(), spec, allErrors)
 	allErrors = validateGateways(ctx, meta, spec, cl, allErrors)
 	allErrors = validatePolicyType(spec, v.Ver, allErrors)
 	allErrors = validateTelemetryType(spec, v.Ver, allErrors)
@@ -609,5 +608,6 @@ func (v *versionStrategyV2_2) GetTrustDomainFieldPath() string {
 }
 
 func (v *versionStrategyV2_2) validateGlobal(spec *v2.ControlPlaneSpec, allErrors []error) []error {
-	return checkControlPlaneModeNotSet(spec, allErrors)
+	allErrors = checkControlPlaneModeNotSet(spec, allErrors)
+	return checkExtensionProvidersNotSet(spec, allErrors)
 }

--- a/pkg/controller/versions/strategy_v2_2.go
+++ b/pkg/controller/versions/strategy_v2_2.go
@@ -142,6 +142,7 @@ func (v *versionStrategyV2_2) ValidateV1(ctx context.Context, cl client.Client, 
 func (v *versionStrategyV2_2) ValidateV2(ctx context.Context, cl client.Client, meta *metav1.ObjectMeta, spec *v2.ControlPlaneSpec) error {
 	var allErrors []error
 	allErrors = v.validateGlobal(spec, allErrors)
+	allErrors = validateUnsupportedAPIs(v.Version(), spec, allErrors)
 	allErrors = validateGateways(ctx, meta, spec, cl, allErrors)
 	allErrors = validatePolicyType(spec, v.Ver, allErrors)
 	allErrors = validateTelemetryType(spec, v.Ver, allErrors)

--- a/pkg/controller/versions/strategy_v2_3.go
+++ b/pkg/controller/versions/strategy_v2_3.go
@@ -131,7 +131,6 @@ func (v *versionStrategyV2_3) ValidateV1(_ context.Context, _ client.Client, _ *
 func (v *versionStrategyV2_3) ValidateV2(ctx context.Context, cl client.Client, meta *metav1.ObjectMeta, spec *v2.ControlPlaneSpec) error {
 	var allErrors []error
 	allErrors = v.validateGlobal(ctx, v.Ver, meta, spec, cl, allErrors)
-	allErrors = validateUnsupportedAPIs(v.Version(), spec, allErrors)
 	allErrors = validateGateways(ctx, meta, spec, cl, allErrors)
 	allErrors = validatePolicyType(spec, v.Ver, allErrors)
 	allErrors = validateTelemetryType(spec, v.Ver, allErrors)
@@ -705,18 +704,18 @@ func (v *versionStrategyV2_3) validateGlobal(
 	spec *v2.ControlPlaneSpec, cl client.Client, allErrors []error,
 ) []error {
 	if spec.Mode != "" {
-		return append(allErrors,
+		allErrors = append(allErrors,
 			fmt.Errorf("the spec.mode field is not supported in version 2.3; use spec.techPreview.%s",
 				v2.TechPreviewControlPlaneModeKey))
 	} else if spec.TechPreview != nil {
 		if mode, found, _ := spec.TechPreview.GetString(v2.TechPreviewControlPlaneModeKey); found {
 			if mode != v2.TechPreviewControlPlaneModeValueClusterScoped && mode != v2.TechPreviewControlPlaneModeValueMultiTenant {
-				return append(allErrors,
+				allErrors = append(allErrors,
 					fmt.Errorf("spec.techPreview.%s must be either %s or %s",
 						v2.TechPreviewControlPlaneModeKey, v2.TechPreviewControlPlaneModeValueMultiTenant, v2.TechPreviewControlPlaneModeValueClusterScoped))
 			}
 		}
 	}
-
+	allErrors = checkExtensionProvidersNotSet(spec, allErrors)
 	return validateGlobal(ctx, version, meta, spec, cl, allErrors)
 }

--- a/pkg/controller/versions/strategy_v2_3.go
+++ b/pkg/controller/versions/strategy_v2_3.go
@@ -131,6 +131,7 @@ func (v *versionStrategyV2_3) ValidateV1(_ context.Context, _ client.Client, _ *
 func (v *versionStrategyV2_3) ValidateV2(ctx context.Context, cl client.Client, meta *metav1.ObjectMeta, spec *v2.ControlPlaneSpec) error {
 	var allErrors []error
 	allErrors = v.validateGlobal(ctx, v.Ver, meta, spec, cl, allErrors)
+	allErrors = validateUnsupportedAPIs(v.Version(), spec, allErrors)
 	allErrors = validateGateways(ctx, meta, spec, cl, allErrors)
 	allErrors = validatePolicyType(spec, v.Ver, allErrors)
 	allErrors = validateTelemetryType(spec, v.Ver, allErrors)

--- a/pkg/controller/versions/strategy_v2_4.go
+++ b/pkg/controller/versions/strategy_v2_4.go
@@ -129,6 +129,7 @@ func (v *versionStrategyV2_4) ValidateV1(_ context.Context, _ client.Client, _ *
 func (v *versionStrategyV2_4) ValidateV2(ctx context.Context, cl client.Client, meta *metav1.ObjectMeta, spec *v2.ControlPlaneSpec) error {
 	var allErrors []error
 	allErrors = v.validateGlobal(ctx, v.Version(), meta, spec, cl, allErrors)
+	allErrors = validateUnsupportedAPIs(v.Version(), spec, allErrors)
 	allErrors = validateGateways(ctx, meta, spec, cl, allErrors)
 	allErrors = validatePolicyType(spec, v.Ver, allErrors)
 	allErrors = validateTelemetryType(spec, v.Ver, allErrors)

--- a/pkg/controller/versions/strategy_v2_4.go
+++ b/pkg/controller/versions/strategy_v2_4.go
@@ -129,7 +129,6 @@ func (v *versionStrategyV2_4) ValidateV1(_ context.Context, _ client.Client, _ *
 func (v *versionStrategyV2_4) ValidateV2(ctx context.Context, cl client.Client, meta *metav1.ObjectMeta, spec *v2.ControlPlaneSpec) error {
 	var allErrors []error
 	allErrors = v.validateGlobal(ctx, v.Version(), meta, spec, cl, allErrors)
-	allErrors = validateUnsupportedAPIs(v.Version(), spec, allErrors)
 	allErrors = validateGateways(ctx, meta, spec, cl, allErrors)
 	allErrors = validatePolicyType(spec, v.Ver, allErrors)
 	allErrors = validateTelemetryType(spec, v.Ver, allErrors)

--- a/pkg/controller/versions/util.go
+++ b/pkg/controller/versions/util.go
@@ -51,6 +51,13 @@ func checkControlPlaneModeNotSet(spec *v2.ControlPlaneSpec, allErrors []error) [
 	return allErrors
 }
 
+func checkExtensionProvidersNotSet(spec *v2.ControlPlaneSpec, allErrors []error) []error {
+	if spec.ExtensionProviders != nil {
+		return append(allErrors, fmt.Errorf("the spec.extensionProviders field is only supported in version 2.4 and above"))
+	}
+	return allErrors
+}
+
 func validateGlobal(ctx context.Context, version Ver, meta *metav1.ObjectMeta, spec *v2.ControlPlaneSpec, cl client.Client, allErrors []error) []error {
 	isClusterScoped, err := version.Strategy().IsClusterScoped(spec)
 	if err != nil {
@@ -235,14 +242,6 @@ func validateProtocolDetection(spec *v2.ControlPlaneSpec, allErrors []error) []e
 		if _, err := time.ParseDuration(autoDetect.Timeout); err != nil {
 			allErrors = append(allErrors, fmt.Errorf("failed parsing spec.proxy.networking.protocol.autoDetect.timeout, not a valid duration: %s", err.Error()))
 		}
-	}
-	return allErrors
-}
-
-func validateUnsupportedAPIs(version Ver, spec *v2.ControlPlaneSpec, allErrors []error) []error {
-	if spec.ExtensionProviders != nil && version.LessThan(V2_4) {
-		allErrors = append(allErrors, fmt.Errorf("spec.extensionProviders is supported in SMCP v2.4 and higher;"+
-			"in previous versions use spec.techPreview.meshConfig.extensionProviders"))
 	}
 	return allErrors
 }

--- a/pkg/controller/versions/util.go
+++ b/pkg/controller/versions/util.go
@@ -240,7 +240,7 @@ func validateProtocolDetection(spec *v2.ControlPlaneSpec, allErrors []error) []e
 }
 
 func validateUnsupportedAPIs(version Ver, spec *v2.ControlPlaneSpec, allErrors []error) []error {
-	if spec.ExtensionProviders != nil && !version.AtLeast(V2_4) {
+	if spec.ExtensionProviders != nil && version.LessThan(V2_4) {
 		allErrors = append(allErrors, fmt.Errorf("spec.extensionProviders is supported in SMCP v2.4 and higher;"+
 			"in previous versions use spec.techPreview.meshConfig.extensionProviders"))
 	}

--- a/pkg/controller/versions/util.go
+++ b/pkg/controller/versions/util.go
@@ -239,6 +239,14 @@ func validateProtocolDetection(spec *v2.ControlPlaneSpec, allErrors []error) []e
 	return allErrors
 }
 
+func validateUnsupportedAPIs(version Ver, spec *v2.ControlPlaneSpec, allErrors []error) []error {
+	if spec.ExtensionProviders != nil && !version.AtLeast(V2_4) {
+		allErrors = append(allErrors, fmt.Errorf("spec.extensionProviders is supported in SMCP v2.4 and higher;"+
+			"in previous versions use spec.techPreview.meshConfig.extensionProviders"))
+	}
+	return allErrors
+}
+
 func errForEnabledValue(obj *v1.HelmValues, path string) error {
 	val, ok, _ := obj.GetFieldNoCopy(path)
 	if ok {


### PR DESCRIPTION
We wanted to make extension providers GA in OSSM 2.4, but currently it's possible to enable this feature for previous versions as well.