### PR TITLE
Add missing annotations for OperatorHub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,6 +306,7 @@ $(ENVTEST): $(LOCALBIN)
 bundle: gen kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMAGE)
+	sed -i "s|^\(    containerImage:\).*$$|\1 ${IMAGE}|g" config/manifests/bases/maistraoperator.clusterserviceversion.yaml
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 	$(OPERATOR_SDK) bundle validate ./bundle
 

--- a/bundle/manifests/maistraoperator.clusterserviceversion.yaml
+++ b/bundle/manifests/maistraoperator.clusterserviceversion.yaml
@@ -23,8 +23,10 @@ metadata:
           }
         }
       ]
-    capabilities: Basic Install
-    createdAt: "2023-06-14T10:28:34Z"
+    capabilities: Seamless Upgrades
+    categories: OpenShift Optional, Integration & Delivery, Networking, Security
+    containerImage: quay.io/maistra-dev/istio-ubi9-operator:3.0-latest
+    createdAt: "2023-06-14T15:41:23Z"
     operators.operatorframework.io/builder: operator-sdk-v1.28.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: maistraoperator.v3.0.0

--- a/config/manifests/bases/maistraoperator.clusterserviceversion.yaml
+++ b/config/manifests/bases/maistraoperator.clusterserviceversion.yaml
@@ -3,7 +3,9 @@ kind: ClusterServiceVersion
 metadata:
   annotations:
     alm-examples: '[]'
-    capabilities: Basic Install
+    capabilities: Seamless Upgrades
+    categories: OpenShift Optional, Integration & Delivery, Networking, Security
+    containerImage: quay.io/maistra-dev/istio-ubi9-operator:3.0-latest
   name: maistraoperator.v3.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
This adds the `containerImage` and `categories` annotations, both of which are required to pass the pipelines in https://github.com/redhat-openshift-ecosystem/community-operators-prod