### PR TITLE
OSSM-3747: Remove duplicated env vars from gateway templates

### DIFF
--- a/build/patch-charts.sh
+++ b/build/patch-charts.sh
@@ -330,12 +330,6 @@ gatewayAPI:
   sed_wrap -i -e 's/^\(.*\)labels:/\1labels:\
 \1  maistra.io\/gateway: {{ $gateway.name | default "istio-egressgateway" }}.{{ $gateway.namespace | default .Release.Namespace }}/' "${HELM_DIR}/gateways/istio-egress/templates/deployment.yaml"
 
-  # MAISTRA-1963 Mark gateways as non-privileged
-  sed_wrap -i -e '/env:/ a\
-          - name: ISTIO_META_UNPRIVILEGED_POD\
-            value: "true"
-' "${HELM_DIR}/gateways/istio-ingress/templates/deployment.yaml" "${HELM_DIR}/gateways/istio-egress/templates/deployment.yaml"
-
   # MAISTRA-2528 Enable DNS Capture for proxies by default
   # MAISTRA-2656 Fix missing DNS registry entries in istio-agent
   sed_wrap -i -e '/env:/ a\

--- a/build/patch-charts.sh
+++ b/build/patch-charts.sh
@@ -332,14 +332,6 @@ gatewayAPI:
 
   # MAISTRA-2528 Enable DNS Capture for proxies by default
   # MAISTRA-2656 Fix missing DNS registry entries in istio-agent
-  sed_wrap -i -e '/env:/ a\
-          - name: ISTIO_META_DNS_CAPTURE\
-            value: "true"\
-          - name: ISTIO_META_DNS_AUTO_ALLOCATE\
-            value: "true"\
-          - name: PROXY_XDS_VIA_AGENT\
-            value: "true"
-' "${HELM_DIR}/gateways/istio-ingress/templates/deployment.yaml" "${HELM_DIR}/gateways/istio-egress/templates/deployment.yaml"
   sed_wrap -i -e 's/proxyMetadata: {}/proxyMetadata:\
       ISTIO_META_DNS_CAPTURE: "true"\
       ISTIO_META_DNS_AUTO_ALLOCATE: "true"\

--- a/resources/helm/v2.4/gateways/istio-egress/templates/deployment.yaml
+++ b/resources/helm/v2.4/gateways/istio-egress/templates/deployment.yaml
@@ -238,12 +238,6 @@ spec:
 {{ toYaml $mesh.defaultConfig | trim | indent 14 }}
 {{- end }}
 {{- end }}
-          - name: ISTIO_META_DNS_CAPTURE
-            value: "true"
-          - name: ISTIO_META_DNS_AUTO_ALLOCATE
-            value: "true"
-          - name: PROXY_XDS_VIA_AGENT
-            value: "true"
           - name: JWT_POLICY
             value: {{ .Values.global.jwtPolicy }}
           - name: PILOT_CERT_PROVIDER

--- a/resources/helm/v2.4/gateways/istio-egress/templates/deployment.yaml
+++ b/resources/helm/v2.4/gateways/istio-egress/templates/deployment.yaml
@@ -244,8 +244,6 @@ spec:
             value: "true"
           - name: PROXY_XDS_VIA_AGENT
             value: "true"
-          - name: ISTIO_META_UNPRIVILEGED_POD
-            value: "true"
           - name: JWT_POLICY
             value: {{ .Values.global.jwtPolicy }}
           - name: PILOT_CERT_PROVIDER

--- a/resources/helm/v2.4/gateways/istio-ingress/templates/deployment.yaml
+++ b/resources/helm/v2.4/gateways/istio-ingress/templates/deployment.yaml
@@ -238,12 +238,6 @@ spec:
 {{ toYaml $mesh.defaultConfig | trim | indent 14 }}
 {{- end }}
 {{- end }}
-          - name: ISTIO_META_DNS_CAPTURE
-            value: "true"
-          - name: ISTIO_META_DNS_AUTO_ALLOCATE
-            value: "true"
-          - name: PROXY_XDS_VIA_AGENT
-            value: "true"
           - name: JWT_POLICY
             value: {{ .Values.global.jwtPolicy }}
           - name: PILOT_CERT_PROVIDER

--- a/resources/helm/v2.4/gateways/istio-ingress/templates/deployment.yaml
+++ b/resources/helm/v2.4/gateways/istio-ingress/templates/deployment.yaml
@@ -244,8 +244,6 @@ spec:
             value: "true"
           - name: PROXY_XDS_VIA_AGENT
             value: "true"
-          - name: ISTIO_META_UNPRIVILEGED_POD
-            value: "true"
           - name: JWT_POLICY
             value: {{ .Values.global.jwtPolicy }}
           - name: PILOT_CERT_PROVIDER


### PR DESCRIPTION
**Problem:**
```
$ k -n istio-system scale deploy istio-egressgateway --replicas 1
Warning: spec.template.spec.containers[0].env[17].name: duplicate name "ISTIO_META_UNPRIVILEGED_POD"
Warning: spec.template.spec.containers[0].env[18].name: duplicate name "ISTIO_META_DNS_AUTO_ALLOCATE"
Warning: spec.template.spec.containers[0].env[19].name: duplicate name "ISTIO_META_DNS_CAPTURE"
Warning: spec.template.spec.containers[0].env[20].name: duplicate name "PROXY_XDS_VIA_AGENT"
```
**Background context:**
1. `ISTIO_META_UNPRIVILEGED_POD` was patched, because in OSSM 2.0, gateways were deployed as privileged workloads, but since 2.1, gateways are unprivileged, so this duplication exists in 2.1, 2.2 and 2.3 as well.
2. `ISTIO_META_DNS_CAPTURE`, `ISTIO_META_DNS_AUTO_ALLOCATE` and `PROXY_XDS_VIA_AGENT` are also set in `meshConfig.defaultConfig.proxyMetadata`, and gateway templates map proxy metadata to deployment envs (see below), so setting them explicitly in the deployment causes duplication.
```
          env:
          {{- range $key, $value := .Values.meshConfig.defaultConfig.proxyMetadata }}
          - name: {{ $key }}
            value: "{{ $value }}"
          {{- end }}
```