### PR TITLE
OSSM-5730: Allow creating 2 cluster-wide SMCPs when one of them is a gateway controller

### DIFF
--- a/pkg/apis/maistra/v2/servicemeshcontrolplane_types.go
+++ b/pkg/apis/maistra/v2/servicemeshcontrolplane_types.go
@@ -205,29 +205,31 @@ func (s ControlPlaneSpec) IsGatewayController() bool {
 	if s.Runtime != nil && s.Runtime.Components != nil {
 		pilot, found := s.Runtime.Components[ControlPlaneComponentNamePilot]
 		if !found {
-			goto CheckTechPreview
+			return s.isTechPreviewGatewayController()
 		}
 		if pilot.Container != nil && pilot.Container.Env != nil {
 			controllerModeEnabledStr, found := pilot.Container.Env["PILOT_ENABLE_GATEWAY_CONTROLLER_MODE"]
 			if !found {
-				goto CheckTechPreview
+				return s.isTechPreviewGatewayController()
 			}
 			controllerModeEnabled, err := strconv.ParseBool(controllerModeEnabledStr)
 			if err != nil {
-				goto CheckTechPreview
+				return s.isTechPreviewGatewayController()
 			}
 			return controllerModeEnabled
 		}
 	}
+	return s.isTechPreviewGatewayController()
+}
 
