### PR TITLE
OSSM-4885 Enable the possibility to run integration test in kind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -458,13 +458,13 @@ lint: lint-scripts lint-go lint-yaml lint-helm lint-bundle lint-watches ## runs 
 .PHONY: test.integration.ocp
 test.integration.ocp:
 	$(info SOURCE_DIR: $(SOURCE_DIR))
-	${SOURCE_DIR}/tests/integration/operator-integ-suite.sh --ocp
+	${SOURCE_DIR}/tests/integration/integ-suite-ocp.sh
 
 ################################################################################
-# run an integration test on K8s
+# run an integration test on Kind
 ################################################################################
-.PHONY: test.integration.k8s
-test.integration.k8s:
+.PHONY: test.integration.kind
+test.integration.kind:
 	$(info SOURCE_DIR: $(SOURCE_DIR))
-	${SOURCE_DIR}/tests/integration/operator-integ-suite.sh --k8s
+	${SOURCE_DIR}/tests/integration/integ-suite-kind.sh
 

--- a/Makefile
+++ b/Makefile
@@ -457,7 +457,6 @@ lint: lint-scripts lint-go lint-yaml lint-helm lint-bundle lint-watches ## runs 
 ################################################################################
 .PHONY: test.integration.ocp
 test.integration.ocp:
-	$(info SOURCE_DIR: $(SOURCE_DIR))
 	${SOURCE_DIR}/tests/integration/integ-suite-ocp.sh
 
 ################################################################################
@@ -465,6 +464,5 @@ test.integration.ocp:
 ################################################################################
 .PHONY: test.integration.kind
 test.integration.kind:
-	$(info SOURCE_DIR: $(SOURCE_DIR))
 	${SOURCE_DIR}/tests/integration/integ-suite-kind.sh
 

--- a/Makefile
+++ b/Makefile
@@ -458,5 +458,13 @@ lint: lint-scripts lint-go lint-yaml lint-helm lint-bundle lint-watches ## runs 
 .PHONY: test.integration.ocp
 test.integration.ocp:
 	$(info SOURCE_DIR: $(SOURCE_DIR))
-	${SOURCE_DIR}/tests/integration/operator-integ-suite-ocp.sh
+	${SOURCE_DIR}/tests/integration/operator-integ-suite.sh --ocp
+
+################################################################################
+# run an integration test on K8s
+################################################################################
+.PHONY: test.integration.k8s
+test.integration.k8s:
+	$(info SOURCE_DIR: $(SOURCE_DIR))
+	${SOURCE_DIR}/tests/integration/operator-integ-suite.sh --k8s
 

--- a/config/samples/istio-sample-kubernetes.yaml
+++ b/config/samples/istio-sample-kubernetes.yaml
@@ -8,4 +8,9 @@ metadata:
   name: istio-sample
 spec:
   version: v3.0
-  values: {}
+  values:
+    pilot:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 1024Mi

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -4,11 +4,7 @@ This integration test suite is similar to the upstream Istio integration tests. 
 
 ## Pre-requisites
 
-* Install the operator: `https://github.com/fjglira/istio-operator/tree/maistra-3.0#:~:text=to%20the%20cluster%3A-,make%20deploy,-Create%20an%20instance`
-
-```
-$ cd "$(git rev-parse --show-toplevel)" && make deploy
-```
+* To perform OCP integration testing, it is essential to have a functional OCP (OpenShift Container Platform) cluster already running. However, when testing against a KinD (Kubernetes in Docker) environment, the KinD cluster will be automatically configured using the provided script.
 
 ## How to Run it Manually
 
@@ -34,7 +30,7 @@ $ docker cp `which oc` test:/bin
 ```
 *Note*: if you are running in arm64, you need to download the proper oc binary from the OCP cluster to be copied into the container. For example, if your architecture is arm64 and your os is macOs, you can download the oc binary from https://downloads-openshift-console.apps-crc.testing/arm64/linux/oc.tar and copy it into the container.
 
-3. Run `operator-integ-suite.sh --flag` in the builder container using the proper flag using the make target. Valid flags are `--ocp` and `--k8s`. 
+3. Run `operator-integ-suite.sh --flag` in the builder container using the proper flag using the make target. Valid flags are `--ocp` and `--kind`. 
 
 * To run in OCP cluster:
 ```
