### PR TITLE
OSSM-2285: Remove support for v2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ test:
 # Helm charts generation and templates processing
 ################################################################################
 
-SUPPORTED_VERSIONS := 2.0 2.1 2.2 2.3 2.4
+SUPPORTED_VERSIONS := 2.1 2.2 2.3 2.4
 
 $(addprefix update-remote-maistra-,$(SUPPORTED_VERSIONS)): update-remote-maistra-%:
 	$(eval version:=$*)
@@ -181,10 +181,10 @@ endif
 # resource collection
 ################################################################################
 .PHONY: collect-charts
-collect-charts: collect-charts-2.0 collect-charts-2.1 collect-charts-2.2 collect-charts-2.3 collect-charts-2.4
+collect-charts: collect-charts-2.1 collect-charts-2.2 collect-charts-2.3 collect-charts-2.4
 
 .PHONY: collect-templates
-collect-templates: collect-templates-2.0 collect-templates-2.1 collect-templates-2.2 collect-templates-2.3 collect-templates-2.4
+collect-templates: collect-templates-2.1 collect-templates-2.2 collect-templates-2.3 collect-templates-2.4
 
 .PHONY: collect-olm-manifests
 collect-olm-manifests:
@@ -227,7 +227,7 @@ lint-yaml:
 lint-helm:
 	@echo "Helm version: `helm version`"
 	@${FINDFILES} -name 'Chart.yaml' -path './resources/helm/v2.?/*' \
-	-not \(	-path './resources/helm/v2.0/*' -o -path './resources/helm/v2.1/*' -o -path './resources/helm/v2.2/*' \) \
+	-not \(	-path './resources/helm/v2.1/*' -o -path './resources/helm/v2.2/*' \) \
 	-print0 | ${XARGS} -L 1 dirname | xargs -r helm lint --strict
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,7 @@ lint-yaml:
 lint-helm:
 	@echo "Helm version: `helm version`"
 	@${FINDFILES} -name 'Chart.yaml' -path './resources/helm/v2.?/*' \
-	-not \(	-path './resources/helm/v2.1/*' -o -path './resources/helm/v2.2/*' \) \
+	-not \(	-path './resources/helm/v2.0/*' -o -path './resources/helm/v2.1/*' -o -path './resources/helm/v2.2/*' \) \
 	-print0 | ${XARGS} -L 1 dirname | xargs -r helm lint --strict
 
 .PHONY: lint

--- a/build/build.sh
+++ b/build/build.sh
@@ -35,7 +35,7 @@ fi
 LD_EXTRAFLAGS+=" -X ${REPO_PATH}/pkg/version.buildStatus=${GITSTATUS}"
 
 : "${GITTAG:=$(git describe 2> /dev/null || echo "unknown")}"
-: "${MINIMUM_SUPPORTED_VERSION:=v2.2}"
+: "${MINIMUM_SUPPORTED_VERSION:=v2.1}"
 LD_EXTRAFLAGS+=" -X ${REPO_PATH}/pkg/version.buildTag=${GITTAG} -X ${REPO_PATH}/pkg/version.minimumSupportedVersion=${MINIMUM_SUPPORTED_VERSION}"
 
 LDFLAGS="-extldflags -static ${LD_EXTRAFLAGS} -s -w"

--- a/build/build.sh
+++ b/build/build.sh
@@ -35,7 +35,7 @@ fi
 LD_EXTRAFLAGS+=" -X ${REPO_PATH}/pkg/version.buildStatus=${GITSTATUS}"
 
 : "${GITTAG:=$(git describe 2> /dev/null || echo "unknown")}"
-: "${MINIMUM_SUPPORTED_VERSION:=v2.0}"
+: "${MINIMUM_SUPPORTED_VERSION:=v2.2}"
 LD_EXTRAFLAGS+=" -X ${REPO_PATH}/pkg/version.buildTag=${GITTAG} -X ${REPO_PATH}/pkg/version.minimumSupportedVersion=${MINIMUM_SUPPORTED_VERSION}"
 
 LDFLAGS="-extldflags -static ${LD_EXTRAFLAGS} -s -w"

--- a/deploy/maistra-operator.yaml
+++ b/deploy/maistra-operator.yaml
@@ -10860,15 +10860,6 @@ spec:
       labels:
         name: istio-operator
       annotations:
-        olm.relatedImage.v2_0.3scale-istio-adapter: quay.io/3scale/3scale-istio-adapter:v2.0.0
-        olm.relatedImage.v2_0.cni: docker.io/maistra/istio-cni-ubi8:2.0.10
-        olm.relatedImage.v2_0.grafana: docker.io/maistra/grafana-ubi8:2.0.10
-        olm.relatedImage.v2_0.mixer: docker.io/maistra/mixer-ubi8:2.0.10
-        olm.relatedImage.v2_0.pilot: docker.io/maistra/pilot-ubi8:2.0.10
-        olm.relatedImage.v2_0.prometheus: docker.io/maistra/prometheus-ubi8:2.0.10
-        olm.relatedImage.v2_0.proxy-init: docker.io/maistra/proxy-init-centos7:2.0.10
-        olm.relatedImage.v2_0.proxyv2: docker.io/maistra/proxyv2-ubi8:2.0.10
-        olm.relatedImage.v2_0.wasm-cacher: docker.io/maistra/pilot-ubi8:2.0.10
 
         olm.relatedImage.v2_1.cni: quay.io/maistra/istio-cni-ubi8:2.1.4
         olm.relatedImage.v2_1.grafana: quay.io/maistra/grafana-ubi8:2.1.4

--- a/deploy/servicemesh-operator.yaml
+++ b/deploy/servicemesh-operator.yaml
@@ -10860,16 +10860,6 @@ spec:
       labels:
         name: istio-operator
       annotations:
-        # 2.0 images
-        olm.relatedImage.v2_0.3scale-istio-adapter: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-3scale-istio-adapter-rhel8:1.0.0
-        olm.relatedImage.v2_0.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_20}
-        olm.relatedImage.v2_0.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_20}
-        olm.relatedImage.v2_0.mixer: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-mixer-rhel8:${OSSM_20}
-        olm.relatedImage.v2_0.pilot: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_20}
-        olm.relatedImage.v2_0.prometheus: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-prometheus-rhel8:${OSSM_20}
-        olm.relatedImage.v2_0.proxy-init: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxy-init-rhel7:${OSSM_20}
-        olm.relatedImage.v2_0.proxyv2: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxyv2-rhel8:${OSSM_20}
-        olm.relatedImage.v2_0.wasm-cacher: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_20}
         # 2.1 images
         olm.relatedImage.v2_1.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_21}
         olm.relatedImage.v2_1.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_21}

