### PR TITLE
OSSM-1352: Integrate with custom Kiali and external Prometheus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ REPLACES_COMMUNITY_CSV ?= 2.3.0
 VERSION                ?= development
 CONTAINER_CLI          ?= docker
 COMMUNITY              ?= true
-TEST_TIMEOUT           ?= 5m
+TEST_TIMEOUT           ?= 10m
 TEST_FLAGS             ?=
 
 SOURCE_DIR          := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))

--- a/pkg/apis/maistra/v2/servicemeshcontrolplane_types.go
+++ b/pkg/apis/maistra/v2/servicemeshcontrolplane_types.go
@@ -204,6 +204,11 @@ func (s ControlPlaneSpec) IsKialiEnabled() bool {
 		*s.Addons.Kiali.Enabled
 }
 
+func (s ControlPlaneSpec) IsCustomKialiConfigured() bool {
+	return s.Addons != nil && s.Addons.Kiali != nil &&
+		s.Addons.Kiali.Name != ""
+}
+
 func (s ControlPlaneSpec) IsPrometheusEnabled() bool {
 	return s.Addons != nil &&
 		s.Addons.Prometheus != nil &&

--- a/pkg/apis/maistra/v2/servicemeshcontrolplane_types.go
+++ b/pkg/apis/maistra/v2/servicemeshcontrolplane_types.go
@@ -205,8 +205,7 @@ func (s ControlPlaneSpec) IsKialiEnabled() bool {
 }
 
 func (s ControlPlaneSpec) IsCustomKialiConfigured() bool {
-	return s.Addons != nil && s.Addons.Kiali != nil &&
-		s.Addons.Kiali.Name != ""
+	return s.Addons != nil && s.Addons.Kiali != nil && s.Addons.Kiali.Name != ""
 }
 
 func (s ControlPlaneSpec) IsPrometheusEnabled() bool {

--- a/pkg/controller/servicemesh/controlplane/addons.go
+++ b/pkg/controller/servicemesh/controlplane/addons.go
@@ -57,8 +57,10 @@ func (r *controlPlaneInstanceReconciler) patchKiali(ctx context.Context, grafana
 	}
 
 	// grafana
-	// TODO: skip if Grafana disabled
-	grafanaURL := r.grafanaURL(ctx, log)
+	var grafanaURL string
+	if grafanaEnabled {
+		grafanaURL = r.grafanaURL(ctx, log)
+	}
 	if grafanaURL == "" {
 		// disable grafana
 		if err := updatedKiali.Spec.SetField("external_services.grafana.enabled", false); err != nil {
@@ -76,8 +78,10 @@ func (r *controlPlaneInstanceReconciler) patchKiali(ctx context.Context, grafana
 	}
 
 	// jaeger
-	// TODO: skip if Jaeger disabled
-	jaegerURL := r.jaegerURL(ctx, log)
+	var jaegerURL string
+	if jaegerEnabled {
+		jaegerURL = r.jaegerURL(ctx, log)
+	}
 	if jaegerURL == "" {
 		// disable jaeger
 		if err := updatedKiali.Spec.SetField("external_services.tracing.enabled", false); err != nil {

--- a/pkg/controller/servicemesh/controlplane/addons.go
+++ b/pkg/controller/servicemesh/controlplane/addons.go
@@ -46,10 +46,6 @@ func (r *controlPlaneInstanceReconciler) patchKiali(ctx context.Context, grafana
 
 	log.Info("patching kiali CR", kiali.Kind, kiali.GetName())
 
-	if kiali.Spec == nil {
-		kiali.Spec = maistrav1.NewHelmValues(make(map[string]interface{}))
-	}
-
 	updatedKiali := &kialiv1alpha1.Kiali{
 		Base: external.Base{
 			ObjectMeta: metav1.ObjectMeta{
@@ -61,6 +57,7 @@ func (r *controlPlaneInstanceReconciler) patchKiali(ctx context.Context, grafana
 	}
 
 	// grafana
+	// TODO: skip if Grafana disabled
 	grafanaURL := r.grafanaURL(ctx, log)
 	if grafanaURL == "" {
 		// disable grafana
@@ -79,6 +76,7 @@ func (r *controlPlaneInstanceReconciler) patchKiali(ctx context.Context, grafana
 	}
 
 	// jaeger
+	// TODO: skip if Jaeger disabled
 	jaegerURL := r.jaegerURL(ctx, log)
 	if jaegerURL == "" {
 		// disable jaeger

--- a/pkg/controller/servicemesh/controlplane/addons_test.go
+++ b/pkg/controller/servicemesh/controlplane/addons_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"testing"
+
 	routev1 "github.com/openshift/api/route/v1"
 	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
@@ -18,11 +21,9 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
-	"os"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"testing"
 
 	"github.com/maistra/istio-operator/pkg/apis/external"
 	jaegerv1 "github.com/maistra/istio-operator/pkg/apis/external/jaeger/v1"

--- a/pkg/controller/servicemesh/controlplane/addons_test.go
+++ b/pkg/controller/servicemesh/controlplane/addons_test.go
@@ -179,7 +179,6 @@ func TestAddonsInstall(t *testing.T) {
 			name: "addons.ingress.hosts",
 			smcp: NewSMCPForPrometheusGrafanaTests(
 				controlPlaneName,
-				versions.V2_3.String(),
 				[]string{
 					"example1.com",
 					"example2.com",
@@ -239,6 +238,9 @@ func NewSMCPForKialiJaegerTests(smcpName, kialiName, jaegerName string) *maistra
 			Type: maistrav2.TracerTypeJaeger,
 		},
 		Addons: &maistrav2.AddonsConfig{
+			Grafana: &maistrav2.GrafanaAddonConfig{
+				Enablement: featureEnabled,
+			},
 			Kiali: &maistrav2.KialiAddonConfig{
 				Enablement: maistrav2.Enablement{
 					Enabled: &enable,
@@ -252,9 +254,8 @@ func NewSMCPForKialiJaegerTests(smcpName, kialiName, jaegerName string) *maistra
 	})
 }
 
-func NewSMCPForPrometheusGrafanaTests(smcpName, version string, grafanaHosts, prometheusHosts []string) *maistrav2.ServiceMeshControlPlane {
+func NewSMCPForPrometheusGrafanaTests(smcpName string, grafanaHosts, prometheusHosts []string) *maistrav2.ServiceMeshControlPlane {
 	return NewV2SMCPResource(smcpName, controlPlaneNamespace, &maistrav2.ControlPlaneSpec{
-		Version: version,
 		Addons: &maistrav2.AddonsConfig{
 			Kiali: &maistrav2.KialiAddonConfig{
 				Enablement: featureDisabled,
@@ -321,7 +322,7 @@ func VerifyKialiUpdate(jaegerName, domain string, values *maistrav1.HelmValues) 
 	var allErrors []error
 	expectedGrafanaURL := "https://grafana." + domain
 	if url, _, _ := values.GetString("spec.external_services.grafana.url"); url != expectedGrafanaURL {
-		allErrors = append(allErrors, fmt.Errorf("unexpected grafana URL, expected %s, got %s", expectedGrafanaURL, url))
+		allErrors = append(allErrors, fmt.Errorf("unexpected grafana URL, expected %s, got '%s'", expectedGrafanaURL, url))
 	}
 	if enabled, _, _ := values.GetBool("spec.external_services.grafana.enabled"); !enabled {
 		allErrors = append(allErrors, fmt.Errorf("expected grafana to be enabled"))

--- a/pkg/controller/servicemesh/controlplane/common_test.go
+++ b/pkg/controller/servicemesh/controlplane/common_test.go
@@ -178,6 +178,12 @@ func New20SMCPResource(name, namespace string, spec *maistrav2.ControlPlaneSpec)
 	return smcp
 }
 
+func NewV2xSMCPResource(name, namespace string, spec *maistrav2.ControlPlaneSpec, version string) *maistrav2.ServiceMeshControlPlane {
+	smcp := NewV2SMCPResource(name, namespace, spec)
+	smcp.Spec.Version = version
+	return smcp
+}
+
 func NewV2SMCPResource(name, namespace string, spec *maistrav2.ControlPlaneSpec) *maistrav2.ServiceMeshControlPlane {
 	smcp := &maistrav2.ServiceMeshControlPlane{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},

--- a/pkg/controller/servicemesh/controlplane/gateways_test.go
+++ b/pkg/controller/servicemesh/controlplane/gateways_test.go
@@ -302,7 +302,7 @@ func TestAdditionalIngressGatewayInstall(t *testing.T) {
 			},
 		},
 	}
-	RunSimpleInstallTest(t, testCases)
+	RunSimpleInstallTests(t, testCases)
 }
 
 func ExpectedLabelGatewayCreate(labelName string, expectedValue string) func(action clienttesting.Action) error {

--- a/pkg/controller/servicemesh/controlplane/integration_test.go
+++ b/pkg/controller/servicemesh/controlplane/integration_test.go
@@ -65,7 +65,7 @@ func TestDefaultInstall(t *testing.T) {
 			},
 		},
 	}
-	RunSimpleInstallTest(t, testCases)
+	RunSimpleInstallTests(t, testCases)
 }
 
 func TestBootstrapping(t *testing.T) {

--- a/pkg/controller/servicemesh/controlplane/networkpolicy_test.go
+++ b/pkg/controller/servicemesh/controlplane/networkpolicy_test.go
@@ -68,5 +68,5 @@ func TestNetworkPolicy(t *testing.T) {
 			},
 		},
 	}
-	RunSimpleInstallTest(t, testCases)
+	RunSimpleInstallTests(t, testCases)
 }

--- a/pkg/controller/servicemesh/controlplane/rls_test.go
+++ b/pkg/controller/servicemesh/controlplane/rls_test.go
@@ -205,7 +205,7 @@ func TestRLS(t *testing.T) {
 			},
 		},
 	}
-	RunSimpleInstallTest(t, testCases)
+	RunSimpleInstallTests(t, testCases)
 }
 
 func checkEnvVariables(mustHaveVariables map[string]string, mustNotHaveVariables []string) func(action clienttesting.Action) error {

--- a/pkg/controller/servicemesh/controlplane/wasm_extensions_test.go
+++ b/pkg/controller/servicemesh/controlplane/wasm_extensions_test.go
@@ -30,5 +30,5 @@ func TestWASMExtensionInstall(t *testing.T) {
 			},
 		},
 	}
-	RunSimpleInstallTest(t, testCases)
+	RunSimpleInstallTests(t, testCases)
 }

--- a/pkg/controller/versions/strategy_v2_4.go
+++ b/pkg/controller/versions/strategy_v2_4.go
@@ -267,7 +267,7 @@ func (v *versionStrategyV2_4) ValidateV2Full(ctx context.Context, cl client.Clie
 		}
 	}
 	// additional validation checks that are only performed just before reconciliation
-	allErrors = validatePrometheusEnabledWhenKialiEnabled(spec, allErrors)
+	allErrors = validatePrometheusEnabledWhenDefaultKialiEnabled(spec, allErrors)
 	return NewValidationError(allErrors...)
 }
 
@@ -739,6 +739,13 @@ func (v *versionStrategyV2_4) validateGlobal(
 	}
 
 	return validateGlobal(ctx, version, meta, spec, cl, allErrors)
+}
+
+func validatePrometheusEnabledWhenDefaultKialiEnabled(spec *v2.ControlPlaneSpec, allErrors []error) []error {
+	if spec.IsKialiEnabled() && !spec.IsCustomKialiConfigured() && !spec.IsPrometheusEnabled() {
+		return append(allErrors, fmt.Errorf(".spec.addons.prometheus.enabled must be true when .spec.addons.kiali.enabled is true and spec.addons.kiali.name is not specified"))
+	}
+	return allErrors
 }
 
 func (v *versionStrategyV2_4) createMemberRoll(ctx context.Context, cr *common.ControllerResources, smcp *v2.ServiceMeshControlPlane) error {

--- a/pkg/controller/versions/strategy_v2_4.go
+++ b/pkg/controller/versions/strategy_v2_4.go
@@ -743,7 +743,8 @@ func (v *versionStrategyV2_4) validateGlobal(
 
 func validatePrometheusEnabledWhenDefaultKialiEnabled(spec *v2.ControlPlaneSpec, allErrors []error) []error {
 	if spec.IsKialiEnabled() && !spec.IsCustomKialiConfigured() && !spec.IsPrometheusEnabled() {
-		return append(allErrors, fmt.Errorf(".spec.addons.prometheus.enabled must be true when .spec.addons.kiali.enabled is true and spec.addons.kiali.name is not specified"))
+		return append(allErrors, fmt.Errorf(".spec.addons.prometheus.enabled must be true when "+
+			".spec.addons.kiali.enabled is true and spec.addons.kiali.name is not specified"))
 	}
 	return allErrors
 }


### PR DESCRIPTION
This change will make it possible to integrate Kiali with OpenShift Monitoring or a custom Prometheus Operator and at the same time, Kiali will still be reconciled by OSSM.

Example:
```
apiVersion: kiali.io/v1alpha1
kind: Kiali
metadata:
  name: kiali-user-workload-monitoring
  namespace: istio-system-1
spec:
  external_services:
    istio:
      config_map_name: istio-basic
      istio_sidecar_injector_config_map_name: istio-sidecar-injector-basic
      istiod_deployment_name: istiod-basic
      istiod_pod_monitoring_port: 15014
      url_service_version: 'http://istiod-basic.istio-system-1:15014/version'
    prometheus:
      auth:
        token: secret:thanos-querier-web-token:token
        type: bearer
        use_kiali_token: false
      query_scope:
        mesh_id: "basic_istio-system-1"
      thanos_proxy:
        enabled: true
      url: https://thanos-querier.openshift-monitoring.svc.cluster.local:9091
  version: v1.57
---
apiVersion: maistra.io/v2
kind: ServiceMeshControlPlane
metadata:
  name: basic
spec:
  addons:
    grafana:
      enabled: false
    kiali:
      enabled: true
      name: kiali-user-workload-monitoring
    prometheus:
      enabled: false
  ...
```