### PR TITLE
Make scorecard test work in kind

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -148,9 +148,9 @@ export
 test: envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
 
-.PHONY: test.scorecard ## Runs the operator scorecard test. Needs a valid k8s cluster as pointed by the KUBECONFIG variable
+.PHONY: test.scorecard ## Runs the operator scorecard test.
 test.scorecard: operator-sdk
-	$(OPERATOR_SDK) scorecard bundle
+	OPERATOR_SDK=$(OPERATOR_SDK) ${SOURCE_DIR}/tests/scorecard-test.sh
 
 .PHONY: test.integration.ocp
 test.integration.ocp:

--- a/tests/integration/common-operator-integ-suite.sh
+++ b/tests/integration/common-operator-integ-suite.sh
@@ -210,7 +210,7 @@ main_test() {
       ${COMMAND} get pods -n "${NAMESPACE}" -o wide
       echo
       echo "Operator logs:"
-      ${COMMAND} logs deploy/istio-operator -n "${CONTROL_PLANE_NS}"
+      ${COMMAND} logs deploy/istio-operator -n "${NAMESPACE}"
       exit 1
     fi
 

--- a/tests/scorecard-test.sh
+++ b/tests/scorecard-test.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Copyright Istio Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eux -o pipefail
+
+SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT="$(dirname "${SCRIPTPATH}")"
+
+# shellcheck source=common/scripts/kind_provisioner.sh
+source "${ROOT}/common/scripts/kind_provisioner.sh"
+
+# Create a temporary kubeconfig
+KUBECONFIG="$(mktemp)"
+export KUBECONFIG
+
+# Create the kind cluster
+export KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
+export DEFAULT_CLUSTER_YAML="${ROOT}/tests/integration/config/default.yaml"
+export ARTIFACTS="${ARTIFACTS:-$(mktemp -d)}"
+export IP_FAMILY="${IP_FAMILY:-ipv4}"
+setup_kind_cluster "${KIND_CLUSTER_NAME}" "" "" "true" "true"
+
+kind export kubeconfig --name="${KIND_CLUSTER_NAME}"
+
+# Run the test
+OPERATOR_SDK="${OPERATOR_SDK:-operator-sdk}"
+${OPERATOR_SDK} scorecard --kubeconfig="${KUBECONFIG}" --namespace=default bundle


### PR DESCRIPTION
Previously, it relied on a k8s cluster to be setup in advance, which worked for us because this job used to run in an OCP cluster, therefore the cluster was always there, pointed by `$KUBECONFIG`.

In order to migrate to Istio Prow we need to run this job in a kind cluster, hence this PR.

Side benefit is that now we can run the test locally directly with `make test.scorecard`.