### PR TITLE
OSSM-4394 Fix ownerReference

### DIFF
--- a/controllers/istiohelminstall_controller.go
+++ b/controllers/istiohelminstall_controller.go
@@ -168,12 +168,14 @@ func (r *IstioHelmInstallReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		BlockOwnerDeletion: pointer.Bool(true),
 	}
 
-	err = helm.UpgradeOrInstallCharts(ctx, r.RestClientGetter, systemCharts, values, ihi.Spec.Version, ihi.Name, kube.GetOperatorNamespace(), ownerReference)
+	err = helm.UpgradeOrInstallCharts(ctx, r.RestClientGetter, systemCharts, values,
+		ihi.Spec.Version, ihi.Name, kube.GetOperatorNamespace(), ownerReference, ihi.Namespace)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	err = helm.UpgradeOrInstallCharts(ctx, r.RestClientGetter, userCharts, values, ihi.Spec.Version, ihi.Name, ihi.Namespace, ownerReference)
+	err = helm.UpgradeOrInstallCharts(ctx, r.RestClientGetter, userCharts, values,
+		ihi.Spec.Version, ihi.Name, ihi.Namespace, ownerReference, ihi.Namespace)
 	if err != nil {
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
When the istio-cni chart was deployed, the ownerReference was set, but it shouldn't have been, since the owner is in a different namespace. This caused the garbage collector to immediately delete all resources deployed by the istio-cni chart.