### PR TITLE
Fix gen-check

### DIFF
--- a/resources/helm/v2.4/mesh-config/templates/telemetryv2_1.16.yaml
+++ b/resources/helm/v2.4/mesh-config/templates/telemetryv2_1.16.yaml
@@ -51,18 +51,10 @@ spec:
                     {{- end }}
                 vm_config:
                   vm_id: stats_outbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
-                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: envoy.wasm.stats
-                  {{- end }}
     - applyTo: HTTP_FILTER
       match:
         context: SIDECAR_INBOUND
@@ -98,18 +90,10 @@ spec:
                     {{- end }}
                 vm_config:
                   vm_id: stats_inbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
-                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: envoy.wasm.stats
-                  {{- end }}
     - applyTo: HTTP_FILTER
       match:
         context: GATEWAY
@@ -145,18 +129,10 @@ spec:
                     {{- end }}
                 vm_config:
                   vm_id: stats_outbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
-                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: envoy.wasm.stats
-                  {{- end }}
 ---
 # Note: tcp stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
@@ -206,18 +182,10 @@ spec:
                     {{- end }}
                 vm_config:
                   vm_id: tcp_stats_inbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
-                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: "envoy.wasm.stats"
-                  {{- end }}
     - applyTo: NETWORK_FILTER
       match:
         context: SIDECAR_OUTBOUND
@@ -250,18 +218,10 @@ spec:
                     {{- end }}
                 vm_config:
                   vm_id: tcp_stats_outbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
-                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: "envoy.wasm.stats"
-                  {{- end }}
     - applyTo: NETWORK_FILTER
       match:
         context: GATEWAY
@@ -294,18 +254,10 @@ spec:
                     {{- end }}
                 vm_config:
                   vm_id: tcp_stats_outbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
-                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: "envoy.wasm.stats"
-                  {{- end }}
 ---
 {{- end }}
 {{- if .Values.telemetry.v2.stackdriver.enabled }}

--- a/resources/helm/v2.5/mesh-config/templates/telemetryv2_1.16.yaml
+++ b/resources/helm/v2.5/mesh-config/templates/telemetryv2_1.16.yaml
@@ -54,18 +54,10 @@ spec:
                     {{- end }}
                 vm_config:
                   vm_id: stats_outbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
-                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: envoy.wasm.stats
-                  {{- end }}
     - applyTo: HTTP_FILTER
       match:
         context: SIDECAR_INBOUND
@@ -101,18 +93,10 @@ spec:
                     {{- end }}
                 vm_config:
                   vm_id: stats_inbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
-                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: envoy.wasm.stats
-                  {{- end }}
     - applyTo: HTTP_FILTER
       match:
         context: GATEWAY
@@ -148,18 +132,10 @@ spec:
                     {{- end }}
                 vm_config:
                   vm_id: stats_outbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
-                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: envoy.wasm.stats
-                  {{- end }}
 ---
 # Note: tcp stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
@@ -209,18 +185,10 @@ spec:
                     {{- end }}
                 vm_config:
                   vm_id: tcp_stats_inbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
-                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: "envoy.wasm.stats"
-                  {{- end }}
     - applyTo: NETWORK_FILTER
       match:
         context: SIDECAR_OUTBOUND
@@ -253,18 +221,10 @@ spec:
                     {{- end }}
                 vm_config:
                   vm_id: tcp_stats_outbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
-                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: "envoy.wasm.stats"
-                  {{- end }}
     - applyTo: NETWORK_FILTER
       match:
         context: GATEWAY
@@ -297,18 +257,10 @@ spec:
                     {{- end }}
                 vm_config:
                   vm_id: tcp_stats_outbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
-                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: "envoy.wasm.stats"
-                  {{- end }}
 ---
 {{- end }}
 {{/*TODO: this is broken, we do not handle the split quite right! */}}


### PR DESCRIPTION
https://github.com/maistra/istio-operator/pull/1651 fails, because https://github.com/maistra/istio-operator/pull/1654 was submitted later, so we have to update charts manually, because none of these PR can pass now.