### PR TITLE
OSSM-5812 Ensure CNI is deployed when using the openshift profile

### DIFF
--- a/controllers/istiorevision/istiorevision_controller.go
+++ b/controllers/istiorevision/istiorevision_controller.go
@@ -241,6 +241,13 @@ func (r *IstioRevisionReconciler) isOldestRevisionWithCNI(ctx context.Context, r
 }
 
 func isCNIEnabled(values helm.HelmValues) (bool, error) {
+	// TODO: remove this temporary hack when we introduce Istio.spec.components.cni.enabled
+	if profile, _, err := values.GetString("profile"); err != nil {
+		return false, err
+	} else if profile == "openshift" {
+		return true, nil
+	}
+
 	enabled, _, err := values.GetBool("istio_cni.enabled")
 	return enabled, err
 }


### PR DESCRIPTION
Previously, when the openshift profile was selected, all the required values were added to the IstioRevision. However, upstream Istio has since changed this. Values from the profiles are now applied when the charts are rendered. This means that the operator can no longer check the IstioRevision.spec.values.cni.enabled field to determine whether it should deploy CNI. Instead, it should check IstioRevision.spec.components.cni.enabled, but we don't yet have the components field.

As a temporary solution, the operator will now also deploy CNI if the profile is set to "openshift".