### PR TITLE
OSSM-5373 Hide the Profile drop-down

### DIFF
--- a/api/v1alpha1/istio_types.go
+++ b/api/v1alpha1/istio_types.go
@@ -40,7 +40,8 @@ type IstioSpec struct {
 	// The built-in installation configuration profile to use.
 	// The 'default' profile is always applied. On OpenShift, the 'openshift' profile is also applied on top of 'default'.
 	// Must be one of: ambient, default, demo, empty, external, minimal, openshift, preview, remote.
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Profile",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:General", "urn:alm:descriptor:com.tectonic.ui:select:ambient", "urn:alm:descriptor:com.tectonic.ui:select:default", "urn:alm:descriptor:com.tectonic.ui:select:demo", "urn:alm:descriptor:com.tectonic.ui:select:empty", "urn:alm:descriptor:com.tectonic.ui:select:external", "urn:alm:descriptor:com.tectonic.ui:select:minimal", "urn:alm:descriptor:com.tectonic.ui:select:preview", "urn:alm:descriptor:com.tectonic.ui:select:remote"}
+	// +++PROFILES-DROPDOWN-HIDDEN-UNTIL-WE-FULLY-IMPLEMENT-THEM+++operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Profile",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:General", "urn:alm:descriptor:com.tectonic.ui:select:ambient", "urn:alm:descriptor:com.tectonic.ui:select:default", "urn:alm:descriptor:com.tectonic.ui:select:demo", "urn:alm:descriptor:com.tectonic.ui:select:empty", "urn:alm:descriptor:com.tectonic.ui:select:external", "urn:alm:descriptor:com.tectonic.ui:select:minimal", "urn:alm:descriptor:com.tectonic.ui:select:preview", "urn:alm:descriptor:com.tectonic.ui:select:remote"}
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	// +kubebuilder:validation:Enum=ambient;default;demo;empty;external;minimal;openshift;preview;remote
 	Profile string `json:"profile,omitempty"`
 

--- a/api/v1alpha1/istio_types.go
+++ b/api/v1alpha1/istio_types.go
@@ -40,7 +40,7 @@ type IstioSpec struct {
 	// The built-in installation configuration profile to use.
 	// The 'default' profile is always applied. On OpenShift, the 'openshift' profile is also applied on top of 'default'.
 	// Must be one of: ambient, default, demo, empty, external, minimal, openshift, preview, remote.
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Profile",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:General", "urn:alm:descriptor:com.tectonic.ui:select:ambient", "urn:alm:descriptor:com.tectonic.ui:select:demo", "urn:alm:descriptor:com.tectonic.ui:select:empty", "urn:alm:descriptor:com.tectonic.ui:select:external", "urn:alm:descriptor:com.tectonic.ui:select:minimal", "urn:alm:descriptor:com.tectonic.ui:select:preview", "urn:alm:descriptor:com.tectonic.ui:select:remote"}
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Profile",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:General", "urn:alm:descriptor:com.tectonic.ui:select:ambient", "urn:alm:descriptor:com.tectonic.ui:select:default", "urn:alm:descriptor:com.tectonic.ui:select:demo", "urn:alm:descriptor:com.tectonic.ui:select:empty", "urn:alm:descriptor:com.tectonic.ui:select:external", "urn:alm:descriptor:com.tectonic.ui:select:minimal", "urn:alm:descriptor:com.tectonic.ui:select:preview", "urn:alm:descriptor:com.tectonic.ui:select:remote"}
 	// +kubebuilder:validation:Enum=ambient;default;demo;empty;external;minimal;openshift;preview;remote
 	Profile string `json:"profile,omitempty"`
 

--- a/bundle/manifests/sailoperator.clusterserviceversion.yaml
+++ b/bundle/manifests/sailoperator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Integration & Delivery, Networking, Security
     containerImage: quay.io/maistra-dev/istio-operator:3.0-latest
