### PR TITLE
Fix the update-istio target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,8 +264,8 @@ check-clean-repo:
 
 .PHONY: update-istio
 update-istio: ## Updates the Istio commit hash to latest on ${ISTIO_BRANCH_30}
-	@LATEST_COMMIT_30=`git ls-remote https://github.com/${ISTIO_REPOSITORY}.git | grep ${ISTIO_BRANCH_30} | cut -f 1` ;\
-	echo Updating to ${ISTIO_REPOSITORY}@$${LATEST_COMMIT_30}; sed -i -e "s/^\(ISTIO_COMMIT_30 ?= \).*$$/\1$${LATEST_COMMIT_30}/g" Makefile
+	$(eval ISTIO_COMMIT_30=$(shell git ls-remote https://github.com/${ISTIO_REPOSITORY}.git | grep ${ISTIO_BRANCH_30} | cut -f 1))
+	@echo Updating to ${ISTIO_REPOSITORY}@${ISTIO_COMMIT_30}; sed -i -e "s/^\(ISTIO_COMMIT_30 ?= \).*$$/\1${ISTIO_COMMIT_30}/g" Makefile
 
 .PHONY: patch-istio-images
 patch-istio-images: ## Patch the Istio images in the ClusterServiceVersion with the right tags


### PR DESCRIPTION
It needs to update the make variable `ISTIO_COMMIT_30` in place, otherwise the new value will not be visible when invoking other targets, such as `gen`.

In particular, this command does not work as expected:

```sh
make update-istio gen
```

Because when the `gen` target is invoked, it is still using the old value of the `ISTIO_COMMIT_30` variable.