### PR TITLE
OSSM-5419: Removing toolchain directive as it's breaking downstream builds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module maistra.io/istio-operator
 
 go 1.21
 
-toolchain go1.21.3
-
 // Client-go does not handle different versions of mergo due to some breaking changes - use the matching version
 // This replacement is aligned with istio/istio's go.mod
 replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5


### PR DESCRIPTION
We can use it again when https://issues.redhat.com/browse/STONEBLD-1973 is fixed.