### PR TITLE
Various fixes

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -19,4 +19,12 @@ resources:
   kind: Istio
   path: maistra.io/istio-operator/api/v1alpha1
   version: v1alpha1
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
+  domain: operator.istio.io
+  kind: IstioRevision
+  path: maistra.io/istio-operator/api/v1alpha1
+  version: v1alpha1
 version: "3"

--- a/api/v1alpha1/istio_types.go
+++ b/api/v1alpha1/istio_types.go
@@ -29,7 +29,7 @@ const IstioKind = "Istio"
 // IstioSpec defines the desired state of Istio
 type IstioSpec struct {
 	// +sail:version
-	// Version defines the version of Istio to install.
+	// Defines the version of Istio to install.
 	// Must be one of: v1.20.0, v1.19.4, latest.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=1,displayName="Istio Version",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:General", "urn:alm:descriptor:com.tectonic.ui:select:v1.20.0", "urn:alm:descriptor:com.tectonic.ui:select:v1.19.4", "urn:alm:descriptor:com.tectonic.ui:select:latest"}
 	// +kubebuilder:validation:Enum=v1.20.0;v1.19.4;latest
@@ -44,13 +44,13 @@ type IstioSpec struct {
 	// +kubebuilder:validation:Enum=ambient;default;demo;empty;external;minimal;openshift;preview;remote
 	Profile string `json:"profile,omitempty"`
 
-	// Values defines the values to be passed to the Helm chart when installing Istio.
+	// Defines the values to be passed to the Helm charts when installing Istio.
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:validation:Schemaless
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Helm Values"
 	Values json.RawMessage `json:"values,omitempty"`
 
-	// RawValues defines the non-validated values to be passed to the Helm chart when installing Istio.
+	// Defines the non-validated values to be passed to the Helm charts when installing Istio.
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:validation:Schemaless
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Helm RawValues"

--- a/api/v1alpha1/istiorevision_types.go
+++ b/api/v1alpha1/istiorevision_types.go
@@ -29,13 +29,13 @@ const IstioRevisionKind = "IstioRevision"
 // IstioRevisionSpec defines the desired state of IstioRevision
 type IstioRevisionSpec struct {
 	// +sail:version
-	// Version defines the version of IstioRevision to install.
+	// Defines the version of Istio to install.
 	// Must be one of: v1.20.0, v1.19.4, latest.
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=1,displayName="IstioRevision Version",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:General", "urn:alm:descriptor:com.tectonic.ui:select:v1.20.0", "urn:alm:descriptor:com.tectonic.ui:select:v1.19.4", "urn:alm:descriptor:com.tectonic.ui:select:latest"}
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=1,displayName="Istio Version",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:General", "urn:alm:descriptor:com.tectonic.ui:select:v1.20.0", "urn:alm:descriptor:com.tectonic.ui:select:v1.19.4", "urn:alm:descriptor:com.tectonic.ui:select:latest"}
 	// +kubebuilder:validation:Enum=v1.20.0;v1.19.4;latest
 	Version string `json:"version"`
 
-	// Values defines the values to be passed to the Helm chart when installing IstioRevision.
+	// Defines the values to be passed to the Helm charts when installing Istio.
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:validation:Schemaless
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Helm Values"
@@ -174,7 +174,7 @@ const (
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.version",description="The version of the control plane installation."
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The age of the object"
 
-// IstioRevision represents an IstioRevision Service Mesh deployment
+// IstioRevision represents a single revision of an Istio Service Mesh deployment
 type IstioRevision struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/bundle/manifests/operator.istio.io_istiorevisions.yaml
+++ b/bundle/manifests/operator.istio.io_istiorevisions.yaml
@@ -38,7 +38,8 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: IstioRevision represents an IstioRevision Service Mesh deployment
+        description: IstioRevision represents a single revision of an Istio Service
+          Mesh deployment
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -56,12 +57,12 @@ spec:
             description: IstioRevisionSpec defines the desired state of IstioRevision
             properties:
               values:
-                description: Values defines the values to be passed to the Helm chart
-                  when installing IstioRevision.
+                description: Defines the values to be passed to the Helm charts when
+                  installing Istio.
                 x-kubernetes-preserve-unknown-fields: true
               version:
-                description: 'Version defines the version of IstioRevision to install.
-                  Must be one of: v1.20.0, v1.19.4, latest.'
+                description: 'Defines the version of Istio to install. Must be one
+                  of: v1.20.0, v1.19.4, latest.'
                 enum:
                 - v1.20.0
                 - v1.19.4

--- a/bundle/manifests/operator.istio.io_istios.yaml
+++ b/bundle/manifests/operator.istio.io_istios.yaml
@@ -70,12 +70,12 @@ spec:
                 - remote
                 type: string
               rawValues:
-                description: RawValues defines the non-validated values to be passed
-                  to the Helm chart when installing Istio.
+                description: Defines the non-validated values to be passed to the
+                  Helm charts when installing Istio.
                 x-kubernetes-preserve-unknown-fields: true
               values:
-                description: Values defines the values to be passed to the Helm chart
-                  when installing Istio.
+                description: Defines the values to be passed to the Helm charts when
+                  installing Istio.
                 properties:
                   base:
                     properties:
@@ -585,8 +585,8 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               version:
-                description: 'Version defines the version of Istio to install. Must
-                  be one of: v1.20.0, v1.19.4, latest.'
+                description: 'Defines the version of Istio to install. Must be one
+                  of: v1.20.0, v1.19.4, latest.'
                 enum:
                 - v1.20.0
                 - v1.19.4

--- a/bundle/manifests/sailoperator.clusterserviceversion.yaml
+++ b/bundle/manifests/sailoperator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Integration & Delivery, Networking, Security
     containerImage: quay.io/maistra-dev/istio-operator:3.0-latest
-    createdAt: "2023-12-14T03:07:40Z"
+    createdAt: "2023-12-14T17:03:34Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/internal-objects: '["wasmplugins.extensions.istio.io","destinationrules.networking.istio.io","envoyfilters.networking.istio.io","gateways.networking.istio.io","proxyconfigs.networking.istio.io","serviceentries.networking.istio.io","sidecars.networking.istio.io","virtualservices.networking.istio.io","workloadentries.networking.istio.io","workloadgroups.networking.istio.io","authorizationpolicies.security.istio.io","peerauthentications.security.istio.io","requestauthentications.security.istio.io","telemetries.telemetry.istio.io"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -49,16 +49,33 @@ spec:
     - kind: Gateway
       name: gateways.networking.istio.io
       version: v1beta1
-    - kind: IstioRevision
+    - description: IstioRevision represents a single revision of an Istio Service
+        Mesh deployment
+      displayName: Istio Revision
+      kind: IstioRevision
       name: istiorevisions.operator.istio.io
+      specDescriptors:
+      - description: 'Defines the version of Istio to install. Must be one of: v1.20.0,
+          v1.19.4, latest.'
+        displayName: Istio Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:General
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.20.0
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.19.4
+        - urn:alm:descriptor:com.tectonic.ui:select:latest
+      - description: Defines the values to be passed to the Helm charts when installing
+          Istio.
+        displayName: Helm Values
+        path: values
       version: v1alpha1
     - description: Istio represents an Istio Service Mesh deployment
       displayName: Istio
       kind: Istio
       name: istios.operator.istio.io
       specDescriptors:
-      - description: 'Version defines the version of Istio to install. Must be one
-          of: v1.20.0, v1.19.4, latest.'
+      - description: 'Defines the version of Istio to install. Must be one of: v1.20.0,
+          v1.19.4, latest.'
         displayName: Istio Version
         path: version
         x-descriptors:
@@ -74,12 +91,12 @@ spec:
         path: profile
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: RawValues defines the non-validated values to be passed to the
-          Helm chart when installing Istio.
+      - description: Defines the non-validated values to be passed to the Helm charts
+          when installing Istio.
         displayName: Helm RawValues
         path: rawValues
-      - description: Values defines the values to be passed to the Helm chart when
-          installing Istio.
+      - description: Defines the values to be passed to the Helm charts when installing
+          Istio.
         displayName: Helm Values
         path: values
       version: v1alpha1

--- a/config/crd/bases/operator.istio.io_istiorevisions.yaml
+++ b/config/crd/bases/operator.istio.io_istiorevisions.yaml
@@ -38,7 +38,8 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: IstioRevision represents an IstioRevision Service Mesh deployment
+        description: IstioRevision represents a single revision of an Istio Service
+          Mesh deployment
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -56,12 +57,12 @@ spec:
             description: IstioRevisionSpec defines the desired state of IstioRevision
             properties:
               values:
-                description: Values defines the values to be passed to the Helm chart
-                  when installing IstioRevision.
+                description: Defines the values to be passed to the Helm charts when
+                  installing Istio.
                 x-kubernetes-preserve-unknown-fields: true
               version:
-                description: 'Version defines the version of IstioRevision to install.
-                  Must be one of: v1.20.0, v1.19.4, latest.'
+                description: 'Defines the version of Istio to install. Must be one
+                  of: v1.20.0, v1.19.4, latest.'
                 enum:
                 - v1.20.0
                 - v1.19.4

--- a/config/crd/bases/operator.istio.io_istios.yaml
+++ b/config/crd/bases/operator.istio.io_istios.yaml
@@ -63,10 +63,10 @@ spec:
                     - remote
                   type: string
                 rawValues:
-                  description: RawValues defines the non-validated values to be passed to the Helm chart when installing Istio.
+                  description: Defines the non-validated values to be passed to the Helm charts when installing Istio.
                   x-kubernetes-preserve-unknown-fields: true
                 values:
-                  description: Values defines the values to be passed to the Helm chart when installing Istio.
+                  description: Defines the values to be passed to the Helm charts when installing Istio.
                   properties:
                     base:
                       properties:
@@ -576,7 +576,7 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
                 version:
-                  description: 'Version defines the version of Istio to install. Must be one of: v1.20.0, v1.19.4, latest.'
+                  description: 'Defines the version of Istio to install. Must be one of: v1.20.0, v1.19.4, latest.'
                   enum:
                     - v1.20.0
                     - v1.19.4

--- a/config/manifests/bases/sailoperator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sailoperator.clusterserviceversion.yaml
@@ -13,13 +13,33 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
+    - description: IstioRevision represents a single revision of an Istio Service
+        Mesh deployment
+      displayName: Istio Revision
+      kind: IstioRevision
+      name: istiorevisions.operator.istio.io
+      specDescriptors:
+      - description: 'Defines the version of Istio to install. Must be one of: v1.20.0,
+          v1.19.4, latest.'
+        displayName: Istio Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:General
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.20.0
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.19.4
+        - urn:alm:descriptor:com.tectonic.ui:select:latest
+      - description: Defines the values to be passed to the Helm charts when installing
+          Istio.
+        displayName: Helm Values
+        path: values
+      version: v1alpha1
     - description: Istio represents an Istio Service Mesh deployment
       displayName: Istio
       kind: Istio
       name: istios.operator.istio.io
       specDescriptors:
-      - description: 'Version defines the version of Istio to install. Must be one
-          of: v1.20.0, v1.19.4, latest.'
+      - description: 'Defines the version of Istio to install. Must be one of: v1.20.0,
+          v1.19.4, latest.'
         displayName: Istio Version
         path: version
         x-descriptors:
@@ -35,12 +55,12 @@ spec:
         path: profile
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: RawValues defines the non-validated values to be passed to the
-          Helm chart when installing Istio.
+      - description: Defines the non-validated values to be passed to the Helm charts
+          when installing Istio.
         displayName: Helm RawValues
         path: rawValues
-      - description: Values defines the values to be passed to the Helm chart when
-          installing Istio.
+      - description: Defines the values to be passed to the Helm charts when installing
+          Istio.
         displayName: Helm Values
         path: values
       version: v1alpha1


### PR DESCRIPTION
- The make gen command did not update the IstioRevision resource information in the CSV
- The IstioRevision resource was missing all the OCP console metadata in the CSV
- Some places referred to the "IstioRevision version" instead of "Istio version"
- The Version dropdown options weren't being updated for IstioRevision
- Improved a few field descriptions