### PR TITLE
OSSM-5849 - add infrastructure feature related annotations

### DIFF
--- a/build/generate-manifests.sh
+++ b/build/generate-manifests.sh
@@ -26,16 +26,16 @@ if [[ ${COMMUNITY} == "true" ]]; then
   OLM_FEATURES="[]"
   ARCHITECTURE_LABELS=$(generateArchitectureLabels amd64)
   OLM_SUBSCRIPTION_ANNOTATION=""
-  OLM_FEATURE_DISCONNECTED='"false"'
-  OLM_FEATURE_FIPS_COMPLIANT='"false"'
-  OLM_FEATURE_PROXY_AWARE='"true"'
-  OLM_FEATURE_TLS_PROFILES='"false"'
-  OLM_FEATURE_TOKEN_AUTH_AWS='"false"'
-  OLM_FEATURE_TOKEN_AUTH_AZURE='"false"'
-  OLM_FEATURE_TOKEN_AUTH_GCP='"false"'
-  OLM_FEATURE_CNF='"false"'
-  OLM_FEATURE_CNI='"true"'
-  OLM_FEATURE_CSI='"false"'
+  OLM_FEATURE_DISCONNECTED="false"
+  OLM_FEATURE_FIPS_COMPLIANT="false"
+  OLM_FEATURE_PROXY_AWARE="true"
+  OLM_FEATURE_TLS_PROFILES="false"
+  OLM_FEATURE_TOKEN_AUTH_AWS="false"
+  OLM_FEATURE_TOKEN_AUTH_AZURE="false"
+  OLM_FEATURE_TOKEN_AUTH_GCP="false"
+  OLM_FEATURE_CNF="false"
+  OLM_FEATURE_CNI="true"
+  OLM_FEATURE_CSI="false"
 else
   BUILD_TYPE="servicemesh"
   JAEGER_STORAGE="Memory"
@@ -47,16 +47,16 @@ else
   OLM_FEATURES="[\"Disconnected\",\"fips\"]"
   ARCHITECTURE_LABELS=$(generateArchitectureLabels amd64 s390x ppc64le arm64)
   OLM_SUBSCRIPTION_ANNOTATION="operators.openshift.io/valid-subscription: '[\"OpenShift Container Platform\", \"OpenShift Platform Plus\"]'"
-  OLM_FEATURE_DISCONNECTED='"true"'
-  OLM_FEATURE_FIPS_COMPLIANT='"true"'
-  OLM_FEATURE_PROXY_AWARE='"true"'
-  OLM_FEATURE_TLS_PROFILES='"false"'
-  OLM_FEATURE_TOKEN_AUTH_AWS='"false"'
-  OLM_FEATURE_TOKEN_AUTH_AZURE='"false"'
-  OLM_FEATURE_TOKEN_AUTH_GCP='"false"'
-  OLM_FEATURE_CNF='"false"'
-  OLM_FEATURE_CNI='"true"'
-  OLM_FEATURE_CSI='"false"'
+  OLM_FEATURE_DISCONNECTED="true"
+  OLM_FEATURE_FIPS_COMPLIANT="true"
+  OLM_FEATURE_PROXY_AWARE="true"
+  OLM_FEATURE_TLS_PROFILES="false"
+  OLM_FEATURE_TOKEN_AUTH_AWS="false"
+  OLM_FEATURE_TOKEN_AUTH_AZURE="false"
+  OLM_FEATURE_TOKEN_AUTH_GCP="false"
+  OLM_FEATURE_CNF="false"
+  OLM_FEATURE_CNI="true"
+  OLM_FEATURE_CSI="false"
   
 fi
 : "${DEPLOYMENT_FILE:=deploy/${BUILD_TYPE}-operator.yaml}"

--- a/build/generate-manifests.sh
+++ b/build/generate-manifests.sh
@@ -26,6 +26,16 @@ if [[ ${COMMUNITY} == "true" ]]; then
   OLM_FEATURES="[]"
   ARCHITECTURE_LABELS=$(generateArchitectureLabels amd64)
   OLM_SUBSCRIPTION_ANNOTATION=""
+  OLM_FEATURE_DISCONNECTED='"false"'
+  OLM_FEATURE_FIPS_COMPLIANT='"false"'
+  OLM_FEATURE_PROXY_AWARE='"true"'
+  OLM_FEATURE_TLS_PROFILES='"false"'
+  OLM_FEATURE_TOKEN_AUTH_AWS='"false"'
+  OLM_FEATURE_TOKEN_AUTH_AZURE='"false"'
+  OLM_FEATURE_TOKEN_AUTH_GCP='"false"'
+  OLM_FEATURE_CNF='"false"'
+  OLM_FEATURE_CNI='"true"'
+  OLM_FEATURE_CSI='"false"'
 else
   BUILD_TYPE="servicemesh"
   JAEGER_STORAGE="Memory"
