### PR TITLE
OSSM-5845 Clean up Helm logging

### DIFF
--- a/controllers/istiorevision/istiorevision_controller.go
+++ b/controllers/istiorevision/istiorevision_controller.go
@@ -114,7 +114,7 @@ func (r *IstioRevisionReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	if rev.DeletionTimestamp != nil {
-		if err := r.uninstallHelmCharts(&rev); err != nil {
+		if err := r.uninstallHelmCharts(ctx, &rev); err != nil {
 			return ctrl.Result{}, err
 		}
 
@@ -208,12 +208,12 @@ func (r *IstioRevisionReconciler) installHelmCharts(ctx context.Context, rev *v1
 	return nil
 }
 
-func (r *IstioRevisionReconciler) uninstallHelmCharts(rev *v1alpha1.IstioRevision) error {
-	if err := helm.UninstallCharts(r.RestClientGetter, []string{"cni"}, cniReleaseNameBase, r.CNINamespace); err != nil {
+func (r *IstioRevisionReconciler) uninstallHelmCharts(ctx context.Context, rev *v1alpha1.IstioRevision) error {
+	if err := helm.UninstallCharts(ctx, r.RestClientGetter, []string{"cni"}, cniReleaseNameBase, r.CNINamespace); err != nil {
 		return err
 	}
 
-	if err := helm.UninstallCharts(r.RestClientGetter, userCharts, rev.Name, rev.Spec.Namespace); err != nil {
+	if err := helm.UninstallCharts(ctx, r.RestClientGetter, userCharts, rev.Name, rev.Spec.Namespace); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/helm/charts.go
+++ b/pkg/helm/charts.go
@@ -31,13 +31,10 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-var (
-	log                  = logf.Log.WithName("helm")
-	ResourceDirectory, _ = filepath.Abs("resources")
-)
+var ResourceDirectory, _ = filepath.Abs("resources")
 
-func UninstallCharts(restClientGetter genericclioptions.RESTClientGetter, charts []string, releaseNameBase, ns string) error {
-	actionConfig, err := newActionConfig(restClientGetter, ns)
+func UninstallCharts(ctx context.Context, restClientGetter genericclioptions.RESTClientGetter, charts []string, releaseNameBase, ns string) error {
+	actionConfig, err := newActionConfig(ctx, restClientGetter, ns)
 	if err != nil {
 		return err
 	}
@@ -55,7 +52,7 @@ func UpgradeOrInstallCharts(ctx context.Context, restClientGetter genericcliopti
 	charts []string, values HelmValues,
 	chartVersion, releaseNameBase, ns string, ownerReference metav1.OwnerReference,
 ) error {
-	actionConfig, err := newActionConfig(restClientGetter, ns)
+	actionConfig, err := newActionConfig(ctx, restClientGetter, ns)
 	if err != nil {
 		return err
 	}
@@ -70,9 +67,10 @@ func UpgradeOrInstallCharts(ctx context.Context, restClientGetter genericcliopti
 }
 
 // newActionConfig Create a new Helm action config from in-cluster service account
-func newActionConfig(restClientGetter genericclioptions.RESTClientGetter, namespace string) (*action.Configuration, error) {
+func newActionConfig(ctx context.Context, restClientGetter genericclioptions.RESTClientGetter, namespace string) (*action.Configuration, error) {
 	actionConfig := new(action.Configuration)
 	logAdapter := func(format string, v ...interface{}) {
+		log := logf.FromContext(ctx)
 		logv2 := log.V(2)
 		if logv2.Enabled() {
 			logv2.Info(fmt.Sprintf(format, v...))
@@ -89,6 +87,8 @@ func upgradeOrInstallChart(ctx context.Context, cfg *action.Configuration,
 	chartName, chartVersion, namespace, releaseName string,
 	ownerReference metav1.OwnerReference, values HelmValues,
 ) (*release.Release, error) {
+	log := logf.FromContext(ctx)
+
 	// Helm List Action
 	listAction := action.NewList(cfg)
 	releases, err := listAction.Run()


### PR DESCRIPTION
Ensure that the context-aware logger is used for all log statements logged by Helm.