### PR TITLE
[maistra-2.3] OSSM-3747: Remove duplicated env vars from gateway templates

### DIFF
--- a/build/patch-charts.sh
+++ b/build/patch-charts.sh
@@ -283,22 +283,6 @@ function patchGateways() {
   sed_wrap -i -e 's/^\(.*\)labels:/\1labels:\
 \1  maistra.io\/gateway: {{ $gateway.name | default "istio-egressgateway" }}.{{ $gateway.namespace | default .Release.Namespace }}/' "${HELM_DIR}/gateways/istio-egress/templates/deployment.yaml"
 
-  # MAISTRA-1963 Mark gateways as non-privileged
-  sed_wrap -i -e '/env:/ a\
-          - name: ISTIO_META_UNPRIVILEGED_POD\
-            value: "true"
-' "${HELM_DIR}/gateways/istio-ingress/templates/deployment.yaml" "${HELM_DIR}/gateways/istio-egress/templates/deployment.yaml"
-
-  # MAISTRA-2528 Enable DNS Capture for proxies by default
-  # MAISTRA-2656 Fix missing DNS registry entries in istio-agent
-  sed_wrap -i -e '/env:/ a\
-          - name: ISTIO_META_DNS_CAPTURE\
-            value: "true"\
-          - name: ISTIO_META_DNS_AUTO_ALLOCATE\
-            value: "true"\
-          - name: PROXY_XDS_VIA_AGENT\
-            value: "true"
-' "${HELM_DIR}/gateways/istio-ingress/templates/deployment.yaml" "${HELM_DIR}/gateways/istio-egress/templates/deployment.yaml"
   sed_wrap -i -e 's/proxyMetadata: {}/proxyMetadata:\
       ISTIO_META_DNS_CAPTURE: "true"\
       ISTIO_META_DNS_AUTO_ALLOCATE: "true"\

--- a/resources/helm/v2.2/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
+++ b/resources/helm/v2.2/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
@@ -30,6 +30,10 @@ webhooks:
         operator: In
         values:
         - {{ .Release.Namespace }}
+    objectSelector:
+      matchExpressions:
+      - key: maistra-version
+        operator: DoesNotExist
     rules:
       - operations:
         - CREATE

--- a/resources/helm/v2.3/gateways/istio-egress/templates/deployment.yaml
+++ b/resources/helm/v2.3/gateways/istio-egress/templates/deployment.yaml
@@ -228,14 +228,6 @@ spec:
 {{ toYaml $mesh.defaultConfig | trim | indent 14 }}
 {{- end }}
 {{- end }}
-          - name: ISTIO_META_DNS_CAPTURE
-            value: "true"
-          - name: ISTIO_META_DNS_AUTO_ALLOCATE
-            value: "true"
-          - name: PROXY_XDS_VIA_AGENT
-            value: "true"
-          - name: ISTIO_META_UNPRIVILEGED_POD
-            value: "true"
           - name: JWT_POLICY
             value: {{ .Values.global.jwtPolicy }}
           - name: PILOT_CERT_PROVIDER

--- a/resources/helm/v2.3/gateways/istio-ingress/templates/deployment.yaml
+++ b/resources/helm/v2.3/gateways/istio-ingress/templates/deployment.yaml
@@ -228,14 +228,6 @@ spec:
 {{ toYaml $mesh.defaultConfig | trim | indent 14 }}
 {{- end }}
 {{- end }}
-          - name: ISTIO_META_DNS_CAPTURE
-            value: "true"
-          - name: ISTIO_META_DNS_AUTO_ALLOCATE
-            value: "true"
-          - name: PROXY_XDS_VIA_AGENT
-            value: "true"
-          - name: ISTIO_META_UNPRIVILEGED_POD
-            value: "true"
           - name: JWT_POLICY
             value: {{ .Values.global.jwtPolicy }}
           - name: PILOT_CERT_PROVIDER


### PR DESCRIPTION
Follow-up to #1169. This PR also includes changes made in #1165.