### PR TITLE
OSSM-4185 Use a simple tag to reference new prometheus images

### DIFF
--- a/deploy/servicemesh-operator.yaml
+++ b/deploy/servicemesh-operator.yaml
@@ -10888,8 +10888,8 @@ spec:
         olm.relatedImage.v2_4.cni: ${OSSM_CNI_IMAGE}
         olm.relatedImage.v2_4.grafana: ${OSSM_GRAFANA_IMAGE}
         olm.relatedImage.v2_4.pilot: ${OSSM_PILOT_IMAGE}
-        olm.relatedImage.v2_4.prometheus: registry.redhat.io/openshift4/ose-prometheus:4.12.0@sha256:41e57c5c44e53c776b68911762db6da95ad8c9dd550d823d94967921d80ed3bb
-        olm.relatedImage.v2_4.prometheus-config-reloader: registry.redhat.io/openshift4/ose-prometheus-config-reloader:4.12.0@sha256:483b288ac721608dc1c51d921946ff6443a04eb5d2a22e9d18a6f7ecc44c14f6
+        olm.relatedImage.v2_4.prometheus: registry.redhat.io/openshift4/ose-prometheus:v4.12
+        olm.relatedImage.v2_4.prometheus-config-reloader: registry.redhat.io/openshift4/ose-prometheus-config-reloader:v4.12
         olm.relatedImage.v2_4.proxyv2: ${OSSM_PROXY_IMAGE}
         olm.relatedImage.v2_4.rls: ${OSSM_RATELIMIT_IMAGE}
 

--- a/deploy/src/deployment-servicemesh.yaml
+++ b/deploy/src/deployment-servicemesh.yaml
@@ -43,8 +43,8 @@ spec:
         olm.relatedImage.v2_4.cni: ${OSSM_CNI_IMAGE}
         olm.relatedImage.v2_4.grafana: ${OSSM_GRAFANA_IMAGE}
         olm.relatedImage.v2_4.pilot: ${OSSM_PILOT_IMAGE}
-        olm.relatedImage.v2_4.prometheus: registry.redhat.io/openshift4/ose-prometheus:4.12.0@sha256:41e57c5c44e53c776b68911762db6da95ad8c9dd550d823d94967921d80ed3bb
-        olm.relatedImage.v2_4.prometheus-config-reloader: registry.redhat.io/openshift4/ose-prometheus-config-reloader:4.12.0@sha256:483b288ac721608dc1c51d921946ff6443a04eb5d2a22e9d18a6f7ecc44c14f6
+        olm.relatedImage.v2_4.prometheus: registry.redhat.io/openshift4/ose-prometheus:v4.12
+        olm.relatedImage.v2_4.prometheus-config-reloader: registry.redhat.io/openshift4/ose-prometheus-config-reloader:v4.12
         olm.relatedImage.v2_4.proxyv2: ${OSSM_PROXY_IMAGE}
         olm.relatedImage.v2_4.rls: ${OSSM_RATELIMIT_IMAGE}
 

--- a/manifests-maistra/2.4.0/maistraoperator.v2.4.0.clusterserviceversion.yaml
+++ b/manifests-maistra/2.4.0/maistraoperator.v2.4.0.clusterserviceversion.yaml
@@ -15,7 +15,7 @@ metadata:
       The Maistra Operator enables you to install, configure, and manage an instance of Maistra service mesh. Maistra is based on the open source Istio project.
 
     containerImage: quay.io/maistra/istio-ubi8-operator:2.4.0
-    createdAt: 2023-06-14T07:58:39MDT
+    createdAt: 2023-06-15T11:52:41CEST
     support: Red Hat, Inc. 
     olm.skipRange: ">=1.0.2 <2.4.0-0"
     operators.openshift.io/infrastructure-features: '[]'

--- a/manifests-servicemesh/2.4.0/servicemeshoperator.v2.4.0.clusterserviceversion.yaml
+++ b/manifests-servicemesh/2.4.0/servicemeshoperator.v2.4.0.clusterserviceversion.yaml
@@ -17,7 +17,7 @@ metadata:
       The OpenShift Service Mesh Operator enables you to install, configure, and manage an instance of Red Hat OpenShift Service Mesh. OpenShift Service Mesh is based on the open source Istio project.
 
     containerImage: ${OSSM_OPERATOR_IMAGE}
-    createdAt: 2023-06-14T07:58:40MDT
+    createdAt: 2023-06-15T11:52:42CEST
     support: Red Hat, Inc. 
     olm.skipRange: ">=1.0.2 <2.4.0-0"
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
@@ -546,8 +546,8 @@ spec:
                 olm.relatedImage.v2_4.cni: ${OSSM_CNI_IMAGE}
                 olm.relatedImage.v2_4.grafana: ${OSSM_GRAFANA_IMAGE}
                 olm.relatedImage.v2_4.pilot: ${OSSM_PILOT_IMAGE}
-                olm.relatedImage.v2_4.prometheus: registry.redhat.io/openshift4/ose-prometheus:4.12.0@sha256:41e57c5c44e53c776b68911762db6da95ad8c9dd550d823d94967921d80ed3bb
-                olm.relatedImage.v2_4.prometheus-config-reloader: registry.redhat.io/openshift4/ose-prometheus-config-reloader:4.12.0@sha256:483b288ac721608dc1c51d921946ff6443a04eb5d2a22e9d18a6f7ecc44c14f6
+                olm.relatedImage.v2_4.prometheus: registry.redhat.io/openshift4/ose-prometheus:v4.12
+                olm.relatedImage.v2_4.prometheus-config-reloader: registry.redhat.io/openshift4/ose-prometheus-config-reloader:v4.12
                 olm.relatedImage.v2_4.proxyv2: ${OSSM_PROXY_IMAGE}
                 olm.relatedImage.v2_4.rls: ${OSSM_RATELIMIT_IMAGE}
                 oauth-proxy.query: "true"


### PR DESCRIPTION
Providing both a tag and digest is not supported by OSBS, causing the spec.relatedImages field to not be populated properly. Apart from that, the tag didn't even exist, it was missing the `v` prefix