### PR TITLE
Add arm64 to servicemesh manifests

### DIFF
--- a/build/generate-manifests.sh
+++ b/build/generate-manifests.sh
@@ -35,7 +35,7 @@ else
   DOCUMENTATION_URL="https://docs.openshift.com/container-platform/latest/service_mesh/v2x/servicemesh-release-notes.html"
   BUG_URL="https://issues.redhat.com/projects/OSSM"
   OLM_FEATURES="[\"Disconnected\",\"fips\"]"
-  ARCHITECTURE_LABELS=$(generateArchitectureLabels amd64 s390x ppc64le)
+  ARCHITECTURE_LABELS=$(generateArchitectureLabels amd64 s390x ppc64le arm64)
   OLM_SUBSCRIPTION_ANNOTATION="operators.openshift.io/valid-subscription: '[\"OpenShift Container Platform\", \"OpenShift Platform Plus\"]'"
 fi
 : "${DEPLOYMENT_FILE:=deploy/${BUILD_TYPE}-operator.yaml}"

--- a/manifests-servicemesh/2.4.3/servicemeshoperator.v2.4.3.clusterserviceversion.yaml
+++ b/manifests-servicemesh/2.4.3/servicemeshoperator.v2.4.3.clusterserviceversion.yaml
@@ -7,6 +7,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.arm64: supported
 
   annotations:
     categories: "OpenShift Optional, Integration & Delivery"
@@ -17,7 +18,7 @@ metadata:
       The OpenShift Service Mesh Operator enables you to install, configure, and manage an instance of Red Hat OpenShift Service Mesh. OpenShift Service Mesh is based on the open source Istio project.
 
     containerImage: ${OSSM_OPERATOR_IMAGE}
-    createdAt: 2023-08-14T10:52:52EDT
+    createdAt: 2023-09-06T12:31:03EDT
     support: Red Hat, Inc. 
     olm.skipRange: ">=1.0.2 <2.4.3-0"
     operators.openshift.io/infrastructure-features: '["Disconnected","fips"]'


### PR DESCRIPTION
This is needed for the operator to be shown in OperatorHub of the OpenShift console on ARM.  Without this, the operator can only be subscribed to ("installed") through the command line.

**DO NOT MERGE THIS** until Service Mesh on ARM is considered ready for public consumption.