-    createdAt: "2023-11-15T08:34:26Z"
+    createdAt: "2023-11-15T09:31:27Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/internal-objects: '["wasmplugins.extensions.istio.io","destinationrules.networking.istio.io","envoyfilters.networking.istio.io","gateways.networking.istio.io","proxyconfigs.networking.istio.io","serviceentries.networking.istio.io","sidecars.networking.istio.io","virtualservices.networking.istio.io","workloadentries.networking.istio.io","workloadgroups.networking.istio.io","authorizationpolicies.security.istio.io","peerauthentications.security.istio.io","requestauthentications.security.istio.io","telemetries.telemetry.istio.io"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -71,15 +71,7 @@ spec:
         displayName: Profile
         path: profile
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:General
-        - urn:alm:descriptor:com.tectonic.ui:select:ambient
-        - urn:alm:descriptor:com.tectonic.ui:select:default
-        - urn:alm:descriptor:com.tectonic.ui:select:demo
-        - urn:alm:descriptor:com.tectonic.ui:select:empty
-        - urn:alm:descriptor:com.tectonic.ui:select:external
-        - urn:alm:descriptor:com.tectonic.ui:select:minimal
-        - urn:alm:descriptor:com.tectonic.ui:select:preview
-        - urn:alm:descriptor:com.tectonic.ui:select:remote
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: RawValues defines the non-validated values to be passed to the
           Helm chart when installing Istio.
         displayName: Helm RawValues

--- a/bundle/manifests/sailoperator.clusterserviceversion.yaml
+++ b/bundle/manifests/sailoperator.clusterserviceversion.yaml
@@ -73,6 +73,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:General
         - urn:alm:descriptor:com.tectonic.ui:select:ambient
+        - urn:alm:descriptor:com.tectonic.ui:select:default
         - urn:alm:descriptor:com.tectonic.ui:select:demo
         - urn:alm:descriptor:com.tectonic.ui:select:empty
         - urn:alm:descriptor:com.tectonic.ui:select:external

--- a/config/manifests/bases/sailoperator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sailoperator.clusterserviceversion.yaml
@@ -37,6 +37,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:General
         - urn:alm:descriptor:com.tectonic.ui:select:ambient
+        - urn:alm:descriptor:com.tectonic.ui:select:default
         - urn:alm:descriptor:com.tectonic.ui:select:demo
         - urn:alm:descriptor:com.tectonic.ui:select:empty
         - urn:alm:descriptor:com.tectonic.ui:select:external

--- a/config/manifests/bases/sailoperator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sailoperator.clusterserviceversion.yaml
@@ -35,15 +35,7 @@ spec:
         displayName: Profile
         path: profile
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:General
-        - urn:alm:descriptor:com.tectonic.ui:select:ambient
-        - urn:alm:descriptor:com.tectonic.ui:select:default
-        - urn:alm:descriptor:com.tectonic.ui:select:demo
-        - urn:alm:descriptor:com.tectonic.ui:select:empty
-        - urn:alm:descriptor:com.tectonic.ui:select:external
-        - urn:alm:descriptor:com.tectonic.ui:select:minimal
-        - urn:alm:descriptor:com.tectonic.ui:select:preview
-        - urn:alm:descriptor:com.tectonic.ui:select:remote
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: RawValues defines the non-validated values to be passed to the
           Helm chart when installing Istio.
         displayName: Helm RawValues

--- a/hack/update-profiles-list.sh
+++ b/hack/update-profiles-list.sh
@@ -8,8 +8,9 @@ enumValues=""
 
 IFS=',' read -ra elements <<< "${profiles}"
 for element in "${elements[@]}"; do
-  if [[ "$element" != "default" && "$element" != "openshift" ]]; then
-    # skip default and openshift profiles in the drop-down, since these profiles are always applied
+  if [[ "$element" != "openshift" ]]; then
+    # skip openshift profile in the drop-down, since it's always applied;
+    # default is also applied, but we preserve it so that users can deselect a profile after they select it
     selectValues+=', "urn:alm:descriptor:com.tectonic.ui:select:'$element'"'
   fi
   enumValues+=$element';'


### PR DESCRIPTION
Note: this PR hides the Profiles drop-down, but also makes sure that once we show it again, it will show the correct list of profiles (`default` and others, but not `openshift`).