### PR TITLE
update overlays to kiali 1.73

### DIFF
--- a/resources/helm/overlays/istio-telemetry/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/overlays/istio-telemetry/kiali/templates/kiali-cr.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.kiali.resourceName | default "kiali" }}
   namespace: {{ .Release.Namespace }}
 spec:
-  version: "v1.65"
+  version: "v1.73"
   installation_tag: "Kiali [{{ .Release.Namespace }}]"
   istio_namespace: "{{ .Release.Namespace }}"
 

--- a/resources/helm/v2.5/istio-telemetry/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/v2.5/istio-telemetry/kiali/templates/kiali-cr.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ .Values.kiali.resourceName | default "kiali" }}
   namespace: {{ .Release.Namespace }}
 spec:
-  version: "v1.65"
+  version: "v1.73"
   installation_tag: "Kiali [{{ .Release.Namespace }}]"
   istio_namespace: "{{ .Release.Namespace }}"
 


### PR DESCRIPTION
"make gen" auto-generated the change to v2.5 template.

https://issues.redhat.com/browse/OSSM-5433