### PR TITLE
OSSM-5685 Don't automatically prefix versions with 'v'

### DIFF
--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -56,10 +56,10 @@ func ReadConfig(configFile string) error {
 	if err != nil {
 		return err
 	}
-	// replace "_" in versions with "." and prefix with 'v' (e.g. 1_20_0 => v1.20.0)
+	// replace "_" in versions with "." (e.g. v1_20_0 => v1.20.0)
 	newImageDigests := make(map[string]IstioImageConfig, len(Config.ImageDigests))
 	for k, v := range Config.ImageDigests {
-		newImageDigests["v"+strings.Replace(k, "_", ".", -1)] = v
+		newImageDigests[strings.Replace(k, "_", ".", -1)] = v
 	}
 	Config.ImageDigests = newImageDigests
 	return nil

--- a/pkg/common/config_test.go
+++ b/pkg/common/config_test.go
@@ -1,0 +1,115 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var testImages = IstioImageConfig{
+	IstiodImage:  "istiod-test",
+	ProxyImage:   "proxy-test",
+	CNIImage:     "cni-test",
+	ZTunnelImage: "ztunnel-test",
+}
+
+func TestReadConfig(t *testing.T) {
+	testCases := []struct {
+		name           string
+		configFile     string
+		expectedConfig OperatorConfig
+		success        bool
+	}{
+		{
+			name: "single-version",
+			configFile: `
+images.v1_20_0.istiod=istiod-test
+images.v1_20_0.proxy=proxy-test
+images.v1_20_0.cni=cni-test
+images.v1_20_0.ztunnel=ztunnel-test
+`,
+			expectedConfig: OperatorConfig{
+				ImageDigests: map[string]IstioImageConfig{
+					"v1.20.0": testImages,
+				},
+			},
+			success: true,
+		},
+		{
+			name: "multiple-versions",
+			configFile: `
+images.v1_20_0.istiod=istiod-test
+images.v1_20_0.proxy=proxy-test
+images.v1_20_0.cni=cni-test
+images.v1_20_0.ztunnel=ztunnel-test
+images.v1_20_1.istiod=istiod-test
+images.v1_20_1.proxy=proxy-test
+images.v1_20_1.cni=cni-test
+images.v1_20_1.ztunnel=ztunnel-test
+images.latest.istiod=istiod-test
+images.latest.proxy=proxy-test
+images.latest.cni=cni-test
+images.latest.ztunnel=ztunnel-test
+`,
+			expectedConfig: OperatorConfig{
+				ImageDigests: map[string]IstioImageConfig{
+					"v1.20.0": testImages,
+					"v1.20.1": testImages,
+					"latest":  testImages,
+				},
+			},
+			success: true,
+		},
+		{
+			name: "missing-proxy",
+			configFile: `
+images.v1_20_0.istiod=istiod-test
+images.v1_20_0.cni=cni-test
+images.v1_20_0.ztunnel=ztunnel-test
+`,
+			success: false,
+		},
+	}
+	for _, tc := range testCases {
+		file, err := os.CreateTemp("", "operator-unit-")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			err = file.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+			os.Remove(file.Name())
+		}()
+
+		file.WriteString(tc.configFile)
+		err = ReadConfig(file.Name())
+		if !tc.success {
+			if err != nil {
+				return
+			}
+			t.Fatal("expected error but got:", err)
+		} else if err != nil {
+			t.Fatal("expected no error but got:", err)
+		}
+		if diff := cmp.Diff(Config, tc.expectedConfig); diff != "" {
+			t.Fatal("config did not match expectation:\n\n", diff)
+		}
+	}
+}


### PR DESCRIPTION
I'm changing the logic slightly to not prefix the `v` anymore, which is helpful if we want to have default images for non-standard versions, like `latest` - but also better because it is more explicit (less magic). While I'm at it, I'm adding tests.