### PR TITLE
OSSM-2436 Add readiness probe and improve first start

### DIFF
--- a/deploy/maistra-operator.yaml
+++ b/deploy/maistra-operator.yaml
@@ -10794,6 +10794,8 @@ metadata:
   namespace: istio-operator
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       name: istio-operator
@@ -10850,6 +10852,8 @@ spec:
         ports:
         - containerPort: 11999
           name: validation
+        - containerPort: 11200
+          name: probes
         - containerPort: 60000
           name: metrics
         command:
@@ -10868,6 +10872,11 @@ spec:
           value: istio-operator
 #        - name: ISTIO_CNI_IMAGE_PULL_SECRET
 #          value: name-of-secret
+        readinessProbe:
+          httpGet:
+            scheme: HTTP
+            path: /readyz
+            port: 11200
         volumeMounts:
         - name: operator-olm-config
           mountPath: /etc/operator/olm

--- a/deploy/servicemesh-operator.yaml
+++ b/deploy/servicemesh-operator.yaml
@@ -10794,6 +10794,8 @@ metadata:
   namespace: istio-operator
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       name: istio-operator
@@ -10856,6 +10858,8 @@ spec:
         ports:
         - containerPort: 11999
           name: validation
+        - containerPort: 11200
+          name: probes
         - containerPort: 60000
           name: metrics
         command:
@@ -10874,6 +10878,11 @@ spec:
           value: istio-operator
 #        - name: ISTIO_CNI_IMAGE_PULL_SECRET
 #          value: name-of-secret
+        readinessProbe:
+          httpGet:
+            scheme: HTTP
+            path: /readyz
+            port: 11200
         volumeMounts:
         - name: operator-olm-config
           mountPath: /etc/operator/olm

--- a/deploy/src/deployment-maistra.yaml
+++ b/deploy/src/deployment-maistra.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: istio-operator
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       name: istio-operator
@@ -61,6 +63,8 @@ spec:
         ports:
         - containerPort: 11999
           name: validation
+        - containerPort: 11200
+          name: probes
         - containerPort: 60000
           name: metrics
         command:
@@ -79,6 +83,11 @@ spec:
           value: istio-operator
 #        - name: ISTIO_CNI_IMAGE_PULL_SECRET
 #          value: name-of-secret
+        readinessProbe:
+          httpGet:
+            scheme: HTTP
+            path: /readyz
+            port: 11200
         volumeMounts:
         - name: operator-olm-config
           mountPath: /etc/operator/olm

--- a/deploy/src/deployment-servicemesh.yaml
+++ b/deploy/src/deployment-servicemesh.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: istio-operator
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       name: istio-operator
@@ -67,6 +69,8 @@ spec:
         ports:
         - containerPort: 11999
           name: validation
+        - containerPort: 11200
+          name: probes
         - containerPort: 60000
           name: metrics
         command:
@@ -85,6 +89,11 @@ spec:
           value: istio-operator
 #        - name: ISTIO_CNI_IMAGE_PULL_SECRET
 #          value: name-of-secret
+        readinessProbe:
+          httpGet:
+            scheme: HTTP
+            path: /readyz
+            port: 11200
         volumeMounts:
         - name: operator-olm-config
           mountPath: /etc/operator/olm

--- a/manifests-maistra/2.4.0/maistraoperator.v2.4.0.clusterserviceversion.yaml
+++ b/manifests-maistra/2.4.0/maistraoperator.v2.4.0.clusterserviceversion.yaml
@@ -15,7 +15,7 @@ metadata:
       The Maistra Operator enables you to install, configure, and manage an instance of Maistra service mesh. Maistra is based on the open source Istio project.
 
     containerImage: quay.io/maistra/istio-ubi8-operator:2.4.0
-    createdAt: 2022-12-19T14:03:48EST
+    createdAt: 2023-04-06T13:11:55CEST
     support: Red Hat, Inc. 
     olm.skipRange: ">=1.0.2 <2.4.0-0"
     operators.openshift.io/infrastructure-features: '[]'
@@ -530,6 +530,8 @@ spec:
         spec:
 
           replicas: 1
+          strategy:
+            type: Recreate
           selector:
             matchLabels:
               name: istio-operator
@@ -581,6 +583,8 @@ spec:
                   ports:
                     - containerPort: 11999
                       name: validation
+                    - containerPort: 11200
+                      name: probes
                     - containerPort: 60000
                       name: metrics
                   command:
@@ -599,6 +603,11 @@ spec:
                       value: istio-operator
                       #        - name: ISTIO_CNI_IMAGE_PULL_SECRET
                       #          value: name-of-secret
+                  readinessProbe:
+                    httpGet:
+                      scheme: HTTP
+                      path: /readyz
+                      port: 11200
                   volumeMounts:
                     - name: operator-olm-config
                       mountPath: /etc/operator/olm

--- a/manifests-servicemesh/2.4.0/servicemeshoperator.v2.4.0.clusterserviceversion.yaml
+++ b/manifests-servicemesh/2.4.0/servicemeshoperator.v2.4.0.clusterserviceversion.yaml
@@ -17,7 +17,7 @@ metadata:
       The OpenShift Service Mesh Operator enables you to install, configure, and manage an instance of Red Hat OpenShift Service Mesh. OpenShift Service Mesh is based on the open source Istio project.
 
     containerImage: ${OSSM_OPERATOR_IMAGE}
-    createdAt: 2022-12-19T14:03:49EST
+    createdAt: 2023-04-06T13:11:56CEST
     support: Red Hat, Inc. 
     olm.skipRange: ">=1.0.2 <2.4.0-0"
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
@@ -508,6 +508,8 @@ spec:
         spec:
 
           replicas: 1
+          strategy:
+            type: Recreate
           selector:
             matchLabels:
               name: istio-operator
@@ -569,6 +571,8 @@ spec:
                   ports:
                     - containerPort: 11999
                       name: validation
+                    - containerPort: 11200
+                      name: probes
                     - containerPort: 60000
                       name: metrics
                   command:
@@ -587,6 +591,11 @@ spec:
                       value: istio-operator
                       #        - name: ISTIO_CNI_IMAGE_PULL_SECRET
                       #          value: name-of-secret
+                  readinessProbe:
+                    httpGet:
+                      scheme: HTTP
+                      path: /readyz
+                      port: 11200
                   volumeMounts:
                     - name: operator-olm-config
                       mountPath: /etc/operator/olm


### PR DESCRIPTION

Before this fix, the first operator run looked like this:
```
$ kubectl get pods -w
NAME             READY   STATUS              RESTARTS   AGE
istio-operator   0/1     Pending             0          0s
istio-operator   0/1     Pending             0          0s
istio-operator   0/1     ContainerCreating   0          0s
istio-operator   0/1     ContainerCreating   0          2s
istio-operator   1/1     Running             0          17s    <-- shown as ready immediately after starting
istio-operator   0/1     Error               0          54s    <-- Error when restarting to pick up secrets
istio-operator   1/1     Running             1          61s    <-- immediately ready
```

After this fix, the operator starts like this:
```
NAME             READY   STATUS              RESTARTS   AGE
istio-operator   0/1     Pending             0          0s
istio-operator   0/1     Pending             0          0s
istio-operator   0/1     ContainerCreating   0          0s
istio-operator   0/1     ContainerCreating   0          3s
istio-operator   0/1     Running             0          11s    <-- running, but not yet ready
istio-operator   0/1     Completed           0          16s    <-- much faster restart and with no Error
istio-operator   0/1     Running             1          19s    <-- running, but not yet ready
istio-operator   1/1     Running             1          31s    <-- ready, because webhooks are ready
```