### PR TITLE
OSSM-5312: Add cluster role for MutatinWebhooks required by TagWatcher

### DIFF
--- a/build/patch-charts.sh
+++ b/build/patch-charts.sh
@@ -165,6 +165,13 @@ function patchGalley() {
           - --enableIngressClassName=false\
 {{- end}}' "${deployment}"
 
+  sed_wrap -i -e '/# sidecar injection controller/ a\
+  {{ if .Values.global.clusterWide }}\
+  - apiGroups: ["admissionregistration.k8s.io"]\
+    resources: ["mutatingwebhookconfigurations"]\
+    verbs: ["get", "list", "watch", "update", "patch"]\
+  {{ end }}' "${HELM_DIR}/istio-control/istio-discovery/templates/clusterrole.yaml"
+
   ############## disable webhook config updates ############################
   # Name of the mutatingwebhookconfiguration to patch, if istioctl is not used.
   sed_wrap -i -e '/env:/ a\

--- a/resources/helm/v2.5/istio-control/istio-discovery/templates/clusterrole.yaml
+++ b/resources/helm/v2.5/istio-control/istio-discovery/templates/clusterrole.yaml
@@ -9,6 +9,11 @@ metadata:
     release: {{ .Release.Name }}
 rules:
   # sidecar injection controller
+  {{ if .Values.global.clusterWide }}
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  {{ end }}
 
   # configuration validation webhook controller
 


### PR DESCRIPTION
Without permissions for MutatingWebhooks, TagWatcher logs the following errors:
```
2023-10-18T22:00:15.752625Z	info	klog	k8s.io/client-go@v0.27.0/tools/cache/reflector.go:231: failed to list *v1.MutatingWebhookConfiguration: mutatingwebhookconfigurations.admissionregistration.k8s.io is forbidden: User "system:serviceaccount:openshift-ingress:istiod-gateway-controller" cannot list resource "mutatingwebhookconfigurations" in API group "admissionregistration.k8s.io" at the cluster scope
2023-10-18T22:00:15.752727Z	error	watch error in cluster : failed to list *v1.MutatingWebhookConfiguration: mutatingwebhookconfigurations.admissionregistration.k8s.io is forbidden: User "system:serviceaccount:openshift-ingress:istiod-gateway-controller" cannot list resource "mutatingwebhookconfigurations" in API group "admissionregistration.k8s.io" at the cluster scope
```
Alternatively, we might disable TagWatcher in Istio at all, but we also may need to support revision-based deployments to migrate from OSSM 2.5 to 3.0, so I think it's better to add these missing permissions.