### PR TITLE
OSSM-5444: Fix mapping `spec.tracing.type: None` to helm values

### DIFF
--- a/pkg/apis/maistra/conversion/jaeger_test.go
+++ b/pkg/apis/maistra/conversion/jaeger_test.go
@@ -39,7 +39,7 @@ func jaegerTestCasesV2(version versions.Version) []conversionTestCase {
 					"meshExpansion": globalMeshExpansionDefaults,
 					"enableTracing": false,
 					"proxy": map[string]interface{}{
-						"tracer": "zipkin",
+						"tracer": "none",
 					},
 				},
 				"meshConfig": map[string]interface{}{

--- a/resources/helm/overlays/global.yaml
+++ b/resources/helm/overlays/global.yaml
@@ -402,15 +402,6 @@ meshConfig:
       ISTIO_META_DNS_AUTO_ALLOCATE: "true"
       # required to enable dns capture
       PROXY_XDS_VIA_AGENT: "true"
-    tracing:
-#      tlsSettings:
-#        mode: DISABLE # DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
-#        clientCertificate: # example: /etc/istio/tracer/cert-chain.pem
-#        privateKey:        # example: /etc/istio/tracer/key.pem
-#        caCertificates:    # example: /etc/istio/tracer/root-cert.pem
-#        sni:               # example: tracer.somedomain
-#        subjectAltNames: []
-        # - tracer.somedomain
 
 base:
   validationURL: ""

--- a/resources/helm/v2.5/global.yaml
+++ b/resources/helm/v2.5/global.yaml
@@ -402,15 +402,6 @@ meshConfig:
       ISTIO_META_DNS_AUTO_ALLOCATE: "true"
       # required to enable dns capture
       PROXY_XDS_VIA_AGENT: "true"
-    tracing:
-#      tlsSettings:
-#        mode: DISABLE # DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
-#        clientCertificate: # example: /etc/istio/tracer/cert-chain.pem
-#        privateKey:        # example: /etc/istio/tracer/key.pem
-#        caCertificates:    # example: /etc/istio/tracer/root-cert.pem
-#        sni:               # example: tracer.somedomain
-#        subjectAltNames: []
-        # - tracer.somedomain
 
 base:
   validationURL: ""


### PR DESCRIPTION
When I was testing zipkin extension provider, I noticed that we incorrectly handle `None` tracing type and as a result istio proxies receive incorrect default config:
```
defaultConfig:
  discoveryAddress: istiod-basic.istio-system.svc:15012
  proxyMetadata:
    ISTIO_META_DNS_AUTO_ALLOCATE: "true"
    ISTIO_META_DNS_CAPTURE: "true"
    PROXY_XDS_VIA_AGENT: "true"
  tracing: null
```
and therefore pilot-agent overwrites `tracing: null` with the default zipkin address, while the expected config is:
```
defaultConfig:
  discoveryAddress: istiod-basic.istio-system.svc:15012
  proxyMetadata:
    ISTIO_META_DNS_AUTO_ALLOCATE: "true"
    ISTIO_META_DNS_CAPTURE: "true"
    PROXY_XDS_VIA_AGENT: "true"
  tracing: {}
```

Actually, it does not affect tracing, because when a `Telemetry` config is applied to a proxy, the default tracing address is not used by Envoy, but it might be confusing when debugging tracing issues.