### PR TITLE
OSSM-4102 - Add Annotation For network-attachment-definitions

### DIFF
--- a/bundle/manifests/maistraoperator.clusterserviceversion.yaml
+++ b/bundle/manifests/maistraoperator.clusterserviceversion.yaml
@@ -24,7 +24,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-06-12T17:59:00Z"
+    createdAt: "2023-06-13T14:49:02Z"
     operators.operatorframework.io/builder: operator-sdk-v1.28.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: maistraoperator.v3.0.0
@@ -79,6 +79,12 @@ spec:
           - autoscaling
           resources:
           - horizontalpodautoscalers
+          verbs:
+          - '*'
+        - apiGroups:
+          - k8s.cni.cncf.io
+          resources:
+          - network-attachment-definitions
           verbs:
           - '*'
         - apiGroups:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -38,6 +38,12 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - k8s.cni.cncf.io
+  resources:
+  - network-attachment-definitions
+  verbs:
+  - '*'
+- apiGroups:
   - maistra.io
   resources:
   - istiohelminstalls

--- a/controllers/istiohelminstall_controller.go
+++ b/controllers/istiohelminstall_controller.go
@@ -68,6 +68,7 @@ func namespaceForChart(chartName string, ihi v1.IstioHelmInstall) string {
 // +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=validatingwebhookconfigurations;mutatingwebhookconfigurations,verbs="*"
 // +kubebuilder:rbac:groups="autoscaling",resources=horizontalpodautoscalers,verbs="*"
 // +kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,verbs="*"
+// +kubebuilder:rbac:groups="k8s.cni.cncf.io",resources=network-attachment-definitions,verbs="*"
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
Fix operator crash that was happening due to insufficient network-attachment-definitions permissions.