@@ -37,6 +47,17 @@ else
   OLM_FEATURES="[\"Disconnected\",\"fips\"]"
   ARCHITECTURE_LABELS=$(generateArchitectureLabels amd64 s390x ppc64le arm64)
   OLM_SUBSCRIPTION_ANNOTATION="operators.openshift.io/valid-subscription: '[\"OpenShift Container Platform\", \"OpenShift Platform Plus\"]'"
+  OLM_FEATURE_DISCONNECTED='"true"'
+  OLM_FEATURE_FIPS_COMPLIANT='"true"'
+  OLM_FEATURE_PROXY_AWARE='"true"'
+  OLM_FEATURE_TLS_PROFILES='"false"'
+  OLM_FEATURE_TOKEN_AUTH_AWS='"false"'
+  OLM_FEATURE_TOKEN_AUTH_AZURE='"false"'
+  OLM_FEATURE_TOKEN_AUTH_GCP='"false"'
+  OLM_FEATURE_CNF='"false"'
+  OLM_FEATURE_CNI='"true"'
+  OLM_FEATURE_CSI='"false"'
+  
 fi
 : "${DEPLOYMENT_FILE:=deploy/${BUILD_TYPE}-operator.yaml}"
 : "${MANIFESTS_DIR:=manifests-${BUILD_TYPE}}"
@@ -115,6 +136,17 @@ $RELATED_IMAGES"
   sed -i -e 's+__BUG_URL__+'"$BUG_URL"'+' "${csv_path}"
   sed -i -e 's+__OLM_FEATURES__+'"$OLM_FEATURES"'+' "${csv_path}"
   sed -i -e 's+__OLM_SUBSCRIPTION_ANNOTATION__+'"$OLM_SUBSCRIPTION_ANNOTATION"'+' "${csv_path}"
+  sed -i -e 's+__OLM_FEATURE_DISCONNECTED__+'"$OLM_FEATURE_DISCONNECTED"'+' "${csv_path}"
+  sed -i -e 's+__OLM_FEATURE_FIPS_COMPLIANT__+'"$OLM_FEATURE_FIPS_COMPLIANT"'+' "${csv_path}"
+  sed -i -e 's+__OLM_FEATURE_PROXY_AWARE__+'"$OLM_FEATURE_PROXY_AWARE"'+' "${csv_path}"
+  sed -i -e 's+__OLM_FEATURE_TLS_PROFILES__+'"$OLM_FEATURE_TLS_PROFILES"'+' "${csv_path}"
+  sed -i -e 's+__OLM_FEATURE_TOKEN_AUTH_AWS__+'"$OLM_FEATURE_TOKEN_AUTH_AWS"'+' "${csv_path}"
+  sed -i -e 's+__OLM_FEATURE_TOKEN_AUTH_AZURE__+'"$OLM_FEATURE_TOKEN_AUTH_AZURE"'+' "${csv_path}"
+  sed -i -e 's+__OLM_FEATURE_TOKEN_AUTH_GCP__+'"$OLM_FEATURE_TOKEN_AUTH_GCP"'+' "${csv_path}"
+  sed -i -e 's+__OLM_FEATURE_TOKEN_AUTH_AWS__+'"$OLM_FEATURE_TOKEN_AUTH_AWS"'+' "${csv_path}"
+  sed -i -e 's+__OLM_FEATURE_CNF__+'"$OLM_FEATURE_CNF"'+' "${csv_path}"
+  sed -i -e 's+__OLM_FEATURE_CNI__+'"$OLM_FEATURE_CNI"'+' "${csv_path}"
+  sed -i -e 's+__OLM_FEATURE_CSI__+'"$OLM_FEATURE_CSI"'+' "${csv_path}"
   sed -i -e 's/__JAEGER_STORAGE__/'${JAEGER_STORAGE}'/' "${csv_path}"
   sed -i -e 's/__DATE__/'"$(date +%Y-%m-%dT%H:%M:%S%Z)"'/g' "${csv_path}"
   sed -i -e 's+__IMAGE_SRC__+'"${IMAGE_SRC}"'+g' "${csv_path}"

--- a/build/manifest-templates/clusterserviceversion.yaml
+++ b/build/manifest-templates/clusterserviceversion.yaml
@@ -19,16 +19,16 @@ metadata:
     olm.skipRange: ">=1.0.2 <__SEMANTIC_VERSION__"
     operators.openshift.io/infrastructure-features: '__OLM_FEATURES__'
     __OLM_SUBSCRIPTION_ANNOTATION__
