### PR TITLE
OSSM-5999: Set istio settings in custom Kiali resource automatically

### DIFF
--- a/pkg/controller/servicemesh/controlplane/addons.go
+++ b/pkg/controller/servicemesh/controlplane/addons.go
@@ -114,6 +114,20 @@ func (r *controlPlaneInstanceReconciler) patchKiali(ctx context.Context, grafana
 		}
 	}
 
+	// istio
+	if err := updatedKiali.Spec.SetField("external_services.istio.config_map_name", fmt.Sprintf("istio-%s", r.Instance.Name)); err != nil {
+		return common.RequeueWithError(errorOnSettingValueInKialiCR("external_services.istio.config_map_name", err))
+	}
+	if err := updatedKiali.Spec.SetField("external_services.istio.url_service_version", fmt.Sprintf("http://istiod-%s.%s:15014/version", r.Instance.Name, r.Instance.Namespace)); err != nil {
+		return common.RequeueWithError(errorOnSettingValueInKialiCR("external_services.istio.url_service_version", err))
+	}
+	if err := updatedKiali.Spec.SetField("external_services.istio.istiod_deployment_name", fmt.Sprintf("istiod-%s", r.Instance.Name)); err != nil {
+		return common.RequeueWithError(errorOnSettingValueInKialiCR("external_services.istio.istiod_deployment_name", err))
+	}
+	if err := updatedKiali.Spec.SetField("external_services.istio.istio_sidecar_injector_config_map_name", fmt.Sprintf("istio-sidecar-injector-%s", r.Instance.Name)); err != nil {
+		return common.RequeueWithError(errorOnSettingValueInKialiCR("external_services.istio.istio_sidecar_injector_config_map_name", err))
+	}
+
 	// FUTURE: add support for synchronizing kiali version with control plane version
 
 	if err := r.Client.Patch(ctx, updatedKiali, client.Merge); err != nil {

--- a/pkg/controller/servicemesh/controlplane/addons.go
+++ b/pkg/controller/servicemesh/controlplane/addons.go
@@ -115,16 +115,20 @@ func (r *controlPlaneInstanceReconciler) patchKiali(ctx context.Context, grafana
 	}
 
 	// istio
-	if err := updatedKiali.Spec.SetField("external_services.istio.config_map_name", fmt.Sprintf("istio-%s", r.Instance.Name)); err != nil {
+	configMapName := fmt.Sprintf("istio-%s", r.Instance.Name)
+	if err := updatedKiali.Spec.SetField("external_services.istio.config_map_name", configMapName); err != nil {
 		return common.RequeueWithError(errorOnSettingValueInKialiCR("external_services.istio.config_map_name", err))
 	}
-	if err := updatedKiali.Spec.SetField("external_services.istio.url_service_version", fmt.Sprintf("http://istiod-%s.%s:15014/version", r.Instance.Name, r.Instance.Namespace)); err != nil {
+	urlServiceAccount := fmt.Sprintf("http://istiod-%s.%s:15014/version", r.Instance.Name, r.Instance.Namespace)
+	if err := updatedKiali.Spec.SetField("external_services.istio.url_service_version", urlServiceAccount); err != nil {
 		return common.RequeueWithError(errorOnSettingValueInKialiCR("external_services.istio.url_service_version", err))
 	}
-	if err := updatedKiali.Spec.SetField("external_services.istio.istiod_deployment_name", fmt.Sprintf("istiod-%s", r.Instance.Name)); err != nil {
+	deploymentName := fmt.Sprintf("istiod-%s", r.Instance.Name)
+	if err := updatedKiali.Spec.SetField("external_services.istio.istiod_deployment_name", deploymentName); err != nil {
 		return common.RequeueWithError(errorOnSettingValueInKialiCR("external_services.istio.istiod_deployment_name", err))
 	}
-	if err := updatedKiali.Spec.SetField("external_services.istio.istio_sidecar_injector_config_map_name", fmt.Sprintf("istio-sidecar-injector-%s", r.Instance.Name)); err != nil {
+	sidecarInjectorName := fmt.Sprintf("istio-sidecar-injector-%s", r.Instance.Name)
+	if err := updatedKiali.Spec.SetField("external_services.istio.istio_sidecar_injector_config_map_name", sidecarInjectorName); err != nil {
 		return common.RequeueWithError(errorOnSettingValueInKialiCR("external_services.istio.istio_sidecar_injector_config_map_name", err))
 	}
 


### PR DESCRIPTION
This change will allow users to customize Prometheus settings in Kiali CR without other settings, like this:
```
apiVersion: kiali.io/v1alpha1
kind: Kiali
metadata:
  name: kiali-user-workload-monitoring
  namespace: istio-system
spec:
  external_services:
    prometheus:
      auth:
        token: secret:thanos-querier-web-token:token
        type: bearer
        use_kiali_token: false
      query_scope:
        mesh_id: "basic-istio-system"
      thanos_proxy:
        enabled: true
      url: https://thanos-querier.openshift-monitoring.svc.cluster.local:9091
```
instead of:
```
apiVersion: kiali.io/v1alpha1
kind: Kiali
metadata:
  name: kiali-user-workload-monitoring
  namespace: istio-system
spec:
  external_services:
    istio:
      config_map_name: istio-basic
      istio_sidecar_injector_config_map_name: istio-sidecar-injector-basic
      istiod_deployment_name: istiod-basic
      url_service_version: 'http://istiod-basic.istio-system:15014/version'
    prometheus:
      auth:
        token: secret:thanos-querier-web-token:token
        type: bearer
        use_kiali_token: false
      query_scope:
        mesh_id: "basic-istio-system"
      thanos_proxy:
        enabled: true
      url: https://thanos-querier.openshift-monitoring.svc.cluster.local:9091
  version: v1.65
```