--- a/deploy/src/deployment-maistra.yaml
+++ b/deploy/src/deployment-maistra.yaml
@@ -15,15 +15,6 @@ spec:
       labels:
         name: istio-operator
       annotations:
-        olm.relatedImage.v2_0.3scale-istio-adapter: quay.io/3scale/3scale-istio-adapter:v2.0.0
-        olm.relatedImage.v2_0.cni: docker.io/maistra/istio-cni-ubi8:2.0.10
-        olm.relatedImage.v2_0.grafana: docker.io/maistra/grafana-ubi8:2.0.10
-        olm.relatedImage.v2_0.mixer: docker.io/maistra/mixer-ubi8:2.0.10
-        olm.relatedImage.v2_0.pilot: docker.io/maistra/pilot-ubi8:2.0.10
-        olm.relatedImage.v2_0.prometheus: docker.io/maistra/prometheus-ubi8:2.0.10
-        olm.relatedImage.v2_0.proxy-init: docker.io/maistra/proxy-init-centos7:2.0.10
-        olm.relatedImage.v2_0.proxyv2: docker.io/maistra/proxyv2-ubi8:2.0.10
-        olm.relatedImage.v2_0.wasm-cacher: docker.io/maistra/pilot-ubi8:2.0.10
 
         olm.relatedImage.v2_1.cni: quay.io/maistra/istio-cni-ubi8:2.1.4
         olm.relatedImage.v2_1.grafana: quay.io/maistra/grafana-ubi8:2.1.4

--- a/deploy/src/deployment-servicemesh.yaml
+++ b/deploy/src/deployment-servicemesh.yaml
@@ -15,16 +15,6 @@ spec:
       labels:
         name: istio-operator
       annotations:
-        # 2.0 images
-        olm.relatedImage.v2_0.3scale-istio-adapter: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-3scale-istio-adapter-rhel8:1.0.0
-        olm.relatedImage.v2_0.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_20}
-        olm.relatedImage.v2_0.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_20}
-        olm.relatedImage.v2_0.mixer: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-mixer-rhel8:${OSSM_20}
-        olm.relatedImage.v2_0.pilot: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_20}
-        olm.relatedImage.v2_0.prometheus: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-prometheus-rhel8:${OSSM_20}
-        olm.relatedImage.v2_0.proxy-init: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxy-init-rhel7:${OSSM_20}
-        olm.relatedImage.v2_0.proxyv2: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxyv2-rhel8:${OSSM_20}
-        olm.relatedImage.v2_0.wasm-cacher: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_20}
         # 2.1 images
         olm.relatedImage.v2_1.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_21}
         olm.relatedImage.v2_1.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_21}

--- a/manifests-maistra/2.4.0/maistraoperator.v2.4.0.clusterserviceversion.yaml
+++ b/manifests-maistra/2.4.0/maistraoperator.v2.4.0.clusterserviceversion.yaml
@@ -15,7 +15,7 @@ metadata:
       The Maistra Operator enables you to install, configure, and manage an instance of Maistra service mesh. Maistra is based on the open source Istio project.
 
     containerImage: quay.io/maistra/istio-ubi8-operator:2.4.0
-    createdAt: 2023-05-12T07:28:40CEST
+    createdAt: 2023-05-16T14:56:04CEST
     support: Red Hat, Inc. 
     olm.skipRange: ">=1.0.2 <2.4.0-0"
     operators.openshift.io/infrastructure-features: '[]'
@@ -211,24 +211,6 @@ spec:
   - type: AllNamespaces
     supported: true
   relatedImages:
-  - name: v2_0.3scale-istio-adapter
-    image: quay.io/3scale/3scale-istio-adapter:v2.0.0
-  - name: v2_0.cni
-    image: docker.io/maistra/istio-cni-ubi8:2.0.10
-  - name: v2_0.grafana
-    image: docker.io/maistra/grafana-ubi8:2.0.10
-  - name: v2_0.mixer
-    image: docker.io/maistra/mixer-ubi8:2.0.10
-  - name: v2_0.pilot
-    image: docker.io/maistra/pilot-ubi8:2.0.10
-  - name: v2_0.prometheus
-    image: docker.io/maistra/prometheus-ubi8:2.0.10
-  - name: v2_0.proxy-init
-    image: docker.io/maistra/proxy-init-centos7:2.0.10
-  - name: v2_0.proxyv2
-    image: docker.io/maistra/proxyv2-ubi8:2.0.10
-  - name: v2_0.wasm-cacher
-    image: docker.io/maistra/pilot-ubi8:2.0.10
   - name: v2_1.cni
     image: quay.io/maistra/istio-cni-ubi8:2.1.4
   - name: v2_1.grafana
@@ -540,15 +522,6 @@ spec:
               labels:
                 name: istio-operator
               annotations:
-                olm.relatedImage.v2_0.3scale-istio-adapter: quay.io/3scale/3scale-istio-adapter:v2.0.0
-                olm.relatedImage.v2_0.cni: docker.io/maistra/istio-cni-ubi8:2.0.10
-                olm.relatedImage.v2_0.grafana: docker.io/maistra/grafana-ubi8:2.0.10
-                olm.relatedImage.v2_0.mixer: docker.io/maistra/mixer-ubi8:2.0.10
-                olm.relatedImage.v2_0.pilot: docker.io/maistra/pilot-ubi8:2.0.10
-                olm.relatedImage.v2_0.prometheus: docker.io/maistra/prometheus-ubi8:2.0.10
-                olm.relatedImage.v2_0.proxy-init: docker.io/maistra/proxy-init-centos7:2.0.10
-                olm.relatedImage.v2_0.proxyv2: docker.io/maistra/proxyv2-ubi8:2.0.10
-                olm.relatedImage.v2_0.wasm-cacher: docker.io/maistra/pilot-ubi8:2.0.10
                 olm.relatedImage.v2_1.cni: quay.io/maistra/istio-cni-ubi8:2.1.4
                 olm.relatedImage.v2_1.grafana: quay.io/maistra/grafana-ubi8:2.1.4
                 olm.relatedImage.v2_1.pilot: quay.io/maistra/pilot-ubi8:2.1.4