-    features.operators.openshift.io/disconnected: __OLM_FEATURE_DISCONNECTED__
-    features.operators.openshift.io/fips-compliant: __OLM_FEATURE_FIPS_COMPLIANT__
-    features.operators.openshift.io/proxy-aware: __OLM_FEATURE_PROXY_AWARE__
-    features.operators.openshift.io/tls-profiles: __OLM_FEATURE_TLS_PROFILES__
-    features.operators.openshift.io/token-auth-aws: __OLM_FEATURE_TOKEN_AUTH_AWS__
-    features.operators.openshift.io/token-auth-azure: __OLM_FEATURE_TOKEN_AUTH_AZURE__
-    features.operators.openshift.io/token-auth-gcp: __OLM_FEATURE_TOKEN_AUTH_GCP__
-    features.operators.openshift.io/cnf: __OLM_FEATURE_CNF__
-    features.operators.openshift.io/cni: __OLM_FEATURE_CNI__
-    features.operators.openshift.io/csi: __OLM_FEATURE_CSI__
+    features.operators.openshift.io/disconnected: '__OLM_FEATURE_DISCONNECTED__'
+    features.operators.openshift.io/fips-compliant: '__OLM_FEATURE_FIPS_COMPLIANT__'
+    features.operators.openshift.io/proxy-aware: '__OLM_FEATURE_PROXY_AWARE__'
+    features.operators.openshift.io/tls-profiles: '__OLM_FEATURE_TLS_PROFILES__'
+    features.operators.openshift.io/token-auth-aws: '__OLM_FEATURE_TOKEN_AUTH_AWS__'
+    features.operators.openshift.io/token-auth-azure: '__OLM_FEATURE_TOKEN_AUTH_AZURE__'
+    features.operators.openshift.io/token-auth-gcp: '__OLM_FEATURE_TOKEN_AUTH_GCP__'
+    features.operators.openshift.io/cnf: '__OLM_FEATURE_CNF__'
+    features.operators.openshift.io/cni: '__OLM_FEATURE_CNI__'
+    features.operators.openshift.io/csi: '__OLM_FEATURE_CSI__'
     alm-examples: |-
       [
         {

--- a/build/manifest-templates/clusterserviceversion.yaml
+++ b/build/manifest-templates/clusterserviceversion.yaml
@@ -19,6 +19,16 @@ metadata:
     olm.skipRange: ">=1.0.2 <__SEMANTIC_VERSION__"
     operators.openshift.io/infrastructure-features: '__OLM_FEATURES__'
     __OLM_SUBSCRIPTION_ANNOTATION__
+    features.operators.openshift.io/disconnected: __OLM_FEATURE_DISCONNECTED__
+    features.operators.openshift.io/fips-compliant: __OLM_FEATURE_FIPS_COMPLIANT__
+    features.operators.openshift.io/proxy-aware: __OLM_FEATURE_PROXY_AWARE__
+    features.operators.openshift.io/tls-profiles: __OLM_FEATURE_TLS_PROFILES__
+    features.operators.openshift.io/token-auth-aws: __OLM_FEATURE_TOKEN_AUTH_AWS__
+    features.operators.openshift.io/token-auth-azure: __OLM_FEATURE_TOKEN_AUTH_AZURE__
+    features.operators.openshift.io/token-auth-gcp: __OLM_FEATURE_TOKEN_AUTH_GCP__
+    features.operators.openshift.io/cnf: __OLM_FEATURE_CNF__
+    features.operators.openshift.io/cni: __OLM_FEATURE_CNI__
+    features.operators.openshift.io/csi: __OLM_FEATURE_CSI__
     alm-examples: |-
       [
         {

--- a/manifests-maistra/2.5.0/maistraoperator.v2.5.0.clusterserviceversion.yaml
+++ b/manifests-maistra/2.5.0/maistraoperator.v2.5.0.clusterserviceversion.yaml
@@ -15,21 +15,21 @@ metadata:
       The Maistra Operator enables you to install, configure, and manage an instance of Maistra service mesh. Maistra is based on the open source Istio project.
 
     containerImage: quay.io/maistra/istio-ubi8-operator:2.5.0
-    createdAt: 2024-02-09T12:11:22GMT
+    createdAt: 2024-02-09T14:17:19GMT
     support: Red Hat, Inc. 
     olm.skipRange: ">=1.0.2 <2.5.0-0"
     operators.openshift.io/infrastructure-features: '[]'
     
-    features.operators.openshift.io/disconnected: "false"
-    features.operators.openshift.io/fips-compliant: "false"
-    features.operators.openshift.io/proxy-aware: "true"
-    features.operators.openshift.io/tls-profiles: "false"
-    features.operators.openshift.io/token-auth-aws: "false"
-    features.operators.openshift.io/token-auth-azure: "false"
-    features.operators.openshift.io/token-auth-gcp: "false"
-    features.operators.openshift.io/cnf: "false"
-    features.operators.openshift.io/cni: "true"
-    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/disconnected: 'false'
+    features.operators.openshift.io/fips-compliant: 'false'
+    features.operators.openshift.io/proxy-aware: 'true'
+    features.operators.openshift.io/tls-profiles: 'false'
+    features.operators.openshift.io/token-auth-aws: 'false'
+    features.operators.openshift.io/token-auth-azure: 'false'
+    features.operators.openshift.io/token-auth-gcp: 'false'
+    features.operators.openshift.io/cnf: 'false'
+    features.operators.openshift.io/cni: 'true'
+    features.operators.openshift.io/csi: 'false'
     alm-examples: |-
       [
         {

--- a/manifests-maistra/2.5.0/maistraoperator.v2.5.0.clusterserviceversion.yaml
+++ b/manifests-maistra/2.5.0/maistraoperator.v2.5.0.clusterserviceversion.yaml
@@ -15,11 +15,21 @@ metadata:
       The Maistra Operator enables you to install, configure, and manage an instance of Maistra service mesh. Maistra is based on the open source Istio project.
 
     containerImage: quay.io/maistra/istio-ubi8-operator:2.5.0
-    createdAt: 2023-10-05T22:49:57CEST
+    createdAt: 2024-02-09T12:11:22GMT
     support: Red Hat, Inc. 
     olm.skipRange: ">=1.0.2 <2.5.0-0"
     operators.openshift.io/infrastructure-features: '[]'
     
+    features.operators.openshift.io/disconnected: "false"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "true"
+    features.operators.openshift.io/csi: "false"
     alm-examples: |-
       [
         {

--- a/manifests-servicemesh/2.5.0/servicemeshoperator.v2.5.0.clusterserviceversion.yaml
+++ b/manifests-servicemesh/2.5.0/servicemeshoperator.v2.5.0.clusterserviceversion.yaml
@@ -18,21 +18,21 @@ metadata:
       The OpenShift Service Mesh Operator enables you to install, configure, and manage an instance of Red Hat OpenShift Service Mesh. OpenShift Service Mesh is based on the open source Istio project.
 
     containerImage: ${OSSM_OPERATOR_IMAGE}
-    createdAt: 2024-02-09T12:11:23GMT
+    createdAt: 2024-02-09T14:17:20GMT
     support: Red Hat, Inc. 
     olm.skipRange: ">=1.0.2 <2.5.0-0"
     operators.openshift.io/infrastructure-features: '["Disconnected","fips"]'
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
-    features.operators.openshift.io/disconnected: "true"
-    features.operators.openshift.io/fips-compliant: "true"
-    features.operators.openshift.io/proxy-aware: "true"
-    features.operators.openshift.io/tls-profiles: "false"
-    features.operators.openshift.io/token-auth-aws: "false"
-    features.operators.openshift.io/token-auth-azure: "false"
-    features.operators.openshift.io/token-auth-gcp: "false"
-    features.operators.openshift.io/cnf: "false"
-    features.operators.openshift.io/cni: "true"
-    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/disconnected: 'true'
+    features.operators.openshift.io/fips-compliant: 'true'
+    features.operators.openshift.io/proxy-aware: 'true'
+    features.operators.openshift.io/tls-profiles: 'false'
+    features.operators.openshift.io/token-auth-aws: 'false'
+    features.operators.openshift.io/token-auth-azure: 'false'
+    features.operators.openshift.io/token-auth-gcp: 'false'
+    features.operators.openshift.io/cnf: 'false'
+    features.operators.openshift.io/cni: 'true'
+    features.operators.openshift.io/csi: 'false'
     alm-examples: |-
       [
         {

--- a/manifests-servicemesh/2.5.0/servicemeshoperator.v2.5.0.clusterserviceversion.yaml
+++ b/manifests-servicemesh/2.5.0/servicemeshoperator.v2.5.0.clusterserviceversion.yaml
@@ -18,11 +18,21 @@ metadata:
       The OpenShift Service Mesh Operator enables you to install, configure, and manage an instance of Red Hat OpenShift Service Mesh. OpenShift Service Mesh is based on the open source Istio project.
 
     containerImage: ${OSSM_OPERATOR_IMAGE}
-    createdAt: 2023-10-05T22:49:58CEST
+    createdAt: 2024-02-09T12:11:23GMT
     support: Red Hat, Inc. 
     olm.skipRange: ">=1.0.2 <2.5.0-0"
     operators.openshift.io/infrastructure-features: '["Disconnected","fips"]'
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "true"
+    features.operators.openshift.io/csi: "false"
     alm-examples: |-
       [
         {


### PR DESCRIPTION

- Are the values for annotations correct?

- The Jira states that these new annotations are to replace: `operators.openshift.io/infrastructure-features` Should this be removed or is it required for older ocp versions?