@@ -45,11 +41,11 @@ cd work
 (root@) make test.integration.ocp
 ```
 
-* To run in K8s cluster:
+* To run in kind cluster:
 ```
 $ docker exec -it test /bin/bash
 git config --global --add safe.directory /work
 export KUBECONFIG=/work/ci-kubeconfig
 cd work
-(root@) make test.integration.k8s
+(root@) make test.integration.kind
 ```

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -2,6 +2,14 @@
 
 This integration test suite is similar to the upstream Istio integration tests. The scripts `lib.sh`, `kind_provisioner.sh` and `istio-integ-suite-kind.sh` are copied from `github.com/maistra/istio` repo.
 
+## Pre-requisites
+
+* Install the operator: `https://github.com/fjglira/istio-operator/tree/maistra-3.0#:~:text=to%20the%20cluster%3A-,make%20deploy,-Create%20an%20instance`
+
+```
+$ cd "$(git rev-parse --show-toplevel)" && make deploy
+```
+
 ## How to Run it Manually
 
 1. Create a builder container:
@@ -16,8 +24,7 @@ $ docker run -d -t --rm \
     entrypoint tail -f /dev/null
 ```
 
-2. Copy this istio-operator integration tests source code into the container
-   Copy OCP kubeconfig into container
+2. Copy this istio-operator integration tests source code into the container, copy kubeconfig file into container and copy oc binary into container (Only needed when you are running against OCP cluster):
 
 ```
 $ cd $(git rev-parse --show-toplevel)
@@ -25,13 +32,24 @@ $ docker cp . test:/work
 $ docker cp ~/.kube/ test:/
 $ docker cp `which oc` test:/bin
 ```
+*Note*: if you are running in arm64, you need to download the proper oc binary from the OCP cluster to be copied into the container. For example, if your architecture is arm64 and your os is macOs, you can download the oc binary from https://downloads-openshift-console.apps-crc.testing/arm64/linux/oc.tar and copy it into the container.
 
-3. Run `operator-integ-suite-ocp.sh` in the builder container
+3. Run `operator-integ-suite.sh --flag` in the builder container using the proper flag using the make target. Valid flags are `--ocp` and `--k8s`. 
 
+* To run in OCP cluster:
 ```
 $ docker exec -it test /bin/bash
 git config --global --add safe.directory /work
 oc login [OCP API server] --kubeconfig /work/ci-kubeconfig
 cd work
 (root@) make test.integration.ocp
