### PR TITLE
OSSM-4957 Move istio CNI plugin binaries to /var/lib/cni/bin

### DIFF
--- a/pkg/bootstrap/cni.go
+++ b/pkg/bootstrap/cni.go
@@ -65,7 +65,7 @@ func internalRenderCNI(ctx context.Context, cl client.Client, config cni.Config,
 
 	cni["chained"] = !config.UseMultus
 	if config.UseMultus {
-		cni["cniBinDir"] = "/opt/multus/bin"
+		cni["cniBinDir"] = "/var/lib/cni/bin"
 		cni["cniConfDir"] = "/etc/cni/multus/net.d"
 		cni["mountedCniConfDir"] = "/host/etc/cni/multus/net.d"
 


### PR DESCRIPTION
OpenShift 4.14 no longer looks for CNI plugins in /opt/multus/bin.