### PR TITLE
Prevent nested docker build

### DIFF
--- a/tests/integration/common-operator-integ-suite.sh
+++ b/tests/integration/common-operator-integ-suite.sh
@@ -129,7 +129,8 @@ build_and_push_image() {
   echo "Building and pushing image"
   echo "Image base: ${IMAGE_BASE}"
   echo " Tag: ${TAG}"
-  IMAGE=${HUB}/${IMAGE_BASE}:${TAG} make docker-build docker-push
+  # running docker build inside another container layer causes issues with bind mounts
+  BUILD_WITH_CONTAINER=0 IMAGE=${HUB}/${IMAGE_BASE}:${TAG} make docker-build docker-push
 }
 
 deploy_operator() {
@@ -144,7 +145,8 @@ deploy_operator() {
 
     TARGET="deploy-openshift"
   fi
-  IMAGE=${HUB}/${IMAGE_BASE}:${TAG} make -s --no-print-directory ${TARGET}
+  # running docker build inside another container layer causes issues with bind mounts
+  BUILD_WITH_CONTAINER=0 IMAGE=${HUB}/${IMAGE_BASE}:${TAG} make -s --no-print-directory ${TARGET}
 }
 
 check_ready() {


### PR DESCRIPTION
When running integration tests with `BUILD_WITH_CONTAINER=1`, the image build would happen inside a nested docker which would fail when trying to mount the source dir.

Upstream has an analogous  solution here: https://github.com/istio/istio/blob/ef5e8019a4b1ccf3ad41522125fdca07bf93c12f/tools/docker-builder/main.go#L245-L246