+```
+
+* To run in K8s cluster:
+```
+$ docker exec -it test /bin/bash
+git config --global --add safe.directory /work
+export KUBECONFIG=/work/ci-kubeconfig
+cd work
+(root@) make test.integration.k8s
 ```

--- a/tests/integration/common-operator-integ-suite.sh
+++ b/tests/integration/common-operator-integ-suite.sh
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 # To be able to run this script it's needed to pass the flag --ocp or --kind
+set -eux -o pipefail
+
 if [ $# -eq 0 ]; then
   echo "No arguments provided"
   exit 1
@@ -45,8 +47,6 @@ fi
 
 WD=$(dirname "$0")
 WD=$(cd "$WD" || exit; pwd)
-
-set -eux -o pipefail
 
 NAMESPACE="${NAMESPACE:-istio-operator}"
 OPERATOR_NAME="${OPERATOR_NAME:-istio-operator}"
@@ -80,6 +80,12 @@ check_ready() {
     $COMMAND  wait deployment "${DEPLOYMENT_NAME}" -n "${NS}" --for condition=Available=True --timeout=${TIMEOUT}
 }
 
+# Build and pus docker image
+make docker-build docker-push
+
+# Deploy Operator
+echo "Deploying Operator"
+cd "$(git rev-parse --show-toplevel)" && make deploy
 
 # Main
 

--- a/tests/integration/common-operator-integ-suite.sh
+++ b/tests/integration/common-operator-integ-suite.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To be able to run this script it's needed to pass the flag --ocp or --k8s
+# To be able to run this script it's needed to pass the flag --ocp or --kind
 if [ $# -eq 0 ]; then
   echo "No arguments provided"
   exit 1
@@ -26,7 +26,7 @@ while [ $# -gt 0 ]; do
       shift
       OCP=true
       ;;
-    --k8s)
+    --kind)
       shift
       OCP=false
       ;;
@@ -40,7 +40,7 @@ done
 if [ "${OCP}" == "true" ]; then
   echo "Running on OCP"
 else
-  echo "Running on K8s"
+  echo "Running on kind"
 fi
 
 WD=$(dirname "$0")

--- a/tests/integration/common-operator-integ-suite.sh
+++ b/tests/integration/common-operator-integ-suite.sh
@@ -44,7 +44,7 @@ else
 fi
 
 WD=$(dirname "$0")
-WD=$(cd "$WD"; pwd)
+WD=$(cd "$WD" || exit; pwd)
 
 set -eux -o pipefail
 

--- a/tests/integration/config/default.yaml
+++ b/tests/integration/config/default.yaml
@@ -1,0 +1,7 @@
+# It's necesary to create control plane and node because of the reservation of CPU and memory. 
+# Only setting control planle it's not enough.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+  - role: worker

--- a/tests/integration/integ-suite-kind.sh
+++ b/tests/integration/integ-suite-kind.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 WD=$(dirname "$0")
-WD=$(cd "$WD"; pwd)
+WD=$(cd "$WD" || exit; pwd)
 
 # verify if a kind cluster is running with the name istio-operator
 if ! kind get clusters | grep -q "istio-operator"; then

--- a/tests/integration/integ-suite-kind.sh
+++ b/tests/integration/integ-suite-kind.sh
@@ -37,7 +37,7 @@ for ((i = 1; i <= max_retries; i++)); do
     echo "Waiting for kind cluster to be running (Attempt $i/$max_retries)"
     sleep $retry_interval
 
-    if [ $i -eq $max_retries ]; then
+    if [ "$i" -eq "$max_retries" ]; then
         echo "Cluster is not ready after $max_retries attempts. Exiting."
         exit 1
     fi

--- a/tests/integration/integ-suite-kind.sh
+++ b/tests/integration/integ-suite-kind.sh
@@ -43,10 +43,6 @@ for ((i = 1; i <= max_retries; i++)); do
     fi
 done
 
-# Deploy Operator
-echo "Deploying Operator"
-cd "$(git rev-parse --show-toplevel)" && make deploy
-
 # Run the integration tests
 echo "Running integration tests"
 ./tests/integration/common-operator-integ-suite.sh --kind

--- a/tests/integration/integ-suite-kind.sh
+++ b/tests/integration/integ-suite-kind.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Copyright 2023 Red Hat, Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+WD=$(dirname "$0")
+WD=$(cd "$WD"; pwd)
+
+# verify if a kind cluster is running with the name istio-operator
+if ! kind get clusters | grep -q "istio-operator"; then
+    echo "No kind cluster found"
+    # Create cluster
+    kind create cluster --name istio-operator --config "${WD}/config/default.yaml"
+fi
+
+# Wait until kind cluster is running
+max_retries=30
+retry_interval=10
+
+for ((i=1; i<=$max_retries; i++)); do
+    if kind get clusters | grep -q "istio-operator"; then
+        echo "Kind cluster is running"
+        break
+    fi
+
+    echo "Waiting for kind cluster to be running (Attempt $i/$max_retries)"
+    sleep $retry_interval
+
+    if [ $i -eq $max_retries ]; then
+        echo "Cluster is not ready after $max_retries attempts. Exiting."
+        exit 1
+    fi
+done
+
+# Deploy Operator
+echo "Deploying Operator"
+cd "$(git rev-parse --show-toplevel)" && make deploy
+
+# Run the integration tests
+echo "Running integration tests"
+./tests/integration/common-operator-integ-suite.sh --kind

--- a/tests/integration/integ-suite-kind.sh
+++ b/tests/integration/integ-suite-kind.sh
@@ -50,3 +50,6 @@ cd "$(git rev-parse --show-toplevel)" && make deploy
 # Run the integration tests
 echo "Running integration tests"
 ./tests/integration/common-operator-integ-suite.sh --kind
+
+# Delete kind cluster
+kind delete cluster --name istio-operator

--- a/tests/integration/integ-suite-kind.sh
+++ b/tests/integration/integ-suite-kind.sh
@@ -28,7 +28,7 @@ fi
 max_retries=30
 retry_interval=10
 
-for ((i=1; i<=$max_retries; i++)); do
+for ((i = 1; i <= max_retries; i++)); do
     if kind get clusters | grep -q "istio-operator"; then
         echo "Kind cluster is running"
         break

--- a/tests/integration/integ-suite-ocp.sh
+++ b/tests/integration/integ-suite-ocp.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Copyright 2023 Red Hat, Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To run this integration test on OCP cluster it's needed to already have the OCP cluster running and be logged in
+
+# Deploy Operator
+echo "Deploying Operator"
+cd "$(git rev-parse --show-toplevel)" && make deploy
+
+# Run the integration tests
+echo "Running integration tests"
+./tests/integration/common-operator-integ-suite.sh --ocp

--- a/tests/integration/integ-suite-ocp.sh
+++ b/tests/integration/integ-suite-ocp.sh
@@ -16,10 +16,6 @@
 
 # To run this integration test on OCP cluster it's needed to already have the OCP cluster running and be logged in
 
-# Deploy Operator
-echo "Deploying Operator"
-cd "$(git rev-parse --show-toplevel)" && make deploy
-
 # Run the integration tests
 echo "Running integration tests"
 ./tests/integration/common-operator-integ-suite.sh --ocp

--- a/tests/integration/operator-integ-suite.sh
+++ b/tests/integration/operator-integ-suite.sh
@@ -58,7 +58,12 @@ if [ "${OCP}" == "true" ]; then
 fi
 
 BRANCH="${BRANCH:-maistra-3.0}"
-ISTIO_MANIFEST="${WD}/../../config/samples/istio-sample-kubernetes.yaml"
+
+if [ "${OCP}" == "true" ]; then
+  ISTIO_MANIFEST="${WD}/../../config/samples/istio-sample-openshift.yaml"
+else
+  ISTIO_MANIFEST="${WD}/../../config/samples/istio-sample-kubernetes.yaml"
+fi
 
 TIMEOUT="3m"
 

--- a/tests/integration/operator-integ-suite.sh
+++ b/tests/integration/operator-integ-suite.sh
@@ -14,6 +14,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# To be able to run this script it's needed to pass the flag --ocp or --k8s
+if [ $# -eq 0 ]; then
+  echo "No arguments provided"
+  exit 1
+fi
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --ocp)
+      shift
+      OCP=true
+      ;;
+    --k8s)
+      shift
+      OCP=false
+      ;;
+    *)
+      echo "Invalid flag: $1"
+      exit 1
+      ;;
+  esac
+done
+
+if [ "${OCP}" == "true" ]; then
+  echo "Running on OCP"
+else
+  echo "Running on K8s"
+fi
+
 WD=$(dirname "$0")
 WD=$(cd "$WD"; pwd)
 
@@ -22,9 +51,14 @@ set -eux -o pipefail
 NAMESPACE="${NAMESPACE:-istio-operator}"
 OPERATOR_NAME="${OPERATOR_NAME:-istio-operator}"
 CONTROL_PLANE_NS="${CONTROL_PLANE_NS:-istio-system}"
+COMMAND="kubectl"
+
+if [ "${OCP}" == "true" ]; then
+  COMMAND="oc"
+fi
 
 BRANCH="${BRANCH:-maistra-3.0}"
-ISTIO_MANIFEST="${WD}/../../config/samples/istio-sample-openshift.yaml"
+ISTIO_MANIFEST="${WD}/../../config/samples/istio-sample-kubernetes.yaml"
 
 TIMEOUT="3m"
 
@@ -35,10 +69,10 @@ check_ready() {
 
     echo "Check POD: NAME SPACE: \"${NS}\"   POD NAME: \"${POD_NAME}\""
     timeout --foreground -v -s SIGHUP -k ${TIMEOUT} ${TIMEOUT} bash --verbose -c \
-    "until oc get pod --field-selector=status.phase=Running -n ${NS} | grep ${POD_NAME}; do sleep 5; done"
+    "until $COMMAND  get pod --field-selector=status.phase=Running -n ${NS} | grep ${POD_NAME}; do sleep 5; done"
 
     echo "Check Deployment Available: NAME SPACE: \"${NS}\"   DEPLOYMENT NAME: \"${DEPLOYMENT_NAME}\""
-    oc wait deployment "${DEPLOYMENT_NAME}" -n "${NS}" --for condition=Available=True --timeout=${TIMEOUT}
+    $COMMAND  wait deployment "${DEPLOYMENT_NAME}" -n "${NS}" --for condition=Available=True --timeout=${TIMEOUT}
 }
 
 
@@ -49,21 +83,21 @@ check_ready "${NAMESPACE}" "${OPERATOR_NAME}" "${OPERATOR_NAME}"
 
 
 echo "Deploy Istio"
-oc get ns "${CONTROL_PLANE_NS}" >/dev/null 2>&1 || oc create namespace "${CONTROL_PLANE_NS}"
-oc apply -f "${ISTIO_MANIFEST}" -n "${CONTROL_PLANE_NS}"
+$COMMAND  get ns "${CONTROL_PLANE_NS}" >/dev/null 2>&1 || oc create namespace "${CONTROL_PLANE_NS}"
+$COMMAND  apply -f "${ISTIO_MANIFEST}" -n "${CONTROL_PLANE_NS}"
 
 
 echo "Check that Istio is running"
 check_ready "${CONTROL_PLANE_NS}" "istiod" "istiod"
 
 echo "Make sure only istiod got deployed and nothing else"
-res=$(oc -n "${CONTROL_PLANE_NS}" get deploy -o json | jq -j '.items | length')
+res=$($COMMAND  -n "${CONTROL_PLANE_NS}" get deploy -o json | jq -j '.items | length')
 if [ "${res}" != "1" ]; then
   echo "Expected just istiod deployment, got:"
-  oc -n "${CONTROL_PLANE_NS}" get deploy
+  $COMMAND  -n "${CONTROL_PLANE_NS}" get deploy
   exit 1
 fi
 
 echo "Check that CNI deamonset ready are running"
 timeout --foreground -v -s SIGHUP -k ${TIMEOUT} ${TIMEOUT} bash --verbose -c \
-    "until oc rollout status ds/istio-cni-node -n ${NAMESPACE}; do sleep 5; done"
+    "until $COMMAND  rollout status ds/istio-cni-node -n ${NAMESPACE}; do sleep 5; done"


### PR DESCRIPTION
Adding the possibility to run the test on kind, for example, kind cluster. Changes made:

- Change the name of the integration test script. Added two separated script that ends in a common running script
- The kind script deploy a kind cluster and verify that it's running before executing the test
- Add two separate make targets, each one for each cluster type
- Updating some information in the readme file to specify that we can run the test also in kind
- Add to the integration test script a validation for the flags to run kind or ocp and the set of the current command to execute all the commands against the cluster (For OCP use oc and for kind use kubectl)