### PR TITLE
OSSM-5594: Do not disable tracing in Kiali when `spec.tracing: None` is set

### DIFF
--- a/pkg/controller/servicemesh/controlplane/addons.go
+++ b/pkg/controller/servicemesh/controlplane/addons.go
@@ -103,8 +103,10 @@ func (r *controlPlaneInstanceReconciler) patchKiali(ctx context.Context, grafana
 	if err := updatedKiali.Spec.SetField("external_services.grafana.auth.password", rawPassword); err != nil {
 		return common.RequeueWithError(errorOnSettingValueInKialiCR("external_services.grafana.auth.password", err))
 	}
-	if err := updatedKiali.Spec.SetField("external_services.tracing.auth.password", rawPassword); err != nil {
-		return common.RequeueWithError(errorOnSettingValueInKialiCR("external_services.tracing.auth.password", err))
+	if jaegerEnabled {
+		if err := updatedKiali.Spec.SetField("external_services.tracing.auth.password", rawPassword); err != nil {
+			return common.RequeueWithError(errorOnSettingValueInKialiCR("external_services.tracing.auth.password", err))
+		}
 	}
 	if prometheusEnabled {
 		if err := updatedKiali.Spec.SetField("external_services.prometheus.auth.password", rawPassword); err != nil {

--- a/pkg/controller/servicemesh/controlplane/addons.go
+++ b/pkg/controller/servicemesh/controlplane/addons.go
@@ -81,20 +81,15 @@ func (r *controlPlaneInstanceReconciler) patchKiali(ctx context.Context, grafana
 	var jaegerURL string
 	if jaegerEnabled {
 		jaegerURL = r.jaegerURL(ctx, log)
-	}
-	if jaegerURL == "" {
-		// disable jaeger
-		if err := updatedKiali.Spec.SetField("external_services.tracing.enabled", false); err != nil {
-			return common.RequeueWithError(errorOnSettingValueInKialiCR("external_services.tracing.enabled", err))
-		}
-	} else {
-		// enable jaeger and set URL
-		// XXX: should we also configure the in_cluster_url
-		if err := updatedKiali.Spec.SetField("external_services.tracing.url", jaegerURL); err != nil {
-			return common.RequeueWithError(errorOnSettingValueInKialiCR("external_services.tracing.url", err))
-		}
-		if err := updatedKiali.Spec.SetField("external_services.tracing.enabled", true); err != nil {
-			return common.RequeueWithError(errorOnSettingValueInKialiCR("external_services.tracing.enabled", err))
+		if jaegerURL != "" {
+			// enable jaeger and set URL
+			// XXX: should we also configure the in_cluster_url
+			if err := updatedKiali.Spec.SetField("external_services.tracing.url", jaegerURL); err != nil {
+				return common.RequeueWithError(errorOnSettingValueInKialiCR("external_services.tracing.url", err))
+			}
+			if err := updatedKiali.Spec.SetField("external_services.tracing.enabled", true); err != nil {
+				return common.RequeueWithError(errorOnSettingValueInKialiCR("external_services.tracing.enabled", err))
+			}
 		}
 	}
 
@@ -155,7 +150,7 @@ func (r *controlPlaneInstanceReconciler) grafanaURL(ctx context.Context, log log
 func (r *controlPlaneInstanceReconciler) jaegerURL(ctx context.Context, log logr.Logger) string {
 	log.Info("attempting to auto-detect Jaeger for Kiali")
 	if r.Instance.Status.AppliedSpec.Addons == nil || !r.Instance.Status.AppliedSpec.IsJaegerEnabled() {
-		log.Info("Jaeger is not installed, disabling tracing in Kiali")
+		log.Info("Jaeger is not installed")
 		return ""
 	}
 	jaegerName := "jaeger"
@@ -171,13 +166,13 @@ func (r *controlPlaneInstanceReconciler) jaegerURL(ctx context.Context, log logr
 		})
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			log.Error(err, "error retrieving Jaeger route - will disable it in Kiali")
+			log.Error(err, "error retrieving Jaeger route")
 			// we aren't going to return here - Grafana is optional for Kiali; Kiali can still run without it
 		}
 		return ""
 	} else if len(jaegerRoutes.Items) == 0 {
 		// no routes
-		log.Info("could not locate Jaeger query route resource, disabling tracing in Kiali")
+		log.Info("could not locate Jaeger query route resource")
 		return ""
 	}
 	// we'll just use the first.  there should only ever be one route


### PR DESCRIPTION
This change is required to properly configure custom Jaeger/Zipkin settings in a custom Kiali instance. Otherwise, tracing will be disabled in Kiali CR during SMCP reconciliation.

**How to test it:**
1. Deploy custom Jaeger:
```
htpasswd -Bbc htpasswd admin admin
oc create secret generic htpasswd-jaeger --from-file=htpasswd=htpasswd -n istio-system

oc apply -n istio-system -f - <<EOF
apiVersion: jaegertracing.io/v1
kind: Jaeger
metadata:
  name: jaeger
spec:
  strategy: allInOne
  allInOne:
    options:
      query:
        base-path: /
  ingress:
    security: oauth-proxy
    openshift:
      sar: '{"namespace": "istio-system", "resource": "pods", "verb": "get"}'
      htpasswdFile: /etc/proxy/htpasswd
  volumeMounts:
  - name: secret-htpasswd
    mountPath: /etc/proxy
  volumes:
  - name: secret-htpasswd
    secret:
      secretName: htpasswd-jaeger
EOF
```
2. Deploy Kiali:
```
oc apply -n istio-system -f - <<EOF
apiVersion: kiali.io/v1alpha1
kind: Kiali
metadata:
  name: kiali
spec:
  external_services:
    istio:
      config_map_name: istio-basic
      istio_sidecar_injector_config_map_name: istio-sidecar-injector-basic
      istiod_deployment_name: istiod-basic
      istiod_pod_monitoring_port: 15014
      url_service_version: "http://istiod-basic.istio-system-1:15014/version"
    prometheus:
      auth:
        type: basic
        use_kiali_token: false
        username: internal
      url: "https://prometheus.istio-system.svc:9090"
    tracing:
      auth:
        type: basic
        username: admin
        password: admin
      enabled: true
      in_cluster_url: "https://jaeger-query.istio-system.svc"
      url: "https://jaeger-istio-system.apps-crc.testing"
      use_grpc: false
  version: v1.57
EOF
```
3. Deploy SMCP:
```
oc apply -n istio-system -f - <<EOF
apiVersion: maistra.io/v2
kind: ServiceMeshControlPlane
metadata:
  name: basic
spec:
  addons:
    grafana:
      enabled: false
    kiali:
      enabled: true
      name: kiali
  gateways:
    egress:
      enabled: false
    openshiftRoute:
      enabled: false
  general:
    logging:
      componentLevels:
        default: info
  meshConfig:
    extensionProviders:
    - name: custom-jaeger
      zipkin:
        service: "jaeger-collector.istio-system.svc.cluster.local"
        port: 9411
  proxy:
    accessLogging:
      file:
        name: /dev/stdout
  tracing:
    type: None
---
apiVersion: maistra.io/v1
kind: ServiceMeshMemberRoll
metadata:
  name: default
spec:
  members:
  - bookinfo
EOF
```
4. Enable tracing:
```
oc apply -n istio-system -f - <<EOF
apiVersion: telemetry.istio.io/v1alpha1
kind: Telemetry
metadata:
  name: default
spec:
  tracing:
  - providers:
    - name: custom-jaeger
    randomSamplingPercentage: 100
EOF
```
5. Deploy apps and generate some traffic:
```
oc apply -f https://raw.githubusercontent.com/maistra/istio/maistra-2.4/samples/bookinfo/platform/kube/bookinfo.yaml -n bookinfo
oc apply -f https://raw.githubusercontent.com/maistra/istio/maistra-2.4/samples/bookinfo/networking/bookinfo-gateway.yaml -n bookinfo
ROUTE=$(oc get routes -n istio-system istio-ingressgateway -o jsonpath='{.spec.host}')
while true; do curl -v http://$ROUTE:80/productpage > /dev/null; sleep 1; done
```