### PR TITLE
Log version on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@
 FROM golang:1.20 as builder
 ARG TARGETOS
 ARG TARGETARCH
+ARG GIT_REVISION
+ARG GIT_TAG
+ARG GIT_STATUS
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -12,24 +15,25 @@ COPY go.sum go.sum
 RUN go mod download
 
 # Copy the go source
-COPY main.go main.go
 COPY api/ api/
-COPY controllers/ controllers/
 COPY pkg/ pkg/
+COPY controllers/ controllers/
+COPY main.go main.go
+COPY Makefile Makefile
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
+RUN make build -e GOOS=${TARGETOS:-linux} -e GOARCH=${TARGETARCH}
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest 
 # gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/bin/manager .
 COPY resources /var/lib/istio-operator/resources
 USER 65532:65532
 

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	"maistra.io/istio-operator/controllers"
 	"maistra.io/istio-operator/pkg/common"
 	"maistra.io/istio-operator/pkg/helm"
+	"maistra.io/istio-operator/pkg/version"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -61,7 +62,7 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
-
+	setupLog.Info(version.Info.String())
 	setupLog.Info("reading config")
 	err := common.ReadConfig(configFile)
 	if err != nil {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -7,10 +7,11 @@ import (
 )
 
 var (
-	buildVersion     = "unknown"
-	buildGitRevision = "unknown"
-	buildStatus      = "unknown"
-	buildTag         = "unknown"
+	buildVersion            = "unknown"
+	buildGitRevision        = "unknown"
+	buildStatus             = "unknown"
+	buildTag                = "unknown"
+	minimumSupportedVersion = "any"
 
 	// Info exports the build version information.
 	Info BuildInfo
@@ -24,7 +25,7 @@ type BuildInfo struct {
 	GitTag                  string
 	GoVersion               string
 	GoArch                  string
-	OperatorSDK             string
+	ControllerRuntime       string
 	MinimumSupportedVersion string
 }
 
@@ -33,23 +34,24 @@ func (b BuildInfo) String() string {
 }
 
 func init() {
-	var sdkVersion string
+	var controllerRuntimeVersion string
 	bi, ok := debug.ReadBuildInfo()
 	if ok {
 		for _, dep := range bi.Deps {
-			if dep.Path == "github.com/operator-franework/operator-sdk" {
-				sdkVersion = dep.Version
+			if dep.Path == "sigs.k8s.io/controller-runtime" {
+				controllerRuntimeVersion = dep.Version
 				break
 			}
 		}
 	}
 	Info = BuildInfo{
-		Version:     buildVersion,
-		GitRevision: buildGitRevision,
-		BuildStatus: buildStatus,
-		GitTag:      buildTag,
-		GoVersion:   runtime.Version(),
-		GoArch:      fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
-		OperatorSDK: sdkVersion,
+		Version:                 buildVersion,
+		GitRevision:             buildGitRevision,
+		BuildStatus:             buildStatus,
+		GitTag:                  buildTag,
+		GoVersion:               runtime.Version(),
+		GoArch:                  fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		ControllerRuntime:       controllerRuntimeVersion,
+		MinimumSupportedVersion: minimumSupportedVersion,
 	}
 }


### PR DESCRIPTION
First log line will look like this:
`
2023-06-06T21:22:29Z	INFO	setup	version.BuildInfo{Version:"3.0.0", GitRevision:"9e5e71dc01c98518102b27c94f4d1b41c0bd93e2", BuildStatus:"Clean", GitTag:"unknown", GoVersion:"go1.20.5", GoArch:"linux/amd64", ControllerRuntime:"v0.14.1", MinimumSupportedVersion:"v3.0"}
`

This is really helpful when debugging reported bugs/issues