### PR TITLE
Add bundle validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -398,5 +398,8 @@ lint-helm: ## runs linters against helm charts
 	@${FINDFILES} -name 'Chart.yaml' -path './resources/helm/v3.?/*' \
 	-print0 | ${XARGS} -L 1 dirname | xargs -r helm lint --strict
 
+lint-bundle: operator-sdk ## runs linters against OLM metadata bundle
+	$(OPERATOR_SDK) bundle validate bundle --select-optional suite=operatorframework
+
 .PHONY: lint
-lint: lint-scripts lint-go lint-yaml lint-helm ## runs all linters
+lint: lint-scripts lint-go lint-yaml lint-helm lint-bundle ## runs all linters

--- a/hack/operatorhub/publish-bundle.sh
+++ b/hack/operatorhub/publish-bundle.sh
@@ -33,7 +33,6 @@ while test $# -gt 0; do
     *)
             echo "Unknown param $1"
             exit 1
-            break
             ;;
   esac
 done


### PR DESCRIPTION
This validates our OLM bundle as part of the linting step. A second commit fixes a linting error that is currently not caught by our CI because the shellcheck version we use is older than my local one.