### PR TITLE
OSSM-3718 Revert CNI resource renaming for all versions except 2.4

### DIFF
--- a/resources/helm/overlays/istio_cni/templates/clusterrole-v2.4.yaml
+++ b/resources/helm/overlays/istio_cni/templates/clusterrole-v2.4.yaml
@@ -1,11 +1,8 @@
-{{ if .Values.cni.enabled }}
-{{ if or (eq .Values.cni.instanceVersion "v2.0") (eq .Values.cni.instanceVersion "v2.1") (eq .Values.cni.instanceVersion "v2.2") (eq .Values.cni.instanceVersion "v2.3")}}
+{{- if and .Values.cni.enabled (has "v2.4" .Values.cni.supportedReleases) (eq .Values.cni.instanceVersion "v2.4") }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
-    maistra-version: "2.4.0"
-  name: istio-cni
+  name: {{ .Values.cni.defaultResourceName }}
 rules:
   - apiGroups: [""]
     resources:
@@ -20,5 +17,4 @@ rules:
       - privileged
     verbs:
       - 'use'
-{{ end }}
-{{ end }}
+{{- end }}

--- a/resources/helm/overlays/istio_cni/templates/clusterrole.yaml
+++ b/resources/helm/overlays/istio_cni/templates/clusterrole.yaml
@@ -1,8 +1,9 @@
 {{ if .Values.cni.enabled }}
+{{ if or (eq .Values.cni.instanceVersion "v2.0") (eq .Values.cni.instanceVersion "v2.1") (eq .Values.cni.instanceVersion "v2.2") (eq .Values.cni.instanceVersion "v2.3")}}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.cni.defaultResourceName }}
+  name: istio-cni
 rules:
   - apiGroups: [""]
     resources:
@@ -17,4 +18,5 @@ rules:
       - privileged
     verbs:
       - 'use'
+{{ end }}
 {{ end }}

--- a/resources/helm/overlays/istio_cni/templates/clusterrolebinding-v2.4.yaml
+++ b/resources/helm/overlays/istio_cni/templates/clusterrolebinding-v2.4.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.cni.enabled (has "v2.4" .Values.cni.supportedReleases) (eq .Values.cni.instanceVersion "v2.4") }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.cni.defaultResourceName }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.cni.defaultResourceName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.cni.defaultResourceName }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/resources/helm/overlays/istio_cni/templates/clusterrolebinding.yaml
+++ b/resources/helm/overlays/istio_cni/templates/clusterrolebinding.yaml
@@ -2,13 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.cni.defaultResourceName }}
+  name: istio-cni
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Values.cni.defaultResourceName }}
+  name: istio-cni
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.cni.defaultResourceName }}
+    name: istio-cni
     namespace: {{ .Release.Namespace }}
 {{ end }}

--- a/resources/helm/overlays/istio_cni/templates/configmap-v2.3.yaml
+++ b/resources/helm/overlays/istio_cni/templates/configmap-v2.3.yaml
@@ -4,7 +4,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: {{ .Values.cni.defaultResourceName }}-config-v2-3
+  name: istio-cni-config-v2-3
   namespace: {{ .Release.Namespace }}
 data:
   # The CNI network configuration to add to the plugin chain on each node.  The special

--- a/resources/helm/overlays/istio_cni/templates/configmap-v2.4.yaml
+++ b/resources/helm/overlays/istio_cni/templates/configmap-v2.4.yaml
@@ -1,5 +1,4 @@
-{{ if .Values.cni.enabled }}
-{{- if and (has "v2.4" .Values.cni.supportedReleases) (eq .Values.cni.instanceVersion "v2.4") }}
+{{- if and .Values.cni.enabled (has "v2.4" .Values.cni.supportedReleases) (eq .Values.cni.instanceVersion "v2.4") }}
 # This ConfigMap is used to configure a self-hosted Istio CNI installation.
 kind: ConfigMap
 apiVersion: v1
@@ -23,4 +22,3 @@ data:
       }
     }
 {{- end }}
-{{ end }}

--- a/resources/helm/overlays/istio_cni/templates/configmap.yaml
+++ b/resources/helm/overlays/istio_cni/templates/configmap.yaml
@@ -4,7 +4,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: {{ .Values.cni.defaultResourceName }}-config
+  name: istio-cni-config
   namespace: {{ .Release.Namespace }}
 data:
   # The CNI network configuration to add to the plugin chain on each node.  The special

--- a/resources/helm/overlays/istio_cni/templates/daemonset-v2.3.yaml
+++ b/resources/helm/overlays/istio_cni/templates/daemonset-v2.3.yaml
@@ -43,7 +43,7 @@ spec:
         - effect: NoExecute
           operator: Exists
       priorityClassName: system-node-critical
