### PR TITLE
Mark Istio(Revision).spec.version as required

### DIFF
--- a/api/v1alpha1/istio_types.go
+++ b/api/v1alpha1/istio_types.go
@@ -31,10 +31,9 @@ type IstioSpec struct {
 	// +sail:version
 	// Version defines the version of Istio to install.
 	// Must be one of: v1.20.0, v1.19.4, latest.
-	// If not specified, the latest version supported by the operator is installed.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=1,displayName="Istio Version",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:General", "urn:alm:descriptor:com.tectonic.ui:select:v1.20.0", "urn:alm:descriptor:com.tectonic.ui:select:v1.19.4", "urn:alm:descriptor:com.tectonic.ui:select:latest"}
 	// +kubebuilder:validation:Enum=v1.20.0;v1.19.4;latest
-	Version string `json:"version,omitempty"`
+	Version string `json:"version"`
 
 	// +sail:profile
 	// The built-in installation configuration profile to use.

--- a/api/v1alpha1/istiorevision_types.go
+++ b/api/v1alpha1/istiorevision_types.go
@@ -31,10 +31,9 @@ type IstioRevisionSpec struct {
 	// +sail:version
 	// Version defines the version of IstioRevision to install.
 	// Must be one of: v1.20.0, v1.19.4, latest.
-	// If not specified, the latest version supported by the operator is installed.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=1,displayName="IstioRevision Version",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:General", "urn:alm:descriptor:com.tectonic.ui:select:v1.20.0", "urn:alm:descriptor:com.tectonic.ui:select:v1.19.4", "urn:alm:descriptor:com.tectonic.ui:select:latest"}
 	// +kubebuilder:validation:Enum=v1.20.0;v1.19.4;latest
-	Version string `json:"version,omitempty"`
+	Version string `json:"version"`
 
 	// Values defines the values to be passed to the Helm chart when installing IstioRevision.
 	// +kubebuilder:pruning:PreserveUnknownFields

--- a/bundle/manifests/operator.istio.io_istiorevisions.yaml
+++ b/bundle/manifests/operator.istio.io_istiorevisions.yaml
@@ -61,13 +61,14 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               version:
                 description: 'Version defines the version of IstioRevision to install.
-                  Must be one of: v1.20.0, v1.19.4, latest. If not specified, the
-                  latest version supported by the operator is installed.'
+                  Must be one of: v1.20.0, v1.19.4, latest.'
                 enum:
                 - v1.20.0
                 - v1.19.4
                 - latest
                 type: string
+            required:
+            - version
             type: object
           status:
             description: IstioRevisionStatus defines the observed state of IstioRevision

--- a/bundle/manifests/operator.istio.io_istios.yaml
+++ b/bundle/manifests/operator.istio.io_istios.yaml
@@ -597,13 +597,14 @@ spec:
                 type: object
               version:
                 description: 'Version defines the version of Istio to install. Must
-                  be one of: v1.20.0, v1.19.4, latest. If not specified, the latest
-                  version supported by the operator is installed.'
+                  be one of: v1.20.0, v1.19.4, latest.'
                 enum:
                 - v1.20.0
                 - v1.19.4
                 - latest
                 type: string
+            required:
+            - version
             type: object
           status:
             description: IstioStatus defines the observed state of Istio

--- a/bundle/manifests/sailoperator.clusterserviceversion.yaml
+++ b/bundle/manifests/sailoperator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Integration & Delivery, Networking, Security
     containerImage: quay.io/maistra-dev/istio-operator:3.0-latest
-    createdAt: "2023-12-12T03:16:46Z"
+    createdAt: "2023-12-12T11:01:02Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/internal-objects: '["wasmplugins.extensions.istio.io","destinationrules.networking.istio.io","envoyfilters.networking.istio.io","gateways.networking.istio.io","proxyconfigs.networking.istio.io","serviceentries.networking.istio.io","sidecars.networking.istio.io","virtualservices.networking.istio.io","workloadentries.networking.istio.io","workloadgroups.networking.istio.io","authorizationpolicies.security.istio.io","peerauthentications.security.istio.io","requestauthentications.security.istio.io","telemetries.telemetry.istio.io"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -58,8 +58,7 @@ spec:
       name: istios.operator.istio.io
       specDescriptors:
       - description: 'Version defines the version of Istio to install. Must be one
-          of: v1.20.0, v1.19.4, latest. If not specified, the latest version supported
-          by the operator is installed.'
+          of: v1.20.0, v1.19.4, latest.'
         displayName: Istio Version
         path: version
         x-descriptors:

--- a/config/crd/bases/operator.istio.io_istiorevisions.yaml
+++ b/config/crd/bases/operator.istio.io_istiorevisions.yaml
@@ -61,13 +61,14 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               version:
                 description: 'Version defines the version of IstioRevision to install.
-                  Must be one of: v1.20.0, v1.19.4, latest. If not specified, the
-                  latest version supported by the operator is installed.'
+                  Must be one of: v1.20.0, v1.19.4, latest.'
                 enum:
                 - v1.20.0
                 - v1.19.4
                 - latest
                 type: string
+            required:
+            - version
             type: object
           status:
             description: IstioRevisionStatus defines the observed state of IstioRevision

--- a/config/crd/bases/operator.istio.io_istios.yaml
+++ b/config/crd/bases/operator.istio.io_istios.yaml
@@ -587,12 +587,14 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
                 version:
-                  description: 'Version defines the version of Istio to install. Must be one of: v1.20.0, v1.19.4, latest. If not specified, the latest version supported by the operator is installed.'
+                  description: 'Version defines the version of Istio to install. Must be one of: v1.20.0, v1.19.4, latest.'
                   enum:
                     - v1.20.0
                     - v1.19.4
                     - latest
                   type: string
+              required:
+                - version
               type: object
             status:
               description: IstioStatus defines the observed state of Istio

--- a/config/manifests/bases/sailoperator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sailoperator.clusterserviceversion.yaml
@@ -19,8 +19,7 @@ spec:
       name: istios.operator.istio.io
       specDescriptors:
       - description: 'Version defines the version of Istio to install. Must be one
-          of: v1.20.0, v1.19.4, latest. If not specified, the latest version supported
-          by the operator is installed.'
+          of: v1.20.0, v1.19.4, latest.'
         displayName: Istio Version
         path: version
         x-descriptors:

--- a/pkg/kube/finalizers_test.go
+++ b/pkg/kube/finalizers_test.go
@@ -17,6 +17,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
+const version = "v1.20.0"
+
 var (
 	cfg       *rest.Config
 	k8sClient client.Client
@@ -66,6 +68,9 @@ func TestHasFinalizer(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Finalizers: []string{"blah"},
 				},
+				Spec: v1.IstioSpec{
+					Version: version,
+				},
 			},
 			expectedResult: false,
 		},
@@ -73,6 +78,9 @@ func TestHasFinalizer(t *testing.T) {
 			obj: &v1.Istio{
 				ObjectMeta: metav1.ObjectMeta{
 					Finalizers: []string{common.FinalizerName},
+				},
+				Spec: v1.IstioSpec{
+					Version: version,
 				},
 			},
 			expectedResult: true,
@@ -96,6 +104,9 @@ func TestAddRemoveFinalizer(t *testing.T) {
 					Name:      "test",
 					Namespace: "test",
 				},
+				Spec: v1.IstioSpec{
+					Version: version,
+				},
 			},
 			resultFinalizers: []string{common.FinalizerName},
 		},
@@ -105,6 +116,9 @@ func TestAddRemoveFinalizer(t *testing.T) {
 					Name:       "test",
 					Namespace:  "test",
 					Finalizers: []string{common.FinalizerName},
+				},
+				Spec: v1.IstioSpec{
+					Version: version,
 				},
 			},
 			resultFinalizers: []string{common.FinalizerName},


### PR DESCRIPTION
We don't yet have a mutating webhook that would initialize the version to the default value. This means that when users create the Istio or IstioRevision CR without specifying the version, the operator fails to reconcile the CRs.