### PR TITLE
OSSM-3235 Ensure operator can't deadlock because istiod isn't running [maistra-2.3]

### DIFF
--- a/build/patch-charts.sh
+++ b/build/patch-charts.sh
@@ -80,12 +80,21 @@ function patchGalley() {
   # add namespace selectors
   # remove define block
   webhookconfig=${HELM_DIR}/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
+
+  # remove original objectSelector
+  sed_wrap -i '/.*objectSelector:/,/.*{{- end }}/d' "${webhookconfig}"
+
+  # replace namespaceSelector and insert maistra objectSelector
   sed_wrap -i -e 's|\(\(^ *\)rules:\)|\2namespaceSelector:\
 \2  matchExpressions:\
 \2  - key: maistra.io/member-of\
 \2    operator: In\
 \2    values:\
 \2    - {{ .Release.Namespace }}\
+\2objectSelector:\
+\2  matchExpressions:\
+\2  - key: maistra-version\
+\2    operator: DoesNotExist\
 \1|' "${webhookconfig}"
   sed_wrap -i -e '/rules:/ a\
       - operations:\
@@ -107,8 +116,7 @@ function patchGalley() {
         resources:\
         - "*"' "${webhookconfig}"
 
-  sed_wrap -i '/.*objectSelector:/,/.*{{- end }}/d' "${webhookconfig}"
-
+  # ensure resource updates fail if the webhook is offline
   sed_wrap -i -e 's/failurePolicy: Ignore/failurePolicy: Fail/' "${webhookconfig}"
 
   # add name to webhook port (XXX: move upstream)

--- a/resources/helm/v2.3/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
+++ b/resources/helm/v2.3/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
@@ -29,6 +29,10 @@ webhooks:
         operator: In
         values:
         - {{ .Release.Namespace }}
+    objectSelector:
+      matchExpressions:
+      - key: maistra-version
+        operator: DoesNotExist
     rules:
       - operations:
         - CREATE


### PR DESCRIPTION
If istiod isn't running, but the validating webhook configuration resource is in place, the operator may not be able to reconcile the SMCP and reset istiod.

Here, we configure the webhook with an objectSelector that excludes resources with the `maistra-version` label. All resources created by the operator for the SMCP contain this label and thus don't trigger the webhook. This allows the operator to complete the reconciliation even if the webhook is offline.