-      serviceAccountName: {{ .Values.cni.defaultResourceName }}
+      serviceAccountName: istio-cni
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 5
@@ -81,7 +81,7 @@ spec:
             - name: CNI_NETWORK_CONFIG
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Values.cni.defaultResourceName }}-config-v2-3
+                  name: istio-cni-config-v2-3
                   key: "{{ default "cni_network_config" .Values.cni.configMap_v2_3 }}"
             - name: CNI_NET_DIR
               value: {{ default "/etc/cni/net.d" .Values.cni.cniConfDir }}

--- a/resources/helm/overlays/istio_cni/templates/daemonset-v2.4.yaml
+++ b/resources/helm/overlays/istio_cni/templates/daemonset-v2.4.yaml
@@ -1,5 +1,4 @@
-{{ if .Values.cni.enabled }}
-{{- if and (has "v2.4" .Values.cni.supportedReleases) (eq .Values.cni.instanceVersion "v2.4") }}
+{{- if and .Values.cni.enabled (has "v2.4" .Values.cni.supportedReleases) (eq .Values.cni.instanceVersion "v2.4") }}
 # This manifest installs the Istio install-cni container, as well
 # as the Istio CNI plugin and config on
 # each master and worker node in a Kubernetes cluster.
@@ -125,4 +124,3 @@ spec:
           hostPath:
             path: /var/run/istio-cni
 {{- end }}
-{{ end }}

--- a/resources/helm/overlays/istio_cni/templates/daemonset.yaml
+++ b/resources/helm/overlays/istio_cni/templates/daemonset.yaml
@@ -43,7 +43,7 @@ spec:
         - effect: NoExecute
           operator: Exists
       priorityClassName: system-node-critical
-      serviceAccountName: {{ .Values.cni.defaultResourceName }}
+      serviceAccountName: istio-cni
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 5

--- a/resources/helm/overlays/istio_cni/templates/serviceaccount-v2.4.yaml
+++ b/resources/helm/overlays/istio_cni/templates/serviceaccount-v2.4.yaml
@@ -1,0 +1,7 @@
+{{- if and .Values.cni.enabled (has "v2.4" .Values.cni.supportedReleases) (eq .Values.cni.instanceVersion "v2.4") }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.cni.defaultResourceName }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/resources/helm/overlays/istio_cni/templates/serviceaccount.yaml
+++ b/resources/helm/overlays/istio_cni/templates/serviceaccount.yaml
@@ -2,6 +2,6 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.cni.defaultResourceName }}
+  name: istio-cni
   namespace: {{ .Release.Namespace }}
 {{ end }}

--- a/resources/helm/v2.4/istio_cni/templates/clusterrole-v2.4.yaml
+++ b/resources/helm/v2.4/istio_cni/templates/clusterrole-v2.4.yaml
@@ -1,11 +1,10 @@
-{{ if .Values.cni.enabled }}
-{{ if or (eq .Values.cni.instanceVersion "v2.0") (eq .Values.cni.instanceVersion "v2.1") (eq .Values.cni.instanceVersion "v2.2") (eq .Values.cni.instanceVersion "v2.3")}}
+{{- if and .Values.cni.enabled (has "v2.4" .Values.cni.supportedReleases) (eq .Values.cni.instanceVersion "v2.4") }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
     maistra-version: "2.4.0"
-  name: istio-cni
+  name: {{ .Values.cni.defaultResourceName }}
 rules:
   - apiGroups: [""]
     resources:
@@ -20,5 +19,4 @@ rules:
       - privileged
     verbs:
       - 'use'
-{{ end }}
-{{ end }}
+{{- end }}

--- a/resources/helm/v2.4/istio_cni/templates/clusterrolebinding-v2.4.yaml
+++ b/resources/helm/v2.4/istio_cni/templates/clusterrolebinding-v2.4.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.cni.enabled (has "v2.4" .Values.cni.supportedReleases) (eq .Values.cni.instanceVersion "v2.4") }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    maistra-version: "2.4.0"
+  name: {{ .Values.cni.defaultResourceName }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.cni.defaultResourceName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.cni.defaultResourceName }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/resources/helm/v2.4/istio_cni/templates/clusterrolebinding.yaml
+++ b/resources/helm/v2.4/istio_cni/templates/clusterrolebinding.yaml
@@ -4,13 +4,13 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     maistra-version: "2.4.0"
-  name: {{ .Values.cni.defaultResourceName }}
+  name: istio-cni
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Values.cni.defaultResourceName }}
+  name: istio-cni
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.cni.defaultResourceName }}
+    name: istio-cni
     namespace: {{ .Release.Namespace }}
 {{ end }}

--- a/resources/helm/v2.4/istio_cni/templates/configmap-v2.3.yaml
+++ b/resources/helm/v2.4/istio_cni/templates/configmap-v2.3.yaml
@@ -6,7 +6,7 @@ apiVersion: v1
 metadata:
   labels:
     maistra-version: "2.4.0"
-  name: {{ .Values.cni.defaultResourceName }}-config-v2-3
+  name: istio-cni-config-v2-3
   namespace: {{ .Release.Namespace }}
 data:
   # The CNI network configuration to add to the plugin chain on each node.  The special

--- a/resources/helm/v2.4/istio_cni/templates/configmap-v2.4.yaml
+++ b/resources/helm/v2.4/istio_cni/templates/configmap-v2.4.yaml
@@ -1,5 +1,4 @@
-{{ if .Values.cni.enabled }}
-{{- if and (has "v2.4" .Values.cni.supportedReleases) (eq .Values.cni.instanceVersion "v2.4") }}
+{{- if and .Values.cni.enabled (has "v2.4" .Values.cni.supportedReleases) (eq .Values.cni.instanceVersion "v2.4") }}
 # This ConfigMap is used to configure a self-hosted Istio CNI installation.
 kind: ConfigMap
 apiVersion: v1
@@ -25,4 +24,3 @@ data:
       }
     }
 {{- end }}
-{{ end }}

--- a/resources/helm/v2.4/istio_cni/templates/configmap.yaml
+++ b/resources/helm/v2.4/istio_cni/templates/configmap.yaml
@@ -6,7 +6,7 @@ apiVersion: v1
 metadata:
   labels:
     maistra-version: "2.4.0"
-  name: {{ .Values.cni.defaultResourceName }}-config
+  name: istio-cni-config
   namespace: {{ .Release.Namespace }}
 data:
   # The CNI network configuration to add to the plugin chain on each node.  The special

--- a/resources/helm/v2.4/istio_cni/templates/daemonset-v2.3.yaml
+++ b/resources/helm/v2.4/istio_cni/templates/daemonset-v2.3.yaml
@@ -44,7 +44,7 @@ spec:
         - effect: NoExecute
           operator: Exists
       priorityClassName: system-node-critical
-      serviceAccountName: {{ .Values.cni.defaultResourceName }}
+      serviceAccountName: istio-cni
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 5
@@ -82,7 +82,7 @@ spec:
             - name: CNI_NETWORK_CONFIG
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Values.cni.defaultResourceName }}-config-v2-3
+                  name: istio-cni-config-v2-3
                   key: "{{ default "cni_network_config" .Values.cni.configMap_v2_3 }}"
             - name: CNI_NET_DIR
               value: {{ default "/etc/cni/net.d" .Values.cni.cniConfDir }}

--- a/resources/helm/v2.4/istio_cni/templates/daemonset-v2.4.yaml
+++ b/resources/helm/v2.4/istio_cni/templates/daemonset-v2.4.yaml
@@ -1,5 +1,4 @@
-{{ if .Values.cni.enabled }}
-{{- if and (has "v2.4" .Values.cni.supportedReleases) (eq .Values.cni.instanceVersion "v2.4") }}
+{{- if and .Values.cni.enabled (has "v2.4" .Values.cni.supportedReleases) (eq .Values.cni.instanceVersion "v2.4") }}
 # This manifest installs the Istio install-cni container, as well
 # as the Istio CNI plugin and config on
 # each master and worker node in a Kubernetes cluster.
@@ -126,4 +125,3 @@ spec:
           hostPath:
             path: /var/run/istio-cni
 {{- end }}
-{{ end }}

--- a/resources/helm/v2.4/istio_cni/templates/daemonset.yaml
+++ b/resources/helm/v2.4/istio_cni/templates/daemonset.yaml
@@ -44,7 +44,7 @@ spec:
         - effect: NoExecute
           operator: Exists
       priorityClassName: system-node-critical
-      serviceAccountName: {{ .Values.cni.defaultResourceName }}
+      serviceAccountName: istio-cni
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 5

--- a/resources/helm/v2.4/istio_cni/templates/serviceaccount-v2.4.yaml
+++ b/resources/helm/v2.4/istio_cni/templates/serviceaccount-v2.4.yaml
@@ -1,0 +1,9 @@
+{{- if and .Values.cni.enabled (has "v2.4" .Values.cni.supportedReleases) (eq .Values.cni.instanceVersion "v2.4") }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    maistra-version: "2.4.0"
+  name: {{ .Values.cni.defaultResourceName }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/resources/helm/v2.4/istio_cni/templates/serviceaccount.yaml
+++ b/resources/helm/v2.4/istio_cni/templates/serviceaccount.yaml
@@ -4,6 +4,6 @@ kind: ServiceAccount
 metadata:
   labels:
     maistra-version: "2.4.0"
-  name: {{ .Values.cni.defaultResourceName }}
+  name: istio-cni
   namespace: {{ .Release.Namespace }}
 {{ end }}


### PR DESCRIPTION
This reverts the name changes for all istio-cni versions < 2.4 and adds new templates for v2.4 resources that will use the new name prefix `ossm-cni` by default