### PR TITLE
OSSM-3235 Ensure operator can't deadlock because istiod isn't running

### DIFF
--- a/resources/helm/v2.4/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
+++ b/resources/helm/v2.4/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
@@ -29,6 +29,10 @@ webhooks:
         operator: In
         values:
         - {{ .Release.Namespace }}
+    objectSelector:
+      matchExpressions:
+      - key: maistra-version
+        operator: DoesNotExist
     rules:
       - operations:
         - CREATE


### PR DESCRIPTION
If istiod isn't running, but the validating webhook configuration resource is in place, the operator may not be able to reconcile the SMCP and reset istiod.

Here, we configure the webhook with an objectSelector that excludes resources with the `maistra-version` label. All resources created by the operator for the SMCP contain this label and thus don't trigger the webhook. This allows the operator to complete the reconciliation even if the webhook is offline.