### PR TITLE
OSSM-4246 Fix make deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ uninstall: kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube
 
 .PHONY: deploy
 deploy: kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	make deploy-yaml | kubectl apply -f -
+	make -s deploy-yaml | kubectl apply -f -
 
 .PHONY: deploy-yaml
 deploy-yaml: kustomize ## Outputs YAML manifests needed to deploy the controller


### PR DESCRIPTION
Because `make deploy` called `make deploy-yaml`, the following line was printed before all the YAMLs:
```
make[1]: Entering directory '/.../go/src/github.com/maistra/istio-operator'
```

Because the output containing this line was piped to kubectl apply,  the following error occurred:
```
Error from server (BadRequest): error when creating "STDIN": Namespace in version "v1" cannot be handled as a Namespace: strict decoding error: unknown field "make[1]"
```

We now call make with the -s (silent) option to prevent it from printing the offending line.