--- a/manifests-servicemesh/2.4.0/servicemeshoperator.v2.4.0.clusterserviceversion.yaml
+++ b/manifests-servicemesh/2.4.0/servicemeshoperator.v2.4.0.clusterserviceversion.yaml
@@ -17,7 +17,7 @@ metadata:
       The OpenShift Service Mesh Operator enables you to install, configure, and manage an instance of Red Hat OpenShift Service Mesh. OpenShift Service Mesh is based on the open source Istio project.
 
     containerImage: ${OSSM_OPERATOR_IMAGE}
-    createdAt: 2023-05-12T07:28:42CEST
+    createdAt: 2023-05-16T14:56:05CEST
     support: Red Hat, Inc. 
     olm.skipRange: ">=1.0.2 <2.4.0-0"
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
@@ -518,16 +518,6 @@ spec:
               labels:
                 name: istio-operator
               annotations:
-                # 2.0 images
-                olm.relatedImage.v2_0.3scale-istio-adapter: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-3scale-istio-adapter-rhel8:1.0.0
-                olm.relatedImage.v2_0.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_20}
-                olm.relatedImage.v2_0.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_20}
-                olm.relatedImage.v2_0.mixer: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-mixer-rhel8:${OSSM_20}
-                olm.relatedImage.v2_0.pilot: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_20}
-                olm.relatedImage.v2_0.prometheus: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-prometheus-rhel8:${OSSM_20}
-                olm.relatedImage.v2_0.proxy-init: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxy-init-rhel7:${OSSM_20}
-                olm.relatedImage.v2_0.proxyv2: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxyv2-rhel8:${OSSM_20}
-                olm.relatedImage.v2_0.wasm-cacher: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_20}
                 # 2.1 images
                 olm.relatedImage.v2_1.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_21}
                 olm.relatedImage.v2_1.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_21}

