### PR TITLE
OSSM-5815: Skip timestamp revert operation for untracked CSV

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -395,9 +395,11 @@ bundle: gen helm operator-sdk ## Generate bundle manifests and metadata, then va
 
 	# check if the only change in the CSV is the createdAt timestamp; if so, revert the change
 	@csvPath="bundle/manifests/${OPERATOR_NAME}.clusterserviceversion.yaml"; \
-		if ! (git diff "$$csvPath" | grep '^[+-][^+-][^+-]' | grep -v "createdAt:" >/dev/null); then \
-			echo "reverting timestamp change in $$csvPath"; \
-			git checkout "$$csvPath"; \
+		if (git ls-files --error-unmatch "$$csvPath" &>/dev/null); then \
+			if ! (git diff "$$csvPath" | grep '^[+-][^+-][^+-]' | grep -v "createdAt:" >/dev/null); then \
+				echo "reverting timestamp change in $$csvPath"; \
+				git checkout "$$csvPath"; \
+			fi \
 		fi
 	$(OPERATOR_SDK) bundle validate ./bundle
 


### PR DESCRIPTION
When renaming operator, newly generated CSV is not yet tracked by git so the timestamp revert attempt is failing. This is to skip that for new untracked CSV.