### PR TITLE
Clean up kustomization.yaml files

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 # This kustomization.yaml is not intended to be run by itself,
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
@@ -20,7 +23,7 @@ resources:
 - bases/telemetry.istio.io_telemetries.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 #- patches/webhook_in_istios.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 # Adds namespace to all resources.
 namespace: istio-operator
 
@@ -23,8 +26,8 @@ namespace: istio-operator
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-patchesStrategicMerge:
-- manager_auth_proxy_patch.yaml
+patches:
+- path: manager_auth_proxy_patch.yaml
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
@@ -36,8 +39,6 @@ patchesStrategicMerge:
 #- webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 resources:
 - ../crd
 - ../rbac

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -6,6 +6,8 @@ images:
 - name: controller
   newName: quay.io/maistra-dev/istio-operator
   newTag: 3.0-latest
-commonLabels:
-  app.kubernetes.io/created-by: sailoperator
-  app.kubernetes.io/part-of: sailoperator
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/created-by: sailoperator
+    app.kubernetes.io/part-of: sailoperator

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 # These resources constitute the fully configured set of manifests
 # used to generate the 'manifests/' directory in a bundle.
 resources:

--- a/config/openshift/kustomization.yaml
+++ b/config/openshift/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
 - ../default
 

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,7 +1,10 @@
-resources:
-- monitor.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app.kubernetes.io/created-by: sailoperator
-  app.kubernetes.io/part-of: sailoperator
+
+resources:
+- monitor.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/created-by: sailoperator
+    app.kubernetes.io/part-of: sailoperator

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
 # All RBAC will be applied under this service account in
 # the deployment namespace. You may comment out this resource
@@ -16,8 +19,8 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-commonLabels:
-  app.kubernetes.io/created-by: sailoperator
-  app.kubernetes.io/part-of: sailoperator
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/created-by: sailoperator
+    app.kubernetes.io/part-of: sailoperator

--- a/config/scorecard/kustomization.yaml
+++ b/config/scorecard/kustomization.yaml
@@ -1,6 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
 - bases/config.yaml
-patchesJson6902:
+patches:
 - path: patches/basic.config.yaml
   target:
     group: scorecard.operatorframework.io


### PR DESCRIPTION
- Fixed usage of deprecated fields `patchesStrategicMerge` and `commonLabels`.
- Moved `apiVersion` and `kind` to the top of each file.