### PR TITLE
Fix missing resources in CRD cluster roles

### DIFF
--- a/pkg/bootstrap/crds.go
+++ b/pkg/bootstrap/crds.go
@@ -135,6 +135,12 @@ func installCRDRole(ctx context.Context, cl client.Client) error {
 				},
 			},
 		}
+
+		if role.role == "view" {
+			crdRole.Rules[0].APIGroups = append(crdRole.Rules[0].APIGroups, "federation.maistra.io", "telemetry.istio.io")
+			crdRole.Rules[1].Resources = append(crdRole.Rules[1].Resources, "servicemeshcontrolplanes", "servicemeshmembers", "servicemeshmemberrolls")
+		}
+
 		existingRole := crdRole.DeepCopy()
 		if err := cl.Get(ctx, client.ObjectKey{Name: crdRole.Name}, existingRole); err == nil {
 			if !reflect.DeepEqual(existingRole.Rules, crdRole.Rules) {


### PR DESCRIPTION
Fix missing resources in CRD cluster roles.
Assuming these were omitted on purpose (for security reasons?), they should at least be aggregated to view.