### PR TITLE
OSSM-5312: Adjust patches for kube-gateway to new template syntax

### DIFF
--- a/build/patch-charts.sh
+++ b/build/patch-charts.sh
@@ -27,13 +27,12 @@ function patchTemplates() {
   # Patch gateway deployment
   sed_wrap -i -e 's/{{- toJsonMap .Labels | nindent 4 }}/{{- toJsonMap (strdict "maistra-version" "'"${MAISTRA_VERSION}"'").Labels | nindent 4}}/' "${HELM_DIR}/istio-control/istio-discovery/files/kube-gateway.yaml"
   sed_wrap -i -e '/"service.istio.io\/canonical-revision" "latest"/ a\
-            "maistra-control-plane" .ReleaseNamespace\
+            "maistra-control-plane" .Values.global.istioNamespace\
             "maistra-version" "'"${MAISTRA_VERSION}"'"' "${HELM_DIR}/istio-control/istio-discovery/files/kube-gateway.yaml"
-  sed_wrap -i -e 's/\.Values\.global\.istioNamespace/.ReleaseNamespace/' "${HELM_DIR}/istio-control/istio-discovery/files/kube-gateway.yaml"
   # Patch gateway service
   sed_wrap -i -e 's/{{ toJsonMap .Labels | nindent 4}}/{{ toJsonMap\
       (strdict\
-        "maistra-control-plane" .ReleaseNamespace\
+        "maistra-control-plane" .Values.global.istioNamespace\
         "maistra-version" "'"${MAISTRA_VERSION}"'"\
       ).Labels | nindent 4}}/' "${HELM_DIR}/istio-control/istio-discovery/files/kube-gateway.yaml"
 

--- a/build/patch-charts.sh
+++ b/build/patch-charts.sh
@@ -24,9 +24,12 @@ function patchTemplates() {
   done
 
   # OSSM-5312: add maistra-control-plane and maistra-version to kube-gateway template, which is populated by Gateway deployment controller.
+  # Patch gateway deployment
   sed_wrap -i -e '/"service.istio.io\/canonical-revision" "latest"/ a\
             "maistra-control-plane" .ReleaseNamespace\
             "maistra-version" "'"${MAISTRA_VERSION}"'"' "${HELM_DIR}/istio-control/istio-discovery/files/kube-gateway.yaml"
+  sed_wrap -i -e 's/\.Values\.global\.istioNamespace/.ReleaseNamespace/' "${HELM_DIR}/istio-control/istio-discovery/files/kube-gateway.yaml"
+  # Patch gateway service
   sed_wrap -i -e 's/{{ toJsonMap .Labels | nindent 4}}/{{ toJsonMap\
       (strdict\
         "maistra-control-plane" .ReleaseNamespace\

--- a/build/patch-charts.sh
+++ b/build/patch-charts.sh
@@ -25,6 +25,7 @@ function patchTemplates() {
 
   # OSSM-5312: add maistra-control-plane and maistra-version to kube-gateway template, which is populated by Gateway deployment controller.
   # Patch gateway deployment
+  sed_wrap -i -e 's/{{- toJsonMap .Labels | nindent 4 }}/{{- toJsonMap (strdict "maistra-version" "'"${MAISTRA_VERSION}"'").Labels | nindent 4}}/' "${HELM_DIR}/istio-control/istio-discovery/files/kube-gateway.yaml"
   sed_wrap -i -e '/"service.istio.io\/canonical-revision" "latest"/ a\
             "maistra-control-plane" .ReleaseNamespace\
             "maistra-version" "'"${MAISTRA_VERSION}"'"' "${HELM_DIR}/istio-control/istio-discovery/files/kube-gateway.yaml"

--- a/resources/helm/v2.5/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/resources/helm/v2.5/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -12,7 +12,7 @@ metadata:
   annotations:
     {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
   labels:
-    {{- toJsonMap .Labels | nindent 4 }}
+    {{- toJsonMap (strdict "maistra-version" "2.5.0").Labels | nindent 4}}
   ownerReferences:
   - apiVersion: gateway.networking.k8s.io/v1beta1
     kind: Gateway

--- a/resources/helm/v2.5/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/resources/helm/v2.5/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -12,7 +12,6 @@ metadata:
   annotations:
     {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
   labels:
-    maistra-version: "2.5.0"
     {{- toJsonMap .Labels | nindent 4 }}
   ownerReferences:
   - apiVersion: gateway.networking.k8s.io/v1beta1
@@ -35,7 +34,6 @@ spec:
             "prometheus.io/scrape" "true"
           ) | nindent 8 }}
       labels:
-        maistra-version: "2.5.0"
         {{- toJsonMap
           (strdict
             "sidecar.istio.io/inject" "false"
@@ -96,7 +94,7 @@ spec:
         {{- if .Values.global.caAddress }}
           value: {{ .Values.global.caAddress }}
         {{- else }}
-          value: istiod-{{ .Values.revision | default "default" }}.{{ .Release.Namespace }}.svc:15012
+          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
         {{- end }}
         - name: POD_NAME
           valueFrom:
@@ -267,8 +265,11 @@ metadata:
   annotations:
     {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
   labels:
-    maistra-version: "2.5.0"
-    {{ toJsonMap .Labels | nindent 4}}
+    {{ toJsonMap
+      (strdict
+        "maistra-control-plane" .ReleaseNamespace
+        "maistra-version" "2.5.0"
+      ).Labels | nindent 4}}
   name: {{.DeploymentName | quote}}
   namespace: {{.Namespace | quote}}
   ownerReferences:

--- a/resources/helm/v2.5/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/resources/helm/v2.5/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -39,7 +39,7 @@ spec:
             "sidecar.istio.io/inject" "false"
             "service.istio.io/canonical-name" .DeploymentName
             "service.istio.io/canonical-revision" "latest"
-            "maistra-control-plane" .ReleaseNamespace
+            "maistra-control-plane" .Values.global.istioNamespace
             "maistra-version" "2.5.0"
            )
           .Labels
@@ -94,7 +94,7 @@ spec:
         {{- if .Values.global.caAddress }}
           value: {{ .Values.global.caAddress }}
         {{- else }}
-          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .ReleaseNamespace }}.svc:15012
+          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
         {{- end }}
         - name: POD_NAME
           valueFrom:
@@ -267,7 +267,7 @@ metadata:
   labels:
     {{ toJsonMap
       (strdict
-        "maistra-control-plane" .ReleaseNamespace
+        "maistra-control-plane" .Values.global.istioNamespace
         "maistra-version" "2.5.0"
       ).Labels | nindent 4}}
   name: {{.DeploymentName | quote}}

--- a/resources/helm/v2.5/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/resources/helm/v2.5/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -94,7 +94,7 @@ spec:
         {{- if .Values.global.caAddress }}
           value: {{ .Values.global.caAddress }}
         {{- else }}
-          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
+          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .ReleaseNamespace }}.svc:15012
         {{- end }}
         - name: POD_NAME
           valueFrom:

--- a/resources/helm/v2.5/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/resources/helm/v2.5/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -36,12 +36,13 @@ spec:
           ) | nindent 8 }}
       labels:
         maistra-version: "2.5.0"
-        maistra-control-plane: {{ .Release.Namespace }}
         {{- toJsonMap
           (strdict
             "sidecar.istio.io/inject" "false"
             "service.istio.io/canonical-name" .DeploymentName
             "service.istio.io/canonical-revision" "latest"
+            "maistra-control-plane" .ReleaseNamespace
+            "maistra-version" "2.5.0"
            )
           .Labels
           (strdict "istio.io/gateway-name" .Name) | nindent 8}}
@@ -267,7 +268,6 @@ metadata:
     {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
   labels:
     maistra-version: "2.5.0"
-    maistra-control-plane: {{ .Release.Namespace }}
     {{ toJsonMap .Labels | nindent 4}}
   name: {{.DeploymentName | quote}}
   namespace: {{.Namespace | quote}}


### PR DESCRIPTION
Gateways are no longer handled by injection webhook. Instead, gateway deployment controller renders templates and applies them. Because of that, we have to adjust kube-gateway template to the syntax required by the deployment controller and additionally, I have to replace `.Release.Namespace` with `.Values.global.istioNamespace`, because deployment controller didn't know `.Release`.