-CheckTechPreview:
+func (s ControlPlaneSpec) isTechPreviewGatewayController() bool {
 	if s.TechPreview != nil {
-		rawGatewayAPI, found, err := s.TechPreview.GetMap("gatewayAPI")
+		gatewayAPI, found, err := s.TechPreview.GetMap("gatewayAPI")
 		if err != nil || !found {
 			return false
 		}
 
-		isControllerMode, found, err := v1.NewHelmValues(rawGatewayAPI).GetBool("controllerMode")
+		isControllerMode, found, err := v1.NewHelmValues(gatewayAPI).GetBool("controllerMode")
 		if err != nil || !found {
 			return false
 		}

--- a/pkg/apis/maistra/v2/servicemeshcontrolplane_types.go
+++ b/pkg/apis/maistra/v2/servicemeshcontrolplane_types.go
@@ -201,7 +201,7 @@ func (s ControlPlaneSpec) IsClusterScoped() bool {
 	return s.Mode == ClusterWideMode
 }
 
-func (s ControlPlaneSpec) IsGatewayController() (bool, error) {
+func (s ControlPlaneSpec) IsGatewayController() bool {
 	if s.Runtime != nil && s.Runtime.Components != nil {
 		pilot, found := s.Runtime.Components[ControlPlaneComponentNamePilot]
 		if !found {
@@ -214,9 +214,9 @@ func (s ControlPlaneSpec) IsGatewayController() (bool, error) {
 			}
 			controllerModeEnabled, err := strconv.ParseBool(controllerModeEnabledStr)
 			if err != nil {
-				return false, err
+				return false
 			}
-			return controllerModeEnabled, nil
+			return controllerModeEnabled
 		}
 	}
 
@@ -224,20 +224,20 @@ CheckTechPreview:
 	if s.TechPreview != nil {
 		rawGatewayAPI, found, err := s.TechPreview.GetMap("gatewayAPI")
 		if err != nil {
-			return false, err
+			return false
 		} else if !found {
-			return false, nil
+			return false
 		}
 
 		isControllerMode, found, err := v1.NewHelmValues(rawGatewayAPI).GetBool("controllerMode")
 		if err != nil {
-			return false, err
+			return false
 		} else if !found {
-			return false, nil
+			return false
 		}
-		return isControllerMode, nil
+		return isControllerMode
 	}
-	return false, nil
+	return false
 }
 
 func (s ControlPlaneSpec) IsKialiEnabled() bool {

--- a/pkg/apis/maistra/v2/servicemeshcontrolplane_types.go
+++ b/pkg/apis/maistra/v2/servicemeshcontrolplane_types.go
@@ -195,6 +195,30 @@ type Enablement struct {
 	Enabled *bool `json:"enabled,omitempty"`
 }
 
+func (s ControlPlaneSpec) IsClusterScoped() bool {
+	return s.Mode == ClusterWideMode
+}
+
+func (s ControlPlaneSpec) IsGatewayController() (bool, error) {
+	if s.TechPreview != nil {
+		rawGatewayAPI, found, err := s.TechPreview.GetMap("gatewayAPI")
+		if err != nil {
+			return false, err
+		} else if !found {
+			return false, nil
+		}
+
+		isControllerMode, found, err := v1.NewHelmValues(rawGatewayAPI).GetBool("controllerMode")
+		if err != nil {
+			return false, err
+		} else if !found {
+			return false, nil
+		}
+		return isControllerMode, nil
+	}
+	return false, nil
+}
+
 func (s ControlPlaneSpec) IsKialiEnabled() bool {
 	return s.Addons != nil &&
 		s.Addons.Kiali != nil &&

--- a/pkg/apis/maistra/v2/servicemeshcontrolplane_types.go
+++ b/pkg/apis/maistra/v2/servicemeshcontrolplane_types.go
@@ -240,6 +240,23 @@ CheckTechPreview:
 	return false
 }
 
+func (s ControlPlaneSpec) GetCaCertConfigMapName() (caRootCertConfigMapName string) {
+	caRootCertConfigMapName = "istio-ca-root-cert"
+	if s.TechPreview != nil {
+		rawGlobal, found, err := s.TechPreview.GetMap("global")
+		if err != nil || !found {
+			return
+		}
+
+		caRootCertConfigMapNameValue, found, err := v1.NewHelmValues(rawGlobal).GetString("caCertConfigMapName")
+		if err != nil || !found {
+			return
+		}
+		caRootCertConfigMapName = caRootCertConfigMapNameValue
+	}
+	return
+}
+
 func (s ControlPlaneSpec) IsKialiEnabled() bool {
 	return s.Addons != nil &&
 		s.Addons.Kiali != nil &&

--- a/pkg/apis/maistra/v2/servicemeshcontrolplane_types.go
+++ b/pkg/apis/maistra/v2/servicemeshcontrolplane_types.go
@@ -214,7 +214,7 @@ func (s ControlPlaneSpec) IsGatewayController() bool {
 			}
 			controllerModeEnabled, err := strconv.ParseBool(controllerModeEnabledStr)
 			if err != nil {
-				return false
+				goto CheckTechPreview
 			}
 			return controllerModeEnabled
 		}

--- a/pkg/apis/maistra/v2/servicemeshcontrolplane_types.go
+++ b/pkg/apis/maistra/v2/servicemeshcontrolplane_types.go
@@ -223,16 +223,12 @@ func (s ControlPlaneSpec) IsGatewayController() bool {
 CheckTechPreview:
 	if s.TechPreview != nil {
 		rawGatewayAPI, found, err := s.TechPreview.GetMap("gatewayAPI")
-		if err != nil {
-			return false
-		} else if !found {
+		if err != nil || !found {
 			return false
 		}
 
 		isControllerMode, found, err := v1.NewHelmValues(rawGatewayAPI).GetBool("controllerMode")
-		if err != nil {
-			return false
-		} else if !found {
+		if err != nil || !found {
 			return false
 		}
 		return isControllerMode

--- a/pkg/apis/maistra/v2/servicemeshcontrolplane_types.go
+++ b/pkg/apis/maistra/v2/servicemeshcontrolplane_types.go
@@ -236,21 +236,21 @@ CheckTechPreview:
 	return false
 }
 
-func (s ControlPlaneSpec) GetCaCertConfigMapName() (caRootCertConfigMapName string) {
-	caRootCertConfigMapName = "istio-ca-root-cert"
+func (s ControlPlaneSpec) GetCaCertConfigMapName() string {
+	defaultCaRootCertConfigMapName := "istio-ca-root-cert"
 	if s.TechPreview != nil {
 		rawGlobal, found, err := s.TechPreview.GetMap("global")
 		if err != nil || !found {
-			return
+			return defaultCaRootCertConfigMapName
 		}
 
-		caRootCertConfigMapNameValue, found, err := v1.NewHelmValues(rawGlobal).GetString("caCertConfigMapName")
+		caRootCertConfigMapName, found, err := v1.NewHelmValues(rawGlobal).GetString("caCertConfigMapName")
 		if err != nil || !found {
-			return
+			return defaultCaRootCertConfigMapName
 		}
-		caRootCertConfigMapName = caRootCertConfigMapNameValue
+		return caRootCertConfigMapName
 	}
-	return
+	return defaultCaRootCertConfigMapName
 }
 
 func (s ControlPlaneSpec) IsKialiEnabled() bool {

--- a/pkg/apis/maistra/v2/servicemeshcontrolplane_types_test.go
+++ b/pkg/apis/maistra/v2/servicemeshcontrolplane_types_test.go
@@ -1,0 +1,143 @@
+package v2
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+
+	"testing"
+)
+
+var testCases = []struct {
+	name                string
+	smcpSpec            *ControlPlaneSpec
+	isGatewayController bool
+}{
+	{
+		name: "techPreview gateway controller - expected true",
+		smcpSpec: newSmcpSpec(`
+techPreview:
+  gatewayAPI:
+    controllerMode: true
+`),
+		isGatewayController: true,
+	},
+	{
+		name: "custom gateway controller - expected true",
+		smcpSpec: newSmcpSpec(`
+runtime:
+  components:
+    pilot:
+      container:
+        env:
+          PILOT_ENABLE_GATEWAY_CONTROLLER_MODE: "true"
+`),
+		isGatewayController: true,
+	},
+	{
+		name: "techPreview custom gateway controller - expected true (environment variable has precedence over techPreview settings)",
+		smcpSpec: newSmcpSpec(`
+runtime:
+  components:
+    pilot:
+      container:
+        env:
+          PILOT_ENABLE_GATEWAY_CONTROLLER_MODE: "true"
+techPreview:
+  gatewayAPI:
+    controllerMode: false
+`),
+		isGatewayController: true,
+	},
+	{
+		name: "techPreview gateway controller disabled - expected false",
+		smcpSpec: newSmcpSpec(`
+techPreview:
+  gatewayAPI:
+    controllerMode: false
+`),
+		isGatewayController: false,
+	},
+	{
+		name: "techPreview gateway controller with invalid value - expected false",
+		smcpSpec: newSmcpSpec(`
+techPreview:
+  gatewayAPI:
+    controllerMode: a
+`),
+		isGatewayController: false,
+	},
+	{
+		name: "custom gateway controller disabled - expected false",
+		smcpSpec: newSmcpSpec(`
+runtime:
+  components:
+    pilot:
+      container:
+        env:
+          PILOT_ENABLE_GATEWAY_CONTROLLER_MODE: "false"
+`),
+		isGatewayController: false,
+	},
+	{
+		name: "custom gateway controller with invalid value - expected false",
+		smcpSpec: newSmcpSpec(`
+runtime:
+  components:
+    pilot:
+      container:
+        env:
+          PILOT_ENABLE_GATEWAY_CONTROLLER_MODE: "a"
+`),
+		isGatewayController: false,
+	},
+	{
+		name: "custom gateway controller with invalid environment variable and enabled techPreview gateway controller - expected true",
+		smcpSpec: newSmcpSpec(`
+runtime:
+  components:
+    pilot:
+      container:
+        env:
+          PILOT_ENABLE_GATEWAY_CONTROLLER_MODE: "a"
+techPreview:
+  gatewayAPI:
+    controllerMode: true
+`),
+		isGatewayController: true,
+	},
+	{
+		name: "custom gateway controller enabled and invalid techPreview gateway controller - expected true",
+		smcpSpec: newSmcpSpec(`
+runtime:
+  components:
+    pilot:
+      container:
+        env:
+          PILOT_ENABLE_GATEWAY_CONTROLLER_MODE: "true"
+techPreview:
+  gatewayAPI:
+    controllerMode: a
+`),
+		isGatewayController: true,
+	},
+}
+
+func TestIsGatewayController(t *testing.T) {
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.smcpSpec.IsGatewayController() != tc.isGatewayController {
+				t.Errorf("exptected to get %t, got %t", tc.isGatewayController, tc.smcpSpec.IsGatewayController())
+			}
+		})
+	}
+}
+
+func newSmcpSpec(specYaml string) *ControlPlaneSpec {
+	smcp := &ControlPlaneSpec{}
+	err := yaml.Unmarshal([]byte(specYaml), smcp)
+	if err != nil {
+		panic(fmt.Sprintf("unexpected error: %v", err))
+	}
+	return smcp
+}

--- a/pkg/apis/maistra/v2/servicemeshcontrolplane_types_test.go
+++ b/pkg/apis/maistra/v2/servicemeshcontrolplane_types_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-var testCases = []struct {
+var isGatewayControllerTestCases = []struct {
 	name                string
 	smcpSpec            *ControlPlaneSpec
 	isGatewayController bool
@@ -124,7 +124,7 @@ techPreview:
 }
 
 func TestIsGatewayController(t *testing.T) {
-	for _, tc := range testCases {
+	for _, tc := range isGatewayControllerTestCases {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.smcpSpec.IsGatewayController() != tc.isGatewayController {
 				t.Errorf("exptected to get %t, got %t", tc.isGatewayController, tc.smcpSpec.IsGatewayController())

--- a/pkg/apis/maistra/v2/servicemeshcontrolplane_types_test.go
+++ b/pkg/apis/maistra/v2/servicemeshcontrolplane_types_test.go
@@ -2,10 +2,9 @@ package v2
 
 import (
 	"fmt"
+	"testing"
 
 	"sigs.k8s.io/yaml"
-
-	"testing"
 )
 
 var isGatewayControllerTestCases = []struct {

--- a/pkg/controller/versions/strategy_v2_3.go
+++ b/pkg/controller/versions/strategy_v2_3.go
@@ -718,5 +718,5 @@ func (v *versionStrategyV2_3) validateGlobal(
 	}
 	allErrors = checkMeshConfigNotSet(spec, allErrors)
 	allErrors = checkDiscoverySelectorsNotSet(spec, allErrors)
-	return validateGlobal(ctx, version, meta, spec, cl, allErrors)
+	return validateGlobal(ctx, meta, spec, cl, allErrors)
 }

--- a/pkg/controller/versions/strategy_v2_3.go
+++ b/pkg/controller/versions/strategy_v2_3.go
@@ -130,7 +130,7 @@ func (v *versionStrategyV2_3) ValidateV1(_ context.Context, _ client.Client, _ *
 
 func (v *versionStrategyV2_3) ValidateV2(ctx context.Context, cl client.Client, meta *metav1.ObjectMeta, spec *v2.ControlPlaneSpec) error {
 	var allErrors []error
-	allErrors = v.validateGlobal(ctx, v.Ver, meta, spec, cl, allErrors)
+	allErrors = v.validateGlobal(ctx, meta, spec, cl, allErrors)
 	allErrors = validateGateways(ctx, meta, spec, cl, allErrors)
 	allErrors = validatePolicyType(spec, v.Ver, allErrors)
 	allErrors = validateTelemetryType(spec, v.Ver, allErrors)
@@ -700,8 +700,7 @@ func (v *versionStrategyV2_3) GetTrustDomainFieldPath() string {
 }
 
 func (v *versionStrategyV2_3) validateGlobal(
-	ctx context.Context, version Ver, meta *metav1.ObjectMeta,
-	spec *v2.ControlPlaneSpec, cl client.Client, allErrors []error,
+	ctx context.Context, meta *metav1.ObjectMeta, spec *v2.ControlPlaneSpec, cl client.Client, allErrors []error,
 ) []error {
 	if spec.Mode != "" {
 		allErrors = append(allErrors,

--- a/pkg/controller/versions/strategy_v2_4.go
+++ b/pkg/controller/versions/strategy_v2_4.go
@@ -131,7 +131,7 @@ func (v *versionStrategyV2_4) ValidateV1(_ context.Context, _ client.Client, _ *
 
 func (v *versionStrategyV2_4) ValidateV2(ctx context.Context, cl client.Client, meta *metav1.ObjectMeta, spec *v2.ControlPlaneSpec) error {
 	var allErrors []error
-	allErrors = v.validateGlobal(ctx, v.Version(), meta, spec, cl, allErrors)
+	allErrors = v.validateGlobal(ctx, meta, spec, cl, allErrors)
 	allErrors = validateGateways(ctx, meta, spec, cl, allErrors)
 	allErrors = validatePolicyType(spec, v.Ver, allErrors)
 	allErrors = validateTelemetryType(spec, v.Ver, allErrors)
@@ -789,8 +789,7 @@ func (v *versionStrategyV2_4) GetTrustDomainFieldPath() string {
 }
 
 func (v *versionStrategyV2_4) validateGlobal(
-	ctx context.Context, version Ver, meta *metav1.ObjectMeta,
-	spec *v2.ControlPlaneSpec, cl client.Client, allErrors []error,
+	ctx context.Context, meta *metav1.ObjectMeta, spec *v2.ControlPlaneSpec, cl client.Client, allErrors []error,
 ) []error {
 	if spec.Mode != "" {
 		if spec.Mode != v2.ClusterWideMode && spec.Mode != v2.MultiTenantMode {

--- a/pkg/controller/versions/strategy_v2_4.go
+++ b/pkg/controller/versions/strategy_v2_4.go
@@ -807,7 +807,7 @@ func (v *versionStrategyV2_4) validateGlobal(
 	}
 
 	allErrors = checkDiscoverySelectors(spec, allErrors)
-	return validateGlobal(ctx, version, meta, spec, cl, allErrors)
+	return validateGlobal(ctx, meta, spec, cl, allErrors)
 }
 
 func (v *versionStrategyV2_4) createMemberRoll(ctx context.Context, cr *common.ControllerResources, smcp *v2.ServiceMeshControlPlane) error {

--- a/pkg/controller/versions/strategy_v2_5.go
+++ b/pkg/controller/versions/strategy_v2_5.go
@@ -765,7 +765,7 @@ func (v *versionStrategyV2_5) validateGlobal(
 	}
 
 	allErrors = checkDiscoverySelectors(spec, allErrors)
-	return validateGlobal(ctx, version, meta, spec, cl, allErrors)
+	return validateGlobal(ctx, meta, spec, cl, allErrors)
 }
 
 func (v *versionStrategyV2_5) createMemberRoll(ctx context.Context, cr *common.ControllerResources, smcp *v2.ServiceMeshControlPlane) error {

--- a/pkg/controller/versions/strategy_v2_5.go
+++ b/pkg/controller/versions/strategy_v2_5.go
@@ -125,7 +125,7 @@ func (v *versionStrategyV2_5) ValidateV1(_ context.Context, _ client.Client, _ *
 
 func (v *versionStrategyV2_5) ValidateV2(ctx context.Context, cl client.Client, meta *metav1.ObjectMeta, spec *v2.ControlPlaneSpec) error {
 	var allErrors []error
-	allErrors = v.validateGlobal(ctx, v.Version(), meta, spec, cl, allErrors)
+	allErrors = v.validateGlobal(ctx, meta, spec, cl, allErrors)
 	allErrors = validateGateways(ctx, meta, spec, cl, allErrors)
 	allErrors = validatePolicyType(spec, v.Ver, allErrors)
 	allErrors = validateTelemetryType(spec, v.Ver, allErrors)
@@ -747,8 +747,7 @@ func (v *versionStrategyV2_5) GetTrustDomainFieldPath() string {
 }
 
 func (v *versionStrategyV2_5) validateGlobal(
-	ctx context.Context, version Ver, meta *metav1.ObjectMeta,
-	spec *v2.ControlPlaneSpec, cl client.Client, allErrors []error,
+	ctx context.Context, meta *metav1.ObjectMeta, spec *v2.ControlPlaneSpec, cl client.Client, allErrors []error,
 ) []error {
 	if spec.Mode != "" {
 		if spec.Mode != v2.ClusterWideMode && spec.Mode != v2.MultiTenantMode {

--- a/pkg/controller/versions/strategy_v2_5_test.go
+++ b/pkg/controller/versions/strategy_v2_5_test.go
@@ -185,6 +185,21 @@ var testCases = []validationTestCase{
 		},
 	},
 	{
+		name: "creating multi-tenant SMCP when cluster-wide gateway controller exists - no errors",
+		smcp: simpleMultiTenant,
+		existingObjs: []*maistrav2.ServiceMeshControlPlane{
+			NewV2SMCPResource("basic", "istio-system-1", clusterWideGatewayController),
+		},
+	},
+	{
+		name: "creating multi-tenant SMCP when cluster-wide gateway controller exists - no errors (2nd execution)",
+		smcp: simpleMultiTenant,
+		existingObjs: []*maistrav2.ServiceMeshControlPlane{
+			NewV2SMCPResource("basic", "istio-system-1", clusterWideGatewayController),
+			NewV2SMCPResource("basic", "istio-system-2", simpleMultiTenant),
+		},
+	},
+	{
 		name: "creating cluster-wide SMCP when multi-tenant gateway controller exists - error expected",
 		smcp: simpleClusterWide,
 		existingObjs: []*maistrav2.ServiceMeshControlPlane{
@@ -247,8 +262,8 @@ var testCases = []validationTestCase{
 		name: "creating custom cluster-wide gateway controller SMCP when another already exists - expected error (2nd execution)",
 		smcp: clusterWideCustomizedGatewayController,
 		existingObjs: []*maistrav2.ServiceMeshControlPlane{
-			NewV2SMCPResource("basic", "istio-system-1", clusterWideGatewayController),
-			NewV2SMCPResource("basic", "istio-system-2", clusterWideCustomizedGatewayController),
+			NewV2SMCPResource("basic", "istio-system-1", clusterWideCustomizedGatewayController),
+			NewV2SMCPResource("basic", "istio-system-2", clusterWideGatewayController),
 		},
 		expectedErr: fmt.Errorf("a cluster-scoped SMCP may only be created when no other SMCPs exist"),
 	},
@@ -268,21 +283,6 @@ var testCases = []validationTestCase{
 			NewV2SMCPResource("basic", "istio-system-2", simpleMultiTenant),
 		},
 		expectedErr: fmt.Errorf("no other SMCPs may be created when a cluster-scoped SMCP exists"),
-	},
-	{
-		name: "creating multi-tenant SMCP when cluster-wide gateway controller exists - no errors",
-		smcp: simpleMultiTenant,
-		existingObjs: []*maistrav2.ServiceMeshControlPlane{
-			NewV2SMCPResource("basic", "istio-system-1", clusterWideGatewayController),
-		},
-	},
-	{
-		name: "creating multi-tenant SMCP when cluster-wide gateway controller exists - no errors (2nd execution)",
-		smcp: simpleMultiTenant,
-		existingObjs: []*maistrav2.ServiceMeshControlPlane{
-			NewV2SMCPResource("basic", "istio-system-1", simpleMultiTenant),
-			NewV2SMCPResource("basic", "istio-system-2", clusterWideGatewayController),
-		},
 	},
 }
 

--- a/pkg/controller/versions/strategy_v2_5_test.go
+++ b/pkg/controller/versions/strategy_v2_5_test.go
@@ -47,16 +47,6 @@ mode: ClusterWide
 techPreview:
   gatewayAPI:
     controllerMode: true`)
-
-	clusterWideCustomizedGatewayController = newSmcpSpec(`
-mode: ClusterWide
-runtime:
-  components:
-    pilot:
-      container:
-        env:
-          PILOT_ENABLE_GATEWAY_CONTROLLER_MODE: "true"
-`)
 )
 
 var testCases = []validationTestCase{
@@ -95,21 +85,6 @@ var testCases = []validationTestCase{
 		},
 	},
 	{
-		name: "creating custom cluster-wide gateway controller when multi-tenant SMCP exists - no errors",
-		smcp: clusterWideCustomizedGatewayController,
-		existingObjs: []*maistrav2.ServiceMeshControlPlane{
-			NewV2SMCPResource("basic", "istio-system-1", simpleMultiTenant),
-		},
-	},
-	{
-		name: "creating custom cluster-wide gateway controller when multi-tenant SMCP exists - no errors (2nd execution)",
-		smcp: clusterWideCustomizedGatewayController,
-		existingObjs: []*maistrav2.ServiceMeshControlPlane{
-			NewV2SMCPResource("basic", "istio-system-1", simpleMultiTenant),
-			NewV2SMCPResource("basic", "istio-system-2", clusterWideCustomizedGatewayController),
-		},
-	},
-	{
 		name: "creating cluster-wide gateway-controller when multi-tenant SMCP exists - no errors",
 		smcp: clusterWideGatewayController,
 		existingObjs: []*maistrav2.ServiceMeshControlPlane{
@@ -140,21 +115,6 @@ var testCases = []validationTestCase{
 		},
 	},
 	{
-		name: "creating custom cluster-wide gateway controller when simple cluster-wide SMCP exists - no errors",
-		smcp: clusterWideCustomizedGatewayController,
-		existingObjs: []*maistrav2.ServiceMeshControlPlane{
-			NewV2SMCPResource("basic", "istio-system-2", simpleClusterWide),
-		},
-	},
-	{
-		name: "creating custom cluster-wide gateway controller when simple cluster-wide SMCP exists - no errors (2nd execution)",
-		smcp: clusterWideCustomizedGatewayController,
-		existingObjs: []*maistrav2.ServiceMeshControlPlane{
-			NewV2SMCPResource("basic", "istio-system-1", clusterWideCustomizedGatewayController),
-			NewV2SMCPResource("basic", "istio-system-2", simpleClusterWide),
-		},
-	},
-	{
 		name: "creating simple cluster-wide SMCP when cluster-wide gateway controller exists - no errors",
 		smcp: simpleClusterWide,
 		existingObjs: []*maistrav2.ServiceMeshControlPlane{
@@ -166,21 +126,6 @@ var testCases = []validationTestCase{
 		smcp: simpleClusterWide,
 		existingObjs: []*maistrav2.ServiceMeshControlPlane{
 			NewV2SMCPResource("basic", "istio-system-1", clusterWideGatewayController),
-			NewV2SMCPResource("basic", "istio-system-2", simpleClusterWide),
-		},
-	},
-	{
-		name: "creating simple cluster-wide SMCP when custom cluster-wide gateway controller exists - no errors",
-		smcp: simpleClusterWide,
-		existingObjs: []*maistrav2.ServiceMeshControlPlane{
-			NewV2SMCPResource("basic", "istio-system-1", clusterWideCustomizedGatewayController),
-		},
-	},
-	{
-		name: "creating simple cluster-wide SMCP when custom cluster-wide gateway controller exists - no errors (2nd execution)",
-		smcp: simpleClusterWide,
-		existingObjs: []*maistrav2.ServiceMeshControlPlane{
-			NewV2SMCPResource("basic", "istio-system-1", clusterWideCustomizedGatewayController),
 			NewV2SMCPResource("basic", "istio-system-2", simpleClusterWide),
 		},
 	},
@@ -263,23 +208,6 @@ var testCases = []validationTestCase{
 		smcp: clusterWideGatewayController,
 		existingObjs: []*maistrav2.ServiceMeshControlPlane{
 			NewV2SMCPResource("basic", "istio-system-1", clusterWideGatewayController),
-			NewV2SMCPResource("basic", "istio-system-2", clusterWideGatewayController),
-		},
-		expectedErr: fmt.Errorf("a cluster-scoped SMCP may only be created when no other SMCPs exist"),
-	},
-	{
-		name: "creating custom cluster-wide gateway controller SMCP when another already exists - expected error",
-		smcp: clusterWideCustomizedGatewayController,
-		existingObjs: []*maistrav2.ServiceMeshControlPlane{
-			NewV2SMCPResource("basic", "istio-system-1", clusterWideGatewayController),
-		},
-		expectedErr: fmt.Errorf("a cluster-scoped SMCP may only be created when no other SMCPs exist"),
-	},
-	{
-		name: "creating custom cluster-wide gateway controller SMCP when another already exists - expected error (2nd execution)",
-		smcp: clusterWideCustomizedGatewayController,
-		existingObjs: []*maistrav2.ServiceMeshControlPlane{
-			NewV2SMCPResource("basic", "istio-system-1", clusterWideCustomizedGatewayController),
 			NewV2SMCPResource("basic", "istio-system-2", clusterWideGatewayController),
 		},
 		expectedErr: fmt.Errorf("a cluster-scoped SMCP may only be created when no other SMCPs exist"),

--- a/pkg/controller/versions/strategy_v2_5_test.go
+++ b/pkg/controller/versions/strategy_v2_5_test.go
@@ -242,15 +242,6 @@ var testCases = []validationTestCase{
 		expectedErr: fmt.Errorf("a cluster-scoped SMCP may only be created when no other SMCPs exist"),
 	},
 	{
-		name: "creating cluster-wide gateway controller SMCP when another already exists - expected error (2nd execution)",
-		smcp: clusterWideGatewayController,
-		existingObjs: []*maistrav2.ServiceMeshControlPlane{
-			NewV2SMCPResource("basic", "istio-system-1", clusterWideGatewayController),
-			NewV2SMCPResource("basic", "istio-system-2", clusterWideGatewayController2),
-		},
-		expectedErr: fmt.Errorf("a cluster-scoped SMCP may only be created when no other SMCPs exist"),
-	},
-	{
 		name: "creating multi-tenant SMCP when cluster-wide SMCP exists - expected error",
 		smcp: simpleMultiTenant,
 		existingObjs: []*maistrav2.ServiceMeshControlPlane{

--- a/pkg/controller/versions/strategy_v2_5_test.go
+++ b/pkg/controller/versions/strategy_v2_5_test.go
@@ -3,13 +3,13 @@ package versions
 import (
 	"context"
 	"fmt"
-	"sigs.k8s.io/yaml"
 
 	maistrav2 "github.com/maistra/istio-operator/pkg/apis/maistra/v2"
 	"github.com/maistra/istio-operator/pkg/controller/common/test/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
 	"testing"
 )

--- a/pkg/controller/versions/strategy_v2_5_test.go
+++ b/pkg/controller/versions/strategy_v2_5_test.go
@@ -3,6 +3,7 @@ package versions
 import (
 	"context"
 	"fmt"
+
 	maistrav2 "github.com/maistra/istio-operator/pkg/apis/maistra/v2"
 	"github.com/maistra/istio-operator/pkg/controller/common/test/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -74,6 +75,10 @@ techPreview:
 	}
 )
 
+// Function ValidateV2 is called in the strategy.Render function and in controlPlaneController.Handle,
+// and the test cases below are duplicated to cover validation during and after rendering.
+// In other words, when an SMCP B is created when an SMCP A exists, ValidateV2 will be called twice and first call
+// to client.List will return [SMCP A] and next time it will return [SMCP A, SMCP B].
 var testCases = []validationTestCase{
 	// TODO: add test cases where 2 multi-tenant control planes already exist
 	{

--- a/pkg/controller/versions/strategy_v2_5_test.go
+++ b/pkg/controller/versions/strategy_v2_5_test.go
@@ -1,0 +1,145 @@
+package versions
+
+import (
+	"context"
+	"fmt"
+	"sigs.k8s.io/yaml"
+
+	maistrav2 "github.com/maistra/istio-operator/pkg/apis/maistra/v2"
+	"github.com/maistra/istio-operator/pkg/controller/common/test/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"testing"
+)
+
+type validationTestCase struct {
+	name         string
+	smcp         *maistrav2.ControlPlaneSpec
+	existingObjs map[*metav1.ObjectMeta]runtime.Object
+	expectedErr  error
+}
+
+func NewV2SMCPResource(name, namespace string, spec *maistrav2.ControlPlaneSpec) *maistrav2.ServiceMeshControlPlane {
+	smcp := &maistrav2.ServiceMeshControlPlane{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+	}
+	spec.DeepCopyInto(&smcp.Spec)
+	smcp.Spec.Profiles = []string{"maistra"}
+	smcp.Spec.Version = "v2.5"
+	smcp.UID = "c3ac6dc8-f845-4410-96a9-31856c800a44"
+	return smcp
+}
+
+var testCases = []validationTestCase{
+	{
+		name:         "creating multi-tenant SMCP when no other SMCPs exists - no errors",
+		smcp:         newSmcpSpec(`mode: ClusterWide`),
+		existingObjs: map[*metav1.ObjectMeta]runtime.Object{},
+	},
+	{
+		name: "creating multi-tenant SMCP when cluster-wide SMCP exists - expected error",
+		smcp: newSmcpSpec(`mode: MultiTenant`),
+		existingObjs: map[*metav1.ObjectMeta]runtime.Object{
+			&metav1.ObjectMeta{Name: "basic", Namespace: "istio-system-1"}: NewV2SMCPResource(
+				"basic", "istio-system-1", newSmcpSpec(`mode: ClusterWide`)),
+		},
+		expectedErr: fmt.Errorf("no other SMCPs may be created when a cluster-scoped SMCP exists"),
+	},
+	{
+		name: "creating cluster-wide SMCP when cluster-wide SMCP exists - expected error",
+		smcp: newSmcpSpec(`mode: ClusterWide`),
+		existingObjs: map[*metav1.ObjectMeta]runtime.Object{
+			&metav1.ObjectMeta{Name: "basic", Namespace: "istio-system-1"}: NewV2SMCPResource(
+				"basic", "istio-system-1", newSmcpSpec(`mode: ClusterWide`)),
+		},
+		expectedErr: fmt.Errorf("a cluster-scoped SMCP may only be created when no other SMCPs exist"),
+	},
+	{
+		name: "creating cluster-wide SMCP when multi-tenant SMCP exists - expected error",
+		smcp: newSmcpSpec(`
+mode: ClusterWide`),
+		existingObjs: map[*metav1.ObjectMeta]runtime.Object{
+			&metav1.ObjectMeta{Name: "basic", Namespace: "istio-system-1"}: NewV2SMCPResource("basic", "istio-system-1", newSmcpSpec(`
+mode: MultiTenant`)),
+		},
+		expectedErr: fmt.Errorf("a cluster-scoped SMCP may only be created when no other SMCPs exist"),
+	},
+}
+
+func TestValidateV2(t *testing.T) {
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := fakeClient{tc.existingObjs}
+			v := versionStrategyV2_5{Ver: V2_5}
+			err := v.ValidateV2(context.TODO(), c, &metav1.ObjectMeta{Name: "basic", Namespace: "istio-sytem"}, tc.smcp)
+
+			if tc.expectedErr == nil {
+				assert.Nil(err, "got unexpected error: ", t)
+			} else {
+				assert.Equals(err.Error(), tc.expectedErr.Error(), "unexpected error occurred", t)
+			}
+		})
+	}
+}
+
+func newSmcpSpec(specYaml string) *maistrav2.ControlPlaneSpec {
+	smcp := &maistrav2.ControlPlaneSpec{}
+	err := yaml.Unmarshal([]byte(specYaml), smcp)
+	if err != nil {
+		panic(fmt.Sprintf("unexpected error: %v", err))
+	}
+	return smcp
+}
+
+type fakeClient struct {
+	objects map[*metav1.ObjectMeta]runtime.Object
+}
+
+func (f fakeClient) Get(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+	if val, exists := f.objects[&metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace}]; exists {
+		obj = val
+	}
+	return nil
+}
+
+func (f fakeClient) List(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+	switch l := list.(type) {
+	case *maistrav2.ServiceMeshControlPlaneList:
+		for _, obj := range f.objects {
+			switch o := obj.(type) {
+			case *maistrav2.ServiceMeshControlPlane:
+				l.Items = append(l.Items, *o)
+			}
+		}
+		list = l
+	default:
+		panic("unsupported resource")
+	}
+	return nil
+}
+
+func (f fakeClient) Create(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
+	panic("implement me")
+}
+
+func (f fakeClient) Delete(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
+	panic("implement me")
+}
+
+func (f fakeClient) Update(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+	panic("implement me")
+}
+
+func (f fakeClient) Patch(ctx context.Context, obj runtime.Object, patch client.Patch, opts ...client.PatchOption) error {
+	panic("implement me")
+}
+
+func (f fakeClient) DeleteAllOf(ctx context.Context, obj runtime.Object, opts ...client.DeleteAllOfOption) error {
+	panic("implement me")
+}
+
+func (f fakeClient) Status() client.StatusWriter {
+	panic("implement me")
+}

--- a/pkg/controller/versions/strategy_v2_5_test.go
+++ b/pkg/controller/versions/strategy_v2_5_test.go
@@ -3,6 +3,7 @@ package versions
 import (
 	"context"
 	"fmt"
+	"testing"
 
 	maistrav2 "github.com/maistra/istio-operator/pkg/apis/maistra/v2"
 	"github.com/maistra/istio-operator/pkg/controller/common/test/assert"
@@ -12,8 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
-
-	"testing"
 )
 
 type validationTestCase struct {
@@ -399,6 +398,7 @@ func newFakeClient(smcps []*maistrav2.ServiceMeshControlPlane) *fakeClient {
 
 func (f fakeClient) Get(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
 	if val, exists := f.objects[&metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace}]; exists {
+		//nolint:ineffassign
 		obj = val
 	}
 	return nil
@@ -413,6 +413,7 @@ func (f fakeClient) List(ctx context.Context, list runtime.Object, opts ...clien
 				l.Items = append(l.Items, *o)
 			}
 		}
+		//nolint:ineffassign
 		list = l
 	default:
 		panic("unsupported resource")

--- a/pkg/controller/versions/strategy_v2_5_test.go
+++ b/pkg/controller/versions/strategy_v2_5_test.go
@@ -396,9 +396,11 @@ func newFakeClient(smcps []*maistrav2.ServiceMeshControlPlane) *fakeClient {
 	return &fakeClient{objects}
 }
 
+//nolint:staticcheck
 func (f fakeClient) Get(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+	//nolint:staticcheck
 	if val, exists := f.objects[&metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace}]; exists {
-		//nolint:ineffassign
+		//nolint:ineffassign,staticcheck
 		obj = val
 	}
 	return nil

--- a/pkg/controller/versions/strategy_v2_5_test.go
+++ b/pkg/controller/versions/strategy_v2_5_test.go
@@ -5,14 +5,15 @@ import (
 	"fmt"
 	"testing"
 
-	maistrav2 "github.com/maistra/istio-operator/pkg/apis/maistra/v2"
-	"github.com/maistra/istio-operator/pkg/controller/common/test/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
+
+	maistrav2 "github.com/maistra/istio-operator/pkg/apis/maistra/v2"
+	"github.com/maistra/istio-operator/pkg/controller/common/test/assert"
 )
 
 type validationTestCase struct {

--- a/pkg/controller/versions/strategy_v2_5_test.go
+++ b/pkg/controller/versions/strategy_v2_5_test.go
@@ -200,6 +200,23 @@ var testCases = []validationTestCase{
 		},
 	},
 	{
+		name: "creating cluster-wide SMCP when multi-tenant mesh already exists - error expected",
+		smcp: simpleClusterWide,
+		existingObjs: []*maistrav2.ServiceMeshControlPlane{
+			NewV2SMCPResource("basic", "istio-system-1", simpleMultiTenant),
+		},
+		expectedErr: fmt.Errorf("a cluster-scoped SMCP may only be created when no other SMCPs exist"),
+	},
+	{
+		name: "creating cluster-wide SMCP when multi-tenant mesh already exists - error expected (2nd execution)",
+		smcp: simpleClusterWide,
+		existingObjs: []*maistrav2.ServiceMeshControlPlane{
+			NewV2SMCPResource("basic", "istio-system-1", simpleMultiTenant),
+			NewV2SMCPResource("basic", "istio-system-2", simpleClusterWide),
+		},
+		expectedErr: fmt.Errorf("a cluster-scoped SMCP may only be created when no other SMCPs exist"),
+	},
+	{
 		name: "creating cluster-wide SMCP when multi-tenant gateway controller exists - error expected",
 		smcp: simpleClusterWide,
 		existingObjs: []*maistrav2.ServiceMeshControlPlane{

--- a/pkg/controller/versions/strategy_v2_5_test.go
+++ b/pkg/controller/versions/strategy_v2_5_test.go
@@ -65,6 +65,14 @@ var testCases = []validationTestCase{
 		},
 	},
 	{
+		name: "creating simple cluster-wide SMCP when cluster-wide gateway controller exists - no errors",
+		smcp: simpleClusterWide,
+		existingObjs: []*maistrav2.ServiceMeshControlPlane{
+			NewV2SMCPResource("basic", "istio-system-1", clusterWideGatewayController),
+			NewV2SMCPResource("basic", "istio-system-2", simpleClusterWide),
+		},
+	},
+	{
 		name: "creating multi-tenant SMCP when cluster-wide SMCP exists - expected error",
 		smcp: simpleMultiTenant,
 		existingObjs: []*maistrav2.ServiceMeshControlPlane{

--- a/pkg/controller/versions/strategy_v2_5_test.go
+++ b/pkg/controller/versions/strategy_v2_5_test.go
@@ -319,7 +319,8 @@ var testCases = []validationTestCase{
 		expectedErr: fmt.Errorf("cannot create cluster-wide SMCP with overlapping caCertConfigMapName"),
 	},
 	{
-		name: "creating simple cluster-wide SMCP with default CA config map name when cluster-wide gateway controller with default CA config map name exists - error expected",
+		name: "creating simple cluster-wide SMCP with default CA config map name when cluster-wide gateway controller " +
+			"with default CA config map name exists - error expected",
 		smcp: simpleClusterWide,
 		existingObjs: []*maistrav2.ServiceMeshControlPlane{
 			NewV2SMCPResource("basic", "istio-system-1", clusterWideGatewayControllerDefaultCA),
@@ -327,7 +328,8 @@ var testCases = []validationTestCase{
 		expectedErr: fmt.Errorf("cannot create cluster-wide SMCP with overlapping caCertConfigMapName"),
 	},
 	{
-		name: "creating simple cluster-wide SMCP with default CA config map name when cluster-wide gateway controller with default CA config map name exists - error expected (2nd execution)",
+		name: "creating simple cluster-wide SMCP with default CA config map name when cluster-wide gateway controller " +
+			"with default CA config map name exists - error expected (2nd execution)",
 		smcp: simpleClusterWide,
 		existingObjs: []*maistrav2.ServiceMeshControlPlane{
 			NewV2SMCPResource("basic", "istio-system-1", clusterWideGatewayControllerDefaultCA),
@@ -359,7 +361,7 @@ func TestValidateV2(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			c := newFakeClient(tc.existingObjs)
 			v := versionStrategyV2_5{Ver: V2_5}
-			err := v.ValidateV2(context.TODO(), c, &metav1.ObjectMeta{Name: "basic", Namespace: "istio-sytem", UID: uuids[tc.smcp]}, tc.smcp)
+			err := v.ValidateV2(context.TODO(), c, &metav1.ObjectMeta{Name: "basic", Namespace: "istio-system", UID: uuids[tc.smcp]}, tc.smcp)
 
 			if tc.expectedErr == nil {
 				assert.Nil(err, "unexpected error occurred", t)

--- a/pkg/controller/versions/strategy_v2_5_test.go
+++ b/pkg/controller/versions/strategy_v2_5_test.go
@@ -252,7 +252,6 @@ var testCases = []validationTestCase{
 		},
 		expectedErr: fmt.Errorf("a cluster-scoped SMCP may only be created when no other SMCPs exist"),
 	},
-	// TODO: Create multi-tenant SMCP when cluster-wide gateway controller exists - no errors
 	{
 		name: "creating multi-tenant SMCP when cluster-wide SMCP exists - expected error",
 		smcp: simpleMultiTenant,
@@ -269,6 +268,21 @@ var testCases = []validationTestCase{
 			NewV2SMCPResource("basic", "istio-system-2", simpleMultiTenant),
 		},
 		expectedErr: fmt.Errorf("no other SMCPs may be created when a cluster-scoped SMCP exists"),
+	},
+	{
+		name: "creating multi-tenant SMCP when cluster-wide gateway controller exists - no errors",
+		smcp: simpleMultiTenant,
+		existingObjs: []*maistrav2.ServiceMeshControlPlane{
+			NewV2SMCPResource("basic", "istio-system-1", clusterWideGatewayController),
+		},
+	},
+	{
+		name: "creating multi-tenant SMCP when cluster-wide gateway controller exists - no errors (2nd execution)",
+		smcp: simpleMultiTenant,
+		existingObjs: []*maistrav2.ServiceMeshControlPlane{
+			NewV2SMCPResource("basic", "istio-system-1", simpleMultiTenant),
+			NewV2SMCPResource("basic", "istio-system-2", clusterWideGatewayController),
+		},
 	},
 }
 

--- a/pkg/controller/versions/strategy_v2_5_test.go
+++ b/pkg/controller/versions/strategy_v2_5_test.go
@@ -83,7 +83,7 @@ var testCases = []validationTestCase{
 	// TODO: add test cases where 2 multi-tenant control planes already exist
 	{
 		name: "creating multi-tenant SMCP when no other SMCPs exists - no errors",
-		smcp: newSmcpSpec(`mode: ClusterWide`),
+		smcp: simpleMultiTenant,
 	},
 	{
 		name: "creating multi-tenant SMCP when another multi-tenant already exists - no errors",

--- a/pkg/controller/versions/strategy_v2_5_test.go
+++ b/pkg/controller/versions/strategy_v2_5_test.go
@@ -37,6 +37,7 @@ func NewV2SMCPResource(name, namespace string, spec *maistrav2.ControlPlaneSpec)
 var (
 	simpleMultiTenant  = newSmcpSpec("mode: MultiTenant")
 	simpleMultiTenant2 = simpleMultiTenant.DeepCopy()
+	simpleMultiTenant3 = simpleMultiTenant.DeepCopy()
 	simpleClusterWide  = newSmcpSpec("mode: ClusterWide")
 	simpleClusterWide2 = simpleClusterWide.DeepCopy()
 
@@ -66,6 +67,7 @@ techPreview:
 	uuids = map[*maistrav2.ControlPlaneSpec]types.UID{
 		simpleMultiTenant:                     uuid.NewUUID(),
 		simpleMultiTenant2:                    uuid.NewUUID(),
+		simpleMultiTenant3:                    uuid.NewUUID(),
 		simpleClusterWide:                     uuid.NewUUID(),
 		simpleClusterWide2:                    uuid.NewUUID(),
 		multiTenantGatewayController:          uuid.NewUUID(),
@@ -80,16 +82,16 @@ techPreview:
 // In other words, when an SMCP B is created when an SMCP A exists, ValidateV2 will be called twice and first call
 // to client.List will return [SMCP A] and next time it will return [SMCP A, SMCP B].
 var testCases = []validationTestCase{
-	// TODO: add test cases where 2 multi-tenant control planes already exist
 	{
 		name: "creating multi-tenant SMCP when no other SMCPs exists - no errors",
 		smcp: simpleMultiTenant,
 	},
 	{
-		name: "creating multi-tenant SMCP when another multi-tenant already exists - no errors",
+		name: "creating multi-tenant SMCP when others multi-tenant already exist - no errors",
 		smcp: simpleMultiTenant,
 		existingObjs: []*maistrav2.ServiceMeshControlPlane{
-			NewV2SMCPResource("basic", "istio-system-1", simpleMultiTenant2),
+			NewV2SMCPResource("basic", "istio-system-2", simpleMultiTenant2),
+			NewV2SMCPResource("basic", "istio-system-3", simpleMultiTenant3),
 		},
 	},
 	{

--- a/pkg/controller/versions/util.go
+++ b/pkg/controller/versions/util.go
@@ -77,6 +77,7 @@ func validateGlobal(ctx context.Context, version Ver, meta *metav1.ObjectMeta, s
 	}
 
 	if isClusterScoped {
+		// TODO(jewertow): allow to create more than 1 control plane if one of them is a gateway-controller; do not allow to create more than 1 gateway-controllers
 		// allow SMCP create/update only when no SMCP exists or when a single SMCP exists and we're updating it
 		if len(smcps.Items) > 1 || len(smcps.Items) == 1 && smcps.Items[0].UID != meta.GetUID() {
 			return append(allErrors,

--- a/pkg/controller/versions/util.go
+++ b/pkg/controller/versions/util.go
@@ -65,7 +65,7 @@ func checkDiscoverySelectorsNotSet(spec *v2.ControlPlaneSpec, allErrors []error)
 	return allErrors
 }
 
-func validateGlobal(ctx context.Context, version Ver, meta *metav1.ObjectMeta, newSmcp *v2.ControlPlaneSpec, cl client.Client, allErrors []error) []error {
+func validateGlobal(ctx context.Context, meta *metav1.ObjectMeta, newSmcp *v2.ControlPlaneSpec, cl client.Client, allErrors []error) []error {
 	smcps := v2.ServiceMeshControlPlaneList{}
 	err := cl.List(ctx, &smcps)
 	if err != nil {
@@ -115,7 +115,9 @@ func validateGlobal(ctx context.Context, version Ver, meta *metav1.ObjectMeta, n
 	return append(allErrors, validateOverlappingCaCertConfigMapNames(meta, newSmcp, &smcps, allErrors)...)
 }
 
-func validateOverlappingCaCertConfigMapNames(meta *metav1.ObjectMeta, newSmcp *v2.ControlPlaneSpec, smcps *v2.ServiceMeshControlPlaneList, allErrors []error) []error {
+func validateOverlappingCaCertConfigMapNames(
+	meta *metav1.ObjectMeta, newSmcp *v2.ControlPlaneSpec, smcps *v2.ServiceMeshControlPlaneList, allErrors []error,
+) []error {
 	overlappingCaCertNameErr := fmt.Errorf("cannot create cluster-wide SMCP with overlapping caCertConfigMapName")
 	for _, smcp := range smcps.Items {
 		if meta.GetUID() == smcp.GetUID() {

--- a/pkg/controller/versions/util.go
+++ b/pkg/controller/versions/util.go
@@ -91,8 +91,7 @@ func validateGlobal(ctx context.Context, meta *metav1.ObjectMeta, newSmcp *v2.Co
 			}
 		}
 		if len(smcps.Items) > 1 {
-			if newSmcp.IsGatewayController() && countGatewayControllers(smcps.Items) > 1 ||
-				!newSmcp.IsGatewayController() && countGatewayControllers(smcps.Items) == 0 {
+			if !newSmcp.IsGatewayController() && countGatewayControllers(smcps.Items) == 0 {
 				return append(allErrors, otherSmcpExists)
 			}
 		}

--- a/pkg/controller/versions/util.go
+++ b/pkg/controller/versions/util.go
@@ -80,7 +80,7 @@ func validateGlobal(ctx context.Context, version Ver, meta *metav1.ObjectMeta, s
 	if spec.IsClusterScoped() {
 		// do not allow creating more than one cluster-wide gateway controller
 		if len(smcps.Items) > 1 && countGatewayControllers(smcps.Items) > 1 ||
-			// do not allow creating more than one cluster-wide SMCPs
+			// do not allow creating more than one cluster-wide SMCP
 			len(smcps.Items) > 1 && !isGatewayController && countGatewayControllers(smcps.Items) == 0 ||
 			// allow create/update SMCP when a single instance exists and we're updating it
 			len(smcps.Items) == 1 && smcps.Items[0].UID != meta.GetUID() {

--- a/pkg/controller/versions/util.go
+++ b/pkg/controller/versions/util.go
@@ -88,6 +88,7 @@ func validateGlobal(ctx context.Context, version Ver, meta *metav1.ObjectMeta, n
 					return append(allErrors, otherSmcpExists)
 				}
 			}
+			// only cluster-wide gateway controller can be created when other SMCP exist
 			if !newSmcp.IsGatewayController() {
 				return append(allErrors, otherSmcpExists)
 			}

--- a/pkg/controller/versions/util.go
+++ b/pkg/controller/versions/util.go
@@ -103,11 +103,7 @@ func validateGlobal(ctx context.Context, version Ver, meta *metav1.ObjectMeta, n
 			if smcp.UID == meta.GetUID() {
 				continue
 			}
-			clusterScoped, err := version.Strategy().IsClusterScoped(&smcp.Spec)
-			if err != nil {
-				return append(allErrors, err)
-			}
-			if clusterScoped {
+			if smcp.Spec.IsClusterScoped() && !smcp.Spec.IsGatewayController() {
 				return append(allErrors,
 					fmt.Errorf("no other SMCPs may be created when a cluster-scoped SMCP exists"))
 			}

--- a/pkg/controller/versions/util.go
+++ b/pkg/controller/versions/util.go
@@ -103,6 +103,7 @@ func validateGlobal(ctx context.Context, version Ver, meta *metav1.ObjectMeta, n
 			if smcp.UID == meta.GetUID() {
 				continue
 			}
+			// do not allow creating multi-tenant mesh when another (non-gateway controller) cluster-wide mesh already exists
 			if smcp.Spec.IsClusterScoped() && !smcp.Spec.IsGatewayController() {
 				return append(allErrors,
 					fmt.Errorf("no other SMCPs may be created when a cluster-scoped SMCP exists"))


### PR DESCRIPTION
This change aims to allow installing SMCP as a gateway controller and another one as a standard service mesh at the same time. What's more, service mesh should be allowed to be cluster-wide, even though the gateway controller is also cluster-wide, because if gateway controller would be pre-installed in the future, then cluster-wide SMCP could not be installed at all. Cluster-wide service mesh still makes sense, because users can narrow its scope using discovery selectors. There is a risk of overwriting istio-ca-root-cert config maps, so I added a validation which makes sure that 2 SMCPs can't be installed with the default config map name. Beside that we should require customizing the GatewayClass name, but it could be implemented in a follow-up.