--- a/pkg/apis/maistra/conversion/cluster_test.go
+++ b/pkg/apis/maistra/conversion/cluster_test.go
@@ -1560,7 +1560,7 @@ func clusterTestCasesV2(version versions.Version) []conversionTestCase {
 
 func init() {
 	// Deprecated v1.1 is deprecated and skip clusterTestCasesV1
-	for _, v := range versions.AllV2Versions {
+	for _, v := range versions.TestedVersions {
 		clusterTestCases = append(clusterTestCases, clusterTestCasesV2(v)...)
 	}
 }

--- a/pkg/apis/maistra/conversion/discovery_selectors_test.go
+++ b/pkg/apis/maistra/conversion/discovery_selectors_test.go
@@ -20,7 +20,7 @@ type conversionDiscoverySelectorsTestCase struct {
 }
 
 func init() {
-	for _, v := range versions.AllV2Versions {
+	for _, v := range versions.TestedVersions {
 		if v.AtLeast(versions.V2_4) {
 			discoverySelectorsTestCases = append(discoverySelectorsTestCases, discoverySelectorsTestCasesV2(v)...)
 		}

--- a/pkg/apis/maistra/conversion/extension_providers_test.go
+++ b/pkg/apis/maistra/conversion/extension_providers_test.go
@@ -18,7 +18,7 @@ type conversionExtensionProvidersTestCase struct {
 }
 
 func init() {
-	for _, v := range versions.AllV2Versions {
+	for _, v := range versions.TestedVersions {
 		if v.AtLeast(versions.V2_4) {
 			extensionProvidersTestCases = append(extensionProvidersTestCases, extensionProvidersTestCasesV2(v)...)
 		}

--- a/pkg/apis/maistra/conversion/gateways_test.go
+++ b/pkg/apis/maistra/conversion/gateways_test.go
@@ -1579,7 +1579,7 @@ func gatewaysTestCasesV2(version versions.Version) []conversionTestCase {
 }
 
 func init() {
-	for _, v := range versions.AllV2Versions {
+	for _, v := range versions.TestedVersions {
 		gatewaysTestCases = append(gatewaysTestCases, gatewaysTestCasesV2(v)...)
 	}
 }

--- a/pkg/apis/maistra/conversion/grafana_test.go
+++ b/pkg/apis/maistra/conversion/grafana_test.go
@@ -484,7 +484,7 @@ func grafanaTestCasesV2(version versions.Version) []conversionTestCase {
 }
 
 func init() {
-	for _, v := range versions.AllV2Versions {
+	for _, v := range versions.TestedVersions {
 		grafanaTestCases = append(grafanaTestCases, grafanaTestCasesV2(v)...)
 	}
 }

--- a/pkg/apis/maistra/conversion/jaeger_test.go
+++ b/pkg/apis/maistra/conversion/jaeger_test.go
@@ -638,7 +638,7 @@ func jaegerTestCasesV2(version versions.Version) []conversionTestCase {
 }
 
 func init() {
-	for _, v := range versions.AllV2Versions {
+	for _, v := range versions.TestedVersions {
 		jaegerTestCases = append(jaegerTestCases, jaegerTestCasesV2(v)...)
 	}
 }

--- a/pkg/apis/maistra/conversion/kiali_test.go
+++ b/pkg/apis/maistra/conversion/kiali_test.go
@@ -641,7 +641,7 @@ func kialiTestCasesV2(version versions.Version) []conversionTestCase {
 }
 
 func init() {
-	for _, v := range versions.AllV2Versions {
+	for _, v := range versions.TestedVersions {
 		kialiTestCases = append(kialiTestCases, kialiTestCasesV2(v)...)
 	}
 }

--- a/pkg/apis/maistra/conversion/logging_test.go
+++ b/pkg/apis/maistra/conversion/logging_test.go
@@ -76,7 +76,7 @@ func loggingTestCasesV2(version versions.Version) []conversionTestCase {
 }
 
 func init() {
-	for _, v := range versions.AllV2Versions {
+	for _, v := range versions.TestedVersions {
 		loggingTestCases = append(loggingTestCases, loggingTestCasesV2(v)...)
 	}
 }

--- a/pkg/apis/maistra/conversion/policy_test.go
+++ b/pkg/apis/maistra/conversion/policy_test.go
@@ -355,7 +355,7 @@ func policyTestCasesV2(version versions.Version) []conversionTestCase {
 
 func init() {
 	// v1.1 is deprecated and skip policyTestCasesV1
-	for _, v := range versions.AllV2Versions {
+	for _, v := range versions.TestedVersions {
 		policyTestCases = append(policyTestCases, policyTestCasesV2(v)...)
 	}
 }

--- a/pkg/apis/maistra/conversion/prometheus_test.go
+++ b/pkg/apis/maistra/conversion/prometheus_test.go
@@ -320,7 +320,7 @@ func prometheusTestCasesV2(version versions.Version) []conversionTestCase {
 
 func init() {
 	// v1.1 is deprecated and skip TestCasesV1
-	for _, v := range versions.AllV2Versions {
+	for _, v := range versions.TestedVersions {
 		prometheusTestCases = append(prometheusTestCases, prometheusTestCasesV2(v)...)
 	}
 }

--- a/pkg/apis/maistra/conversion/proxy_test.go
+++ b/pkg/apis/maistra/conversion/proxy_test.go
@@ -1098,7 +1098,7 @@ func proxyTestCasesV2(version versions.Version) []conversionTestCase {
 }
 
 func init() {
-	for _, v := range versions.AllV2Versions {
+	for _, v := range versions.TestedVersions {
 		proxyTestCases = append(proxyTestCases, proxyTestCasesV2(v)...)
 	}
 }

--- a/pkg/apis/maistra/conversion/runtime_test.go
+++ b/pkg/apis/maistra/conversion/runtime_test.go
@@ -2332,10 +2332,8 @@ func runtimeTestCasesV2(version versions.Version) []conversionTestCase {
 }
 
 func init() {
-	for _, v := range versions.AllV2Versions {
-		if v.AtLeast(versions.V2_2) {
-			runtimeTestCases = append(runtimeTestCases, runtimeTestCasesV2(v)...)
-		}
+	for _, v := range versions.TestedVersions {
+		runtimeTestCases = append(runtimeTestCases, runtimeTestCasesV2(v)...)
 	}
 }
 

--- a/pkg/apis/maistra/conversion/runtime_test.go
+++ b/pkg/apis/maistra/conversion/runtime_test.go
@@ -2333,7 +2333,9 @@ func runtimeTestCasesV2(version versions.Version) []conversionTestCase {
 
 func init() {
 	for _, v := range versions.AllV2Versions {
-		runtimeTestCases = append(runtimeTestCases, runtimeTestCasesV2(v)...)
+		if v.AtLeast(versions.V2_2) {
+			runtimeTestCases = append(runtimeTestCases, runtimeTestCasesV2(v)...)
+		}
 	}
 }
 

--- a/pkg/apis/maistra/conversion/security_test.go
+++ b/pkg/apis/maistra/conversion/security_test.go
@@ -902,7 +902,7 @@ func securityTestCasesV2(version versions.Version) []conversionTestCase {
 
 func init() {
 	// v1.1 is deprecated and skip TestCasesV1
-	for _, v := range versions.AllV2Versions {
+	for _, v := range versions.TestedVersions {
 		securityTestCases = append(securityTestCases, securityTestCasesV2(v)...)
 	}
 }

--- a/pkg/apis/maistra/conversion/techpreviews_test.go
+++ b/pkg/apis/maistra/conversion/techpreviews_test.go
@@ -37,7 +37,7 @@ func techPreviewTestCasesV2(version versions.Version) []conversionTestCase {
 }
 
 func init() {
-	for _, v := range versions.AllV2Versions {
+	for _, v := range versions.TestedVersions {
 		techPreviewTestCases = append(techPreviewTestCases, techPreviewTestCasesV2(v)...)
 	}
 }

--- a/pkg/apis/maistra/conversion/telemetry_test.go
+++ b/pkg/apis/maistra/conversion/telemetry_test.go
@@ -1440,7 +1440,7 @@ func telemetryTestCasesV2(version versions.Version) []conversionTestCase {
 
 func init() {
 	// v1.1 is deprecated and skip TestCasesV1
-	for _, v := range versions.AllV2Versions {
+	for _, v := range versions.TestedVersions {
 		telemetryTestCases = append(telemetryTestCases, telemetryTestCasesV2(v)...)
 	}
 }

--- a/pkg/apis/maistra/conversion/threescale_test.go
+++ b/pkg/apis/maistra/conversion/threescale_test.go
@@ -224,7 +224,7 @@ func threeScaleTestCasesV2(version versions.Version) []conversionTestCase {
 }
 
 func init() {
-	for _, v := range versions.AllV2Versions {
+	for _, v := range versions.TestedVersions {
 		threeScaleTestCases = append(threeScaleTestCases, threeScaleTestCasesV2(v)...)
 	}
 }

--- a/pkg/bootstrap/cni.go
+++ b/pkg/bootstrap/cni.go
@@ -47,9 +47,6 @@ func internalRenderCNI(ctx context.Context, cl client.Client, config cni.Config,
 
 	cni := make(map[string]interface{})
 	cni["enabled"] = config.Enabled
-	cni["image_v1_1"] = common.Config.OLM.Images.V1_1.CNI
-	cni["image_v2_0"] = common.Config.OLM.Images.V2_0.CNI
-	cni["image_v2_1"] = common.Config.OLM.Images.V2_1.CNI
 	cni["image_v2_2"] = common.Config.OLM.Images.V2_2.CNI
 	cni["image_v2_3"] = common.Config.OLM.Images.V2_3.CNI
 	cni["image_v2_4"] = common.Config.OLM.Images.V2_4.CNI
@@ -58,8 +55,6 @@ func internalRenderCNI(ctx context.Context, cl client.Client, config cni.Config,
 
 	cni["logLevel"] = common.Config.OLM.CNILogLevel
 
-	cni["configMap_v2_0"] = "cni_network_config_v2_0"
-	cni["configMap_v2_1"] = "cni_network_config_v2_1"
 	cni["configMap_v2_2"] = "cni_network_config_v2_2"
 	cni["configMap_v2_3"] = "cni_network_config"
 	cni["configMap_v2_4"] = "cni_network_config"
@@ -70,8 +65,6 @@ func internalRenderCNI(ctx context.Context, cl client.Client, config cni.Config,
 		cni["cniConfDir"] = "/etc/cni/multus/net.d"
 		cni["mountedCniConfDir"] = "/host/etc/cni/multus/net.d"
 
-		cni["cniConfFileName_v2_0"] = "v2-0-istio-cni.conf"
-		cni["cniConfFileName_v2_1"] = "v2-1-istio-cni.conf"
 		cni["cniConfFileName_v2_2"] = "v2-2-istio-cni.conf"
 		cni["cniConfFileName_v2_3"] = "v2-3-istio-cni.conf"
 		cni["cniConfFileName_v2_4"] = "v2-4-istio-cni.conf"

--- a/pkg/bootstrap/cni.go
+++ b/pkg/bootstrap/cni.go
@@ -47,6 +47,7 @@ func internalRenderCNI(ctx context.Context, cl client.Client, config cni.Config,
 
 	cni := make(map[string]interface{})
 	cni["enabled"] = config.Enabled
+	cni["image_v2_1"] = common.Config.OLM.Images.V2_1.CNI
 	cni["image_v2_2"] = common.Config.OLM.Images.V2_2.CNI
 	cni["image_v2_3"] = common.Config.OLM.Images.V2_3.CNI
 	cni["image_v2_4"] = common.Config.OLM.Images.V2_4.CNI
@@ -55,6 +56,7 @@ func internalRenderCNI(ctx context.Context, cl client.Client, config cni.Config,
 
 	cni["logLevel"] = common.Config.OLM.CNILogLevel
 
+	cni["configMap_v2_1"] = "cni_network_config_v2_1"
 	cni["configMap_v2_2"] = "cni_network_config_v2_2"
 	cni["configMap_v2_3"] = "cni_network_config"
 	cni["configMap_v2_4"] = "cni_network_config"
@@ -65,6 +67,7 @@ func internalRenderCNI(ctx context.Context, cl client.Client, config cni.Config,
 		cni["cniConfDir"] = "/etc/cni/multus/net.d"
 		cni["mountedCniConfDir"] = "/host/etc/cni/multus/net.d"
 
+		cni["cniConfFileName_v2_1"] = "v2-1-istio-cni.conf"
 		cni["cniConfFileName_v2_2"] = "v2-2-istio-cni.conf"
 		cni["cniConfFileName_v2_3"] = "v2-3-istio-cni.conf"
 		cni["cniConfFileName_v2_4"] = "v2-4-istio-cni.conf"

--- a/pkg/bootstrap/cni_test.go
+++ b/pkg/bootstrap/cni_test.go
@@ -129,14 +129,6 @@ func TestCNISupportedVersionRendering(t *testing.T) {
 func InitializeGlobals(operatorNamespace string) func() {
 	return func() {
 		// make sure globals are initialized for testing
-		common.Config.OLM.Images.V2_1.CNI = "istio-cni-test-2_1"
-		common.Config.OLM.Images.V2_1.ThreeScale = "injected-3scale-v2.1"
-		common.Config.OLM.Images.V2_1.Grafana = "injected-grafana-v2.1"
-		common.Config.OLM.Images.V2_1.Pilot = "injected-pilot-v2.1"
-		common.Config.OLM.Images.V2_1.Prometheus = "injected-prometheus-v2.1"
-		common.Config.OLM.Images.V2_1.ProxyInit = "injected-proxy-init-v2.1"
-		common.Config.OLM.Images.V2_1.ProxyV2 = "injected-proxyv2-v2.1"
-		common.Config.OLM.Images.V2_1.WASMCacher = "injected-wasm-cacher-v2.1"
 		os.Setenv("POD_NAMESPACE", operatorNamespace)
 		common.GetOperatorNamespace()
 		if _, filename, _, ok := goruntime.Caller(0); ok {

--- a/pkg/bootstrap/cni_test.go
+++ b/pkg/bootstrap/cni_test.go
@@ -35,7 +35,7 @@ func TestCNISupportedVersionRendering(t *testing.T) {
 			name:              "Default Supported Versions SMCP v2.2",
 			supportedVersions: versions.GetSupportedVersions(),
 			instanceVersion:   versions.V2_2.Version(),
-			containerNames:    []string{"install-cni-v2-0", "install-cni-v2-1", "install-cni-v2-2"},
+			containerNames:    []string{"install-cni-v2-2"},
 			daemonsetName:     "istio-cni-node",
 		},
 		{
@@ -44,6 +44,13 @@ func TestCNISupportedVersionRendering(t *testing.T) {
 			instanceVersion:   versions.V2_3.Version(),
 			containerNames:    []string{"install-cni"},
 			daemonsetName:     "istio-cni-node-v2-3",
+		},
+		{
+			name:              "Default Supported Versions SMCP v2.4",
+			supportedVersions: versions.GetSupportedVersions(),
+			instanceVersion:   versions.V2_4.Version(),
+			containerNames:    []string{"install-cni"},
+			daemonsetName:     "istio-cni-node-v2-4",
 		},
 		{
 			name:              "v2.2 only",
@@ -122,34 +129,13 @@ func TestCNISupportedVersionRendering(t *testing.T) {
 func InitializeGlobals(operatorNamespace string) func() {
 	return func() {
 		// make sure globals are initialized for testing
-		common.Config.OLM.Images.V1_1.CNI = "istio-cni-test-1_1"
-		common.Config.OLM.Images.V2_0.CNI = "istio-cni-test-2_0"
 		common.Config.OLM.Images.V2_1.CNI = "istio-cni-test-2_1"
-		common.Config.OLM.Images.V1_1.ThreeScale = "injected-3scale-v1.1"
-		common.Config.OLM.Images.V2_0.ThreeScale = "injected-3scale-v2.0"
 		common.Config.OLM.Images.V2_1.ThreeScale = "injected-3scale-v2.1"
-		common.Config.OLM.Images.V1_1.Citadel = "injected-citadel-v1.1"
-		common.Config.OLM.Images.V1_1.Galley = "injected-galley-v1.1"
-		common.Config.OLM.Images.V1_1.Grafana = "injected-grafana-v1.1"
-		common.Config.OLM.Images.V2_0.Grafana = "injected-grafana-v2.0"
 		common.Config.OLM.Images.V2_1.Grafana = "injected-grafana-v2.1"
-		common.Config.OLM.Images.V1_1.Mixer = "injected-mixer-v1.1"
-		common.Config.OLM.Images.V2_0.Mixer = "injected-mixer-v2.0"
-		common.Config.OLM.Images.V1_1.Pilot = "injected-pilot-v1.1"
-		common.Config.OLM.Images.V2_0.Pilot = "injected-pilot-v2.0"
 		common.Config.OLM.Images.V2_1.Pilot = "injected-pilot-v2.1"
-		common.Config.OLM.Images.V1_1.Prometheus = "injected-prometheus-v1.1"
-		common.Config.OLM.Images.V2_0.Prometheus = "injected-prometheus-v2.0"
 		common.Config.OLM.Images.V2_1.Prometheus = "injected-prometheus-v2.1"
-		common.Config.OLM.Images.V1_1.ProxyInit = "injected-proxy-init-v1.1"
-		common.Config.OLM.Images.V2_0.ProxyInit = "injected-proxy-init-v2.0"
 		common.Config.OLM.Images.V2_1.ProxyInit = "injected-proxy-init-v2.1"
-		common.Config.OLM.Images.V1_1.ProxyV2 = "injected-proxyv2-v1.1"
-		common.Config.OLM.Images.V2_0.ProxyV2 = "injected-proxyv2-v2.0"
 		common.Config.OLM.Images.V2_1.ProxyV2 = "injected-proxyv2-v2.1"
-		common.Config.OLM.Images.V1_1.SidecarInjector = "injected-sidecar-injector-v1.1"
-		common.Config.OLM.Images.V1_1.IOR = "injected-ior-v1.1"
-		common.Config.OLM.Images.V2_0.WASMCacher = "injected-wasm-cacher-v2.0"
 		common.Config.OLM.Images.V2_1.WASMCacher = "injected-wasm-cacher-v2.1"
 		os.Setenv("POD_NAMESPACE", operatorNamespace)
 		common.GetOperatorNamespace()

--- a/pkg/bootstrap/cni_test.go
+++ b/pkg/bootstrap/cni_test.go
@@ -46,20 +46,6 @@ func TestCNISupportedVersionRendering(t *testing.T) {
 			daemonsetName:     "istio-cni-node-v2-3",
 		},
 		{
-			name:              "v2.0 only",
-			supportedVersions: []versions.Version{versions.V2_0},
-			instanceVersion:   versions.V2_0.Version(),
-			containerNames:    []string{"install-cni-v2-0"},
-			daemonsetName:     "istio-cni-node",
-		},
-		{
-			name:              "v2.1 only",
-			supportedVersions: []versions.Version{versions.V2_1},
-			instanceVersion:   versions.V2_1.Version(),
-			containerNames:    []string{"install-cni-v2-1"},
-			daemonsetName:     "istio-cni-node",
-		},
-		{
 			name:              "v2.2 only",
 			supportedVersions: []versions.Version{versions.V2_2},
 			instanceVersion:   versions.V2_2.Version(),

--- a/pkg/bootstrap/cni_test.go
+++ b/pkg/bootstrap/cni_test.go
@@ -35,7 +35,7 @@ func TestCNISupportedVersionRendering(t *testing.T) {
 			name:              "Default Supported Versions SMCP v2.2",
 			supportedVersions: versions.GetSupportedVersions(),
 			instanceVersion:   versions.V2_2.Version(),
-			containerNames:    []string{"install-cni-v2-2"},
+			containerNames:    []string{"install-cni-v2-1", "install-cni-v2-2"},
 			daemonsetName:     "istio-cni-node",
 		},
 		{

--- a/pkg/controller/servicemesh/controlplane/addons_test.go
+++ b/pkg/controller/servicemesh/controlplane/addons_test.go
@@ -255,7 +255,7 @@ func TestAddonsInstall(t *testing.T) {
 
 func allV2Versions() []string {
 	var result []string
-	for _, v := range versions.AllV2Versions {
+	for _, v := range versions.TestedVersions {
 		result = append(result, v.String())
 	}
 	return result

--- a/pkg/controller/servicemesh/controlplane/integration_test.go
+++ b/pkg/controller/servicemesh/controlplane/integration_test.go
@@ -47,7 +47,7 @@ func TestDefaultInstall(t *testing.T) {
 			},
 		},
 	}
-	for _, v := range versions.AllV2Versions {
+	for _, v := range versions.TestedVersions {
 		if v.AtLeast(versions.V2_3) {
 			testCases = append(testCases, IntegrationTestCase{
 				name: "default." + v.String(),
@@ -96,22 +96,20 @@ func TestBootstrapping(t *testing.T) {
 	}
 
 	var testCases []testCase
-	for _, v := range versions.AllV2Versions {
-		if v.AtLeast(versions.V2_2) {
-			testCases = append(testCases, testCase{
-				version: v,
-				smcp: &maistrav2.ServiceMeshControlPlane{
-					ObjectMeta: metav1.ObjectMeta{Name: smcpName, Namespace: controlPlaneNamespace},
-					Spec: maistrav2.ControlPlaneSpec{
-						Version:  v.String(),
-						Profiles: []string{"maistra"},
-					},
+	for _, v := range versions.TestedVersions {
+		testCases = append(testCases, testCase{
+			version: v,
+			smcp: &maistrav2.ServiceMeshControlPlane{
+				ObjectMeta: metav1.ObjectMeta{Name: smcpName, Namespace: controlPlaneNamespace},
+				Spec: maistrav2.ControlPlaneSpec{
+					Version:  v.String(),
+					Profiles: []string{"maistra"},
 				},
-				cniDaemonSetName:        cniDaemonSetNames[v],
-				crdCount:                19,
-				unexpectedCNIDaemonSets: unexpectedCNIDaemonSetNames(cniDaemonSetNames, v),
-			})
-		}
+			},
+			cniDaemonSetName:        cniDaemonSetNames[v],
+			crdCount:                19,
+			unexpectedCNIDaemonSets: unexpectedCNIDaemonSetNames(cniDaemonSetNames, v),
+		})
 	}
 
 	if testing.Verbose() {

--- a/pkg/controller/servicemesh/controlplane/integration_test.go
+++ b/pkg/controller/servicemesh/controlplane/integration_test.go
@@ -173,8 +173,9 @@ func unexpectedCNIDaemonSetNames(cniDaemonSetNames map[versions.Version]string, 
 	var unexpectedCNIDaemonSets []ActionAssertion
 	for ver, daemonSetName := range cniDaemonSetNames {
 		if ver != currentVer {
-			unexpectedCNIDaemonSets = append(unexpectedCNIDaemonSets, Assert("create").On("daemonsets").Named(daemonSetName).IsNotSeen())
-			unexpectedCNIDaemonSets = append(unexpectedCNIDaemonSets, Assert("update").On("daemonsets").Named(daemonSetName).IsNotSeen())
+			unexpectedCNIDaemonSets = append(unexpectedCNIDaemonSets,
+				Assert("create").On("daemonsets").Named(daemonSetName).IsNotSeen(),
+				Assert("update").On("daemonsets").Named(daemonSetName).IsNotSeen())
 		}
 	}
 	return unexpectedCNIDaemonSets

--- a/pkg/controller/servicemesh/controlplane/integration_test.go
+++ b/pkg/controller/servicemesh/controlplane/integration_test.go
@@ -79,81 +79,39 @@ func TestBootstrapping(t *testing.T) {
 		operatorNamespace     = "istio-operator"
 		controlPlaneNamespace = "test"
 		smcpName              = "test"
-		cniDaemonSetNamev2    = "istio-cni-node"
-		cniDaemonSetNamev2_3  = "istio-cni-node-v2-3" // introduced a new cniDaemonSet in v2.3
 	)
 
-	var (
+	cniDaemonSetNames := map[versions.Version]string{
+		versions.V2_2: "istio-cni-node",
+		versions.V2_3: "istio-cni-node-v2-3",
+		versions.V2_4: "istio-cni-node-v2-4",
+	}
+
+	type testCase struct {
+		version                 versions.Version
+		smcp                    *maistrav2.ServiceMeshControlPlane
+		crdCount                int
 		cniDaemonSetName        string
-		cniDaemonSetNameInvalid string
-	)
+		unexpectedCNIDaemonSets []ActionAssertion
+	}
 
-	testCases := []struct {
-		name     string
-		smcp     *maistrav2.ServiceMeshControlPlane
-		crdCount int
-	}{
-		{
-			name: "v2.0",
-			smcp: &maistrav2.ServiceMeshControlPlane{
-				ObjectMeta: metav1.ObjectMeta{Name: smcpName, Namespace: controlPlaneNamespace},
-				Spec: maistrav2.ControlPlaneSpec{
-					Version:  versions.V2_0.String(),
-					Profiles: []string{"maistra"},
-				},
-			},
-			crdCount: 26,
-		},
-		{
-			name: "v2.0.mixer",
-			smcp: &maistrav2.ServiceMeshControlPlane{
-				ObjectMeta: metav1.ObjectMeta{Name: smcpName, Namespace: controlPlaneNamespace},
-				Spec: maistrav2.ControlPlaneSpec{
-					Version:  versions.V2_0.String(),
-					Profiles: []string{"maistra"},
-					Policy: &maistrav2.PolicyConfig{
-						Type: maistrav2.PolicyTypeMixer,
-					},
-					Telemetry: &maistrav2.TelemetryConfig{
-						Type: maistrav2.TelemetryTypeMixer,
+	var testCases []testCase
+	for _, v := range versions.AllV2Versions {
+		if v.AtLeast(versions.V2_2) {
+			testCases = append(testCases, testCase{
+				version: v,
+				smcp: &maistrav2.ServiceMeshControlPlane{
+					ObjectMeta: metav1.ObjectMeta{Name: smcpName, Namespace: controlPlaneNamespace},
+					Spec: maistrav2.ControlPlaneSpec{
+						Version:  v.String(),
+						Profiles: []string{"maistra"},
 					},
 				},
-			},
-			crdCount: 26,
-		},
-		{
-			name: "v2.1",
-			smcp: &maistrav2.ServiceMeshControlPlane{
-				ObjectMeta: metav1.ObjectMeta{Name: smcpName, Namespace: controlPlaneNamespace},
-				Spec: maistrav2.ControlPlaneSpec{
-					Version:  versions.V2_1.String(),
-					Profiles: []string{"maistra"},
-				},
-			},
-			crdCount: 17,
-		},
-		{
-			name: "v2.2",
-			smcp: &maistrav2.ServiceMeshControlPlane{
-				ObjectMeta: metav1.ObjectMeta{Name: smcpName, Namespace: controlPlaneNamespace},
-				Spec: maistrav2.ControlPlaneSpec{
-					Version:  versions.V2_2.String(),
-					Profiles: []string{"maistra"},
-				},
-			},
-			crdCount: 19,
-		},
-		{
-			name: "v2.3",
-			smcp: &maistrav2.ServiceMeshControlPlane{
-				ObjectMeta: metav1.ObjectMeta{Name: smcpName, Namespace: controlPlaneNamespace},
-				Spec: maistrav2.ControlPlaneSpec{
-					Version:  versions.V2_3.String(),
-					Profiles: []string{"maistra"},
-				},
-			},
-			crdCount: 19,
-		},
+				cniDaemonSetName:        cniDaemonSetNames[v],
+				crdCount:                19,
+				unexpectedCNIDaemonSets: unexpectedCNIDaemonSetNames(cniDaemonSetNames, v),
+			})
+		}
 	}
 
 	if testing.Verbose() {
@@ -161,15 +119,12 @@ func TestBootstrapping(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		if tc.name == "v2.3" {
-			cniDaemonSetName = cniDaemonSetNamev2_3
-			cniDaemonSetNameInvalid = cniDaemonSetNamev2
-		} else {
-			cniDaemonSetName = cniDaemonSetNamev2
-			cniDaemonSetNameInvalid = cniDaemonSetNamev2_3
-		}
-
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.version.String(), func(t *testing.T) {
+			assertions := ActionAssertions{
+				// verify proper number of CRDs is created
+				Assert("create").On("customresourcedefinitions").Version("v1").SeenCountIs(tc.crdCount),
+			}
+			assertions = append(assertions, tc.unexpectedCNIDaemonSets...)
 			RunControllerTestCase(t, ControllerTestCase{
 				Name:             "clean-install-cni-no-errors",
 				ConfigureGlobals: InitializeGlobals(operatorNamespace),
@@ -196,19 +151,14 @@ func TestBootstrapping(t *testing.T) {
 							// verify that a CRD is installed
 							Verify("create").On("customresourcedefinitions").Version("v1").IsSeen(),
 							// verify that the correct CNI daemonset is installed
-							Verify("create").On("daemonsets").Named(cniDaemonSetName).In(operatorNamespace).IsSeen(),
+							Verify("create").On("daemonsets").Named(tc.cniDaemonSetName).In(operatorNamespace).IsSeen(),
 							// verify readiness check triggered daemon set creation
 							VerifyReadinessCheckOccurs(controlPlaneNamespace),
 						),
-						Assertions: ActionAssertions{
-							// verify proper number of CRDs is created
-							Assert("create").On("customresourcedefinitions").Version("v1").SeenCountIs(tc.crdCount),
-							// verify that the other CNI daemonset is not installed
-							Assert("update").On("daemonsets").Named(cniDaemonSetNameInvalid).In(operatorNamespace).IsNotSeen(),
-						},
+						Assertions: assertions,
 						Reactors: []clienttesting.Reactor{
 							ReactTo("list").On("daemonsets").In(operatorNamespace).With(
-								SetDaemonSetStatus(cniDaemonSetName, appsv1.DaemonSetStatus{
+								SetDaemonSetStatus(tc.cniDaemonSetName, appsv1.DaemonSetStatus{
 									NumberAvailable:   0,
 									NumberUnavailable: 3,
 								})),
@@ -219,6 +169,17 @@ func TestBootstrapping(t *testing.T) {
 			})
 		})
 	}
+}
+
+func unexpectedCNIDaemonSetNames(cniDaemonSetNames map[versions.Version]string, currentVer versions.Version) []ActionAssertion {
+	var unexpectedCNIDaemonSets []ActionAssertion
+	for ver, daemonSetName := range cniDaemonSetNames {
+		if ver != currentVer {
+			unexpectedCNIDaemonSets = append(unexpectedCNIDaemonSets, Assert("create").On("daemonsets").Named(daemonSetName).IsNotSeen())
+			unexpectedCNIDaemonSets = append(unexpectedCNIDaemonSets, Assert("update").On("daemonsets").Named(daemonSetName).IsNotSeen())
+		}
+	}
+	return unexpectedCNIDaemonSets
 }
 
 func SetDaemonSetStatus(name string, status appsv1.DaemonSetStatus) ReactionFunc {

--- a/pkg/controller/servicemesh/webhooks/validation/controlplane_test.go
+++ b/pkg/controller/servicemesh/webhooks/validation/controlplane_test.go
@@ -377,6 +377,7 @@ func TestFullAffinityOnlySupportedForKiali(t *testing.T) {
 							Version: v.String(),
 							Runtime: &maistrav2.ControlPlaneRuntimeConfig{
 								Components: map[maistrav2.ControlPlaneComponentName]*maistrav2.ComponentRuntimeConfig{
+									// nolint:exportloopref
 									component: &tc.componentRuntimeConfig,
 								},
 							},

--- a/pkg/controller/versions/versions.go
+++ b/pkg/controller/versions/versions.go
@@ -38,6 +38,7 @@ const (
 
 var (
 	AllV2Versions  = []Version{V2_0, V2_1, V2_2, V2_3, V2_4}
+	TestedVersions = []Version{V2_2, V2_3, V2_4}
 	legacyVersions = map[string]bool{
 		"v1.0": true,
 	}

--- a/pkg/controller/versions/versions.go
+++ b/pkg/controller/versions/versions.go
@@ -46,9 +46,6 @@ var (
 func init() {
 	versionToString = map[Ver]string{
 		InvalidVersion: "InvalidVersion",
-		V1_1:           "v1.1",
-		V2_0:           "v2.0",
-		V2_1:           "v2.1",
 		V2_2:           "v2.2",
 		V2_3:           "v2.3",
 		V2_4:           "v2.4",
@@ -56,9 +53,6 @@ func init() {
 
 	versionToStrategy = map[Ver]VersionStrategy{
 		InvalidVersion: &invalidVersionStrategy{InvalidVersion},
-		V1_1:           &versionStrategyV1_1{Ver: V1_1},
-		V2_0:           &versionStrategyV2_0{Ver: V2_0},
-		V2_1:           &versionStrategyV2_1{Ver: V2_1},
 		V2_2:           &versionStrategyV2_2{Ver: V2_2},
 		V2_3:           &versionStrategyV2_3{Ver: V2_3},
 		V2_4:           &versionStrategyV2_4{Ver: V2_4},
@@ -66,9 +60,6 @@ func init() {
 
 	versionToCNINetwork = map[Ver]string{
 		InvalidVersion: "",
-		V1_1:           "v1-1-istio-cni",
-		V2_0:           "v2-0-istio-cni",
-		V2_1:           "v2-1-istio-cni",
 		V2_2:           "v2-2-istio-cni",
 		V2_3:           "v2-3-istio-cni",
 		V2_4:           "v2-4-istio-cni",

--- a/pkg/controller/versions/versions.go
+++ b/pkg/controller/versions/versions.go
@@ -46,6 +46,9 @@ var (
 func init() {
 	versionToString = map[Ver]string{
 		InvalidVersion: "InvalidVersion",
+		V1_1:           "v1.1",
+		V2_0:           "v2.0",
+		V2_1:           "v2.1",
 		V2_2:           "v2.2",
 		V2_3:           "v2.3",
 		V2_4:           "v2.4",
@@ -53,6 +56,9 @@ func init() {
 
 	versionToStrategy = map[Ver]VersionStrategy{
 		InvalidVersion: &invalidVersionStrategy{InvalidVersion},
+		V1_1:           &versionStrategyV1_1{Ver: V1_1},
+		V2_0:           &versionStrategyV2_0{Ver: V2_0},
+		V2_1:           &versionStrategyV2_1{Ver: V2_1},
 		V2_2:           &versionStrategyV2_2{Ver: V2_2},
 		V2_3:           &versionStrategyV2_3{Ver: V2_3},
 		V2_4:           &versionStrategyV2_4{Ver: V2_4},
@@ -60,6 +66,9 @@ func init() {
 
 	versionToCNINetwork = map[Ver]string{
 		InvalidVersion: "",
+		V1_1:           "v1-1-istio-cni",
+		V2_0:           "v2-0-istio-cni",
+		V2_1:           "v2-1-istio-cni",
 		V2_2:           "v2-2-istio-cni",
 		V2_3:           "v2-3-istio-cni",
 		V2_4:           "v2-4-istio-cni",

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,7 +14,7 @@ var (
 	buildTag         = "unknown"
 
 	// Minimum supported mesh version (nil (all), "v2_0", "v2_1" etc)
-	minimumSupportedVersion = "v2.0"
+	minimumSupportedVersion = "v2.2"
 
 	// Info exports the build version information.
 	Info BuildInfo

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,7 +14,7 @@ var (
 	buildTag         = "unknown"
 
 	// Minimum supported mesh version (nil (all), "v2_0", "v2_1" etc)
-	minimumSupportedVersion = "v2.2"
+	minimumSupportedVersion = "v2.1"
 
 	// Info exports the build version information.
 	Info BuildInfo


### PR DESCRIPTION
Apart from removing v2.0 containers from manifests I also refactored tests so that we only execute them for v2.2+, because v2.1 is no longer supported and will not be patched.