### PR TITLE
OSSM-4774 Use internal registry of OCP

### DIFF
--- a/tests/integration/common-operator-integ-suite.sh
+++ b/tests/integration/common-operator-integ-suite.sh
@@ -87,7 +87,7 @@ get_internal_registry() {
 
   # Check if default route already exist
   if [ -z "$(${COMMAND} get route default-route -n openshift-image-registry -o name)" ]; then
-    echo "Route default-route does not exist, so you can perform patching here."
+    echo "Route default-route does not exist, patching DefaultRoute to true on Image Registry."
     ${COMMAND} patch configs.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge
   
     timeout --foreground -v -s SIGHUP -k ${TIMEOUT} ${TIMEOUT} bash --verbose -c \

--- a/tests/integration/common-operator-integ-suite.sh
+++ b/tests/integration/common-operator-integ-suite.sh
@@ -147,11 +147,11 @@ check_ready() {
   local POD_NAME=$2
   local DEPLOYMENT_NAME=$3
 
-  echo "Check POD: NAME SPACE: \"${NS}\"   POD NAME: \"${POD_NAME}\""
+  echo "Check POD: NAMESPACE: \"${NS}\"   POD NAME: \"${POD_NAME}\""
   timeout --foreground -v -s SIGHUP -k ${TIMEOUT} ${TIMEOUT} bash --verbose -c \
     "until ${COMMAND} get pod --field-selector=status.phase=Running -n ${NS} | grep ${POD_NAME}; do sleep 5; done"
 
-  echo "Check Deployment Available: NAME SPACE: \"${NS}\"   DEPLOYMENT NAME: \"${DEPLOYMENT_NAME}\""
+  echo "Check Deployment Available: NAMESPACE: \"${NS}\"   DEPLOYMENT NAME: \"${DEPLOYMENT_NAME}\""
   ${COMMAND} wait deployment "${DEPLOYMENT_NAME}" -n "${NS}" --for condition=Available=True --timeout=${TIMEOUT}
 }
 

--- a/tests/integration/config/role-bindings.yaml
+++ b/tests/integration/config/role-bindings.yaml
@@ -1,0 +1,29 @@
+kind: List
+apiVersion: v1
+items:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: image-puller
+    namespace: ${NAMESPACE}
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:image-puller
+  subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: system:unauthenticated
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: image-pusher
+    namespace: ${NAMESPACE}
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:image-builder
+  subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: system:unauthenticated


### PR DESCRIPTION
The goal is to avoid the use of quay as a registry to build and push images to be tested for the operator.

Changes done:
* Rebuild the entire testing common script to separate all the steps into functions to easily understand the goal of each step and also to separate the actual test from the setup steps
* Add verification to get the internal registry
* Login to the internal registry
* Run docker build and push using the HUB variable to override the value in the make file