### PR TITLE
OSSM-4014 Add Make target that downloads charts

### DIFF
--- a/hack/download-charts.sh
+++ b/hack/download-charts.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -e -u
+
+: "${MAISTRA_RELEASE_STREAM:=$1}"
+: "${ISTIO_REPO:=$2}"
+: "${ISTIO_COMMIT:=$3}"
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT=$(dirname "${SCRIPT_DIR}")
+HELM_DIR="${REPO_ROOT}/resources/charts/${MAISTRA_RELEASE_STREAM}"
+
+ISTIO_FILE="${ISTIO_COMMIT}.zip"
+ISTIO_URL="${ISTIO_REPO}/archive/${ISTIO_COMMIT}.zip"
+WORK_DIR=$(mktemp -d)
+EXTRACT_DIR="${ISTIO_REPO##*/}-${ISTIO_COMMIT}"
+EXTRACT_CMD="unzip -q ${ISTIO_FILE} ${EXTRACT_DIR}/manifests/charts/* ${EXTRACT_DIR}/manifests/addons/dashboards/*"
+
+function downloadIstioCharts() {
+  rm -rf "${HELM_DIR}"
+  mkdir -p "${HELM_DIR}"
+
+  echo "downloading charts from ${ISTIO_URL}"
+  cd "${WORK_DIR}"
+  curl -LfO "${ISTIO_URL}"
+
+  echo "extracting charts to ${WORK_DIR}/${EXTRACT_DIR}"
+  ${EXTRACT_CMD}
+  echo "copying charts to ${HELM_DIR}"
+  cp -rf "${WORK_DIR}"/"${EXTRACT_DIR}"/manifests/charts/* "${HELM_DIR}/"
+}
+
+downloadIstioCharts

--- a/resources/charts/v3.0/UPDATING-CHARTS.md
+++ b/resources/charts/v3.0/UPDATING-CHARTS.md
@@ -59,7 +59,7 @@ These manifests can be found in [gen-istio.yaml](../charts/istio-control/istio-d
 To regenerate the manifests, run:
 
 ```bash
-$ make copy-templates gen-kustomize update-golden
+$ make copy-templates update-golden
 ```
 
 ## Step 5. Create a PR using outputs from Steps 1 to 4

--- a/resources/charts/v3.0/istio-cni/templates/daemonset.yaml
+++ b/resources/charts/v3.0/istio-cni/templates/daemonset.yaml
@@ -24,7 +24,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 1
+      maxUnavailable: {{ .Values.cni.rollingMaxUnavailable }}
   template:
     metadata:
       labels:

--- a/resources/charts/v3.0/istio-cni/values.yaml
+++ b/resources/charts/v3.0/istio-cni/values.yaml
@@ -80,6 +80,13 @@ cni:
     enabled: false
     pods: 5000
 
+  # The number of pods that can be unavailable during rolling update (see
+  # `updateStrategy.rollingUpdate.maxUnavailable` here:
+  # https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/#DaemonSetSpec).
+  # May be specified as a number of pods or as a percent of the total number
+  # of pods at the start of the update.
+  rollingMaxUnavailable: 1
+
 # Revision is set as 'version' label and part of the resource names when installing multiple control planes.
 revision: ""
 

--- a/resources/charts/v3.0/istio-control/istio-discovery/files/grpc-simple.yaml
+++ b/resources/charts/v3.0/istio-control/istio-discovery/files/grpc-simple.yaml
@@ -1,5 +1,6 @@
 metadata:
-  sidecar.istio.io/rewriteAppHTTPProbers: "false"
+  annotations:
+    sidecar.istio.io/rewriteAppHTTPProbers: "false"
 spec:
   initContainers:
     - name: grpc-bootstrap-init

--- a/resources/charts/v3.0/istio-control/istio-discovery/files/injection-template.yaml
+++ b/resources/charts/v3.0/istio-control/istio-discovery/files/injection-template.yaml
@@ -155,7 +155,6 @@ spec:
       runAsUser: 1337
       runAsNonRoot: true
     {{- end }}
-    restartPolicy: Always
   {{ end -}}
   {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
   - name: enable-core-dump
@@ -345,7 +344,6 @@ spec:
       privileged: true
       readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       runAsGroup: 1337
-      fsGroup: 1337
       runAsNonRoot: false
       runAsUser: 0
       {{- else }}
@@ -365,7 +363,6 @@ spec:
       privileged: {{ .Values.global.proxy.privileged }}
       readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       runAsGroup: 1337
-      fsGroup: 1337
       {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
       runAsNonRoot: false
       runAsUser: 0

--- a/resources/charts/v3.0/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/resources/charts/v3.0/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -157,9 +157,9 @@ spec:
               fieldPath: spec.nodeName
         - name: ISTIO_META_INTERCEPTION_MODE
           value: "{{ .ProxyConfig.InterceptionMode.String }}"
-        {{- if .Values.global.network }}
+        {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
         - name: ISTIO_META_NETWORK
-          value: "{{ .Values.global.network }}"
+          value: {{.|quote}}
         {{- end }}
         - name: ISTIO_META_WORKLOAD_NAME
           value: {{.DeploymentName|quote}}

--- a/resources/charts/v3.0/istiod-remote/files/injection-template.yaml
+++ b/resources/charts/v3.0/istiod-remote/files/injection-template.yaml
@@ -155,7 +155,6 @@ spec:
       runAsUser: 1337
       runAsNonRoot: true
     {{- end }}
-    restartPolicy: Always
   {{ end -}}
   {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
   - name: enable-core-dump
@@ -345,7 +344,6 @@ spec:
       privileged: true
       readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       runAsGroup: 1337
-      fsGroup: 1337
       runAsNonRoot: false
       runAsUser: 0
       {{- else }}
@@ -365,7 +363,6 @@ spec:
       privileged: {{ .Values.global.proxy.privileged }}
       readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       runAsGroup: 1337
-      fsGroup: 1337
       {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
       runAsNonRoot: false
       runAsUser: 0


### PR DESCRIPTION
I took the original script from the 2.4 branch and stripped it down a little bit to make it less confusing. Also, it will now download and extract into a tmp directory, so we avoid the need to run `make clean` everytime- if you have worked on the old operator, you might have encountered the situation that you were working with outdated charts because an old zip file was still around somewhere.