### PR TITLE
OSSM-5685 Support offline installation through default image digests

### DIFF
--- a/chart/templates/auth_proxy_service.yaml
+++ b/chart/templates/auth_proxy_service.yaml
@@ -4,12 +4,12 @@ metadata:
   labels:
     app.kubernetes.io/component: kube-rbac-proxy
     app.kubernetes.io/created-by: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ .Values.deploymentName }}-metrics-service
+    app.kubernetes.io/instance: {{ .Values.deployment.name }}-metrics-service
     app.kubernetes.io/managed-by: helm
     app.kubernetes.io/name: service
     app.kubernetes.io/part-of: {{ .Values.name }}
-    control-plane: {{ .Values.deploymentName }}
-  name: {{ .Values.deploymentName }}-metrics-service
+    control-plane: {{ .Values.deployment.name }}
+  name: {{ .Values.deployment.name }}-metrics-service
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
@@ -20,4 +20,4 @@ spec:
   selector:
     app.kubernetes.io/created-by: {{ .Values.name }}
     app.kubernetes.io/part-of: {{ .Values.name }}
-    control-plane: {{ .Values.deploymentName }}
+    control-plane: {{ .Values.deployment.name }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -4,12 +4,12 @@ metadata:
   labels:
     app.kubernetes.io/component: manager
     app.kubernetes.io/created-by: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ .Values.deploymentName }}
+    app.kubernetes.io/instance: {{ .Values.deployment.name }}
     app.kubernetes.io/managed-by: helm
     app.kubernetes.io/name: deployment
     app.kubernetes.io/part-of: {{ .Values.name }}
-    control-plane: {{ .Values.deploymentName }}
-  name: {{ .Values.deploymentName }}
+    control-plane: {{ .Values.deployment.name }}
+  name: {{ .Values.deployment.name }}
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
@@ -17,16 +17,19 @@ spec:
     matchLabels:
       app.kubernetes.io/created-by: {{ .Values.name }}
       app.kubernetes.io/part-of: {{ .Values.name }}
-      control-plane: {{ .Values.deploymentName }}
+      control-plane: {{ .Values.deployment.name }}
   strategy: {}
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
+{{- range $key, $val := .Values.deployment.annotations }}
+        {{ $key | quote }}: {{ $val | quote}}
+{{- end }}
       labels:
         app.kubernetes.io/created-by: {{ .Values.name }}
         app.kubernetes.io/part-of: {{ .Values.name }}
-        control-plane: {{ .Values.deploymentName }}
+        control-plane: {{ .Values.deployment.name }}
     spec:
       affinity:
         nodeAffinity:

--- a/chart/templates/namespace.yaml
+++ b/chart/templates/namespace.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: {{ .Values.deploymentName }}
+    control-plane: {{ .Values.deployment.name }}
     app.kubernetes.io/name: namespace
     app.kubernetes.io/instance: {{ .Release.Namespace }}
     app.kubernetes.io/component: manager

--- a/chart/templates/rbac/auth_proxy_role_binding.yaml
+++ b/chart/templates/rbac/auth_proxy_role_binding.yaml
@@ -13,5 +13,5 @@ roleRef:
   name: {{ .Values.name }}-proxy-role
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.deploymentName }}
+  name: {{ .Values.deployment.name }}
   namespace: {{ .Release.Namespace }}

--- a/chart/templates/rbac/leader_election_role_binding.yaml
+++ b/chart/templates/rbac/leader_election_role_binding.yaml
@@ -14,5 +14,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.deploymentName }}
+  name: {{ .Values.deployment.name }}
   namespace: {{ .Release.Namespace }}

--- a/chart/templates/rbac/role_binding.yaml
+++ b/chart/templates/rbac/role_binding.yaml
@@ -13,5 +13,5 @@ roleRef:
   name: {{ .Values.name }}-role
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.deploymentName }}
+  name: {{ .Values.deployment.name }}
   namespace: {{ .Release.Namespace }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,5 +1,7 @@
 name: sailoperator
-deploymentName: istio-operator
+deployment:
+  name: istio-operator
+  annotations: {}
 service:
   port: 8443
 serviceAccountName: istio-operator

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -31,7 +31,16 @@ var (
 	RepositoryRoot = filepath.Join(filepath.Dir(b), "../../")
 )
 
-type OperatorConfig struct{}
+type OperatorConfig struct {
+	ImageDigests map[string]IstioImageConfig `properties:"images"`
+}
+
+type IstioImageConfig struct {
+	IstiodImage  string `properties:"istiod"`
+	ProxyImage   string `properties:"proxy"`
+	CNIImage     string `properties:"cni"`
+	ZTunnelImage string `properties:"ztunnel"`
+}
 
 func ReadConfig(configFile string) error {
 	p, err := properties.LoadFile(configFile, properties.UTF8)
@@ -47,5 +56,11 @@ func ReadConfig(configFile string) error {
 	if err != nil {
 		return err
 	}
+	// replace "_" in versions with "." and prefix with 'v' (e.g. 1_20_0 => v1.20.0)
+	newImageDigests := make(map[string]IstioImageConfig, len(Config.ImageDigests))
+	for k, v := range Config.ImageDigests {
+		newImageDigests["v"+strings.Replace(k, "_", ".", -1)] = v
+	}
+	Config.ImageDigests = newImageDigests
 	return nil
 }


### PR DESCRIPTION
This adds the support for defining default image digests in the operator config, similar to how it worked in 2.x - however, in this new implementation it is much easier for a user to overwrite an image/hub/tag for one component and still use the default images for other components.