### PR TITLE
OSSM-3235 Ensure operator can't deadlock because istiod isn't running [maistra-2.2]

### DIFF
--- a/build/patch-charts.sh
+++ b/build/patch-charts.sh
@@ -87,13 +87,22 @@ function patchGalley() {
   # add namespace selectors
   # remove define block
   webhookconfig=${HELM_DIR}/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
+
+  # remove original objectSelector
+  sed_wrap -i '/.*objectSelector:/,/.*{{- end }}/d' "${webhookconfig}"
+
+  # replace namespaceSelector and insert maistra objectSelector
   sed_wrap -i -e 's|\(\(^ *\)rules:\)|\2namespaceSelector:\
 \2  matchExpressions:\
 \2  - key: maistra.io/member-of\
 \2    operator: In\
 \2    values:\
 \2    - {{ .Release.Namespace }}\
-\1|' $webhookconfig
+\2objectSelector:\
+\2  matchExpressions:\
+\2  - key: maistra-version\
+\2    operator: DoesNotExist\
+\1|' "${webhookconfig}"
   sed_wrap -i -e '/rules:/ a\
       - operations:\
         - CREATE\
@@ -123,9 +132,8 @@ function patchGalley() {
         resources:\
         - "*"' $webhookconfig
 
-  sed_wrap -i '/.*objectSelector:/,/.*{{- end }}/d' $webhookconfig
-
-  sed_wrap -i -e 's/failurePolicy: Ignore/failurePolicy: Fail/' $webhookconfig
+  # ensure resource updates fail if the webhook is offline
+  sed_wrap -i -e 's/failurePolicy: Ignore/failurePolicy: Fail/' "${webhookconfig}"
 
   # add name to webhook port (XXX: move upstream)
   # change the location of the healthCheckFile from /health to /tmp/health

--- a/resources/helm/v2.2/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
+++ b/resources/helm/v2.2/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
@@ -30,6 +30,10 @@ webhooks:
         operator: In
         values:
         - {{ .Release.Namespace }}
+    objectSelector:
+      matchExpressions:
+      - key: maistra-version
+        operator: DoesNotExist
     rules:
       - operations:
         - CREATE


### PR DESCRIPTION
If istiod isn't running, but the validating webhook configuration resource is in place, the operator may not be able to reconcile the SMCP and reset istiod.

Here, we configure the webhook with an objectSelector that excludes resources with the `maistra-version` label. All resources created by the operator for the SMCP contain this label and thus don't trigger the webhook. This allows the operator to complete the reconciliation even if the webhook is offline.