### PR TITLE
Fix printing of operator logs

### DIFF
--- a/tests/integration/common-operator-integ-suite.sh
+++ b/tests/integration/common-operator-integ-suite.sh
@@ -210,7 +210,7 @@ main_test() {
       ${COMMAND} get pods -n "${NAMESPACE}" -o wide
       echo
       echo "Operator logs:"
-      ${COMMAND} logs deploy/istio-operator -n "${CONTROL_PLANE_NS}"
+      ${COMMAND} logs deploy/istio-operator -n "${NAMESPACE}"
       exit 1
     fi
 


### PR DESCRIPTION
Little typo in https://github.com/maistra/istio-operator/pull/1662 prevented it from actually printing operator logs