### PR TITLE
OSSM-5541: istio-operator Pod keeps waiting for leader lease

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	"github.com/magiconair/properties"
@@ -27,7 +26,6 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
-	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -130,48 +128,12 @@ func main() {
 	}
 
 	ctx := context.Background()
-	c1 := make(chan error, 1)
+	// Become the leader before proceeding
+	err = leader.Become(ctx, "istio-operator-lock")
 
-	go func() {
-		// Become the leader before proceeding
-		c1 <- leader.Become(ctx, "istio-operator-lock")
-	}()
-
-	select {
-	case err := <-c1:
-		if err != nil {
-			log.Error(err, "")
-			os.Exit(1)
-		}
-		break
-
-	// OSSM-5541: Delete the existing configmap when leader selection timeout
-	case <-time.After(5 * time.Minute):
-		client, err := crclient.New(cfg, crclient.Options{})
-		if err != nil {
-			log.Error(err, "")
-		}
-
-		// Delete the existing lock from this pod, in case the node stopped
-		existing := &v1.ConfigMap{}
-		key := crclient.ObjectKey{Namespace: namespace, Name: "istio-operator-lock"}
-		err = client.Get(ctx, key, existing)
-		if err != nil {
-			log.Info("No pre-existing configmap istio-operator-lock was found.")
-		} else {
-			err = client.Delete(ctx, existing)
-			if err != nil {
-				log.Error(err, "Unknown error trying to delete existing ConfigMap.")
-			}
-		}
-
-		// Block until receiving a notification from leader.Become
-		err = <-c1
-
-		if err != nil {
-			log.Error(err, "")
-			os.Exit(1)
-		}
+	if err != nil {
+		log.Error(err, "")
+		os.Exit(1)
 	}
 
 	// Set default manager options

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -76,7 +76,8 @@ func main() {
 	pflag.BoolVar(&logAPIRequests, "logAPIRequests", false, "Log API requests performed by the operator.")
 
 	var leaderElect bool
-	pflag.BoolVar(&leaderElect, "leader-elect", true, "Enable leader election for this operator. Enabling this will ensure there is only one active controller manager.")
+	pflag.BoolVar(&leaderElect, "leader-elect", true, "Enable leader election for this operator. "+
+		"Enabling this will ensure there is only one active controller manager.")
 
 	// config file
 	configFile := ""

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -75,6 +75,9 @@ func main() {
 	var logAPIRequests bool
 	pflag.BoolVar(&logAPIRequests, "logAPIRequests", false, "Log API requests performed by the operator.")
 
+	var runLocalBuild bool
+	pflag.BoolVar(&runLocalBuild, "runLocalBuild", false, "Run the operator locally.")
+
 	// config file
 	configFile := ""
 	pflag.StringVar(&configFile, "config", "/etc/istio-operator/config.properties", "The root location of the user supplied templates.")
@@ -145,6 +148,11 @@ func main() {
 	if strings.Contains(namespace, ",") {
 		options.Namespace = ""
 		options.NewCache = cache.MultiNamespacedCacheBuilder(strings.Split(namespace, ","))
+	}
+
+	// When you run the operator locally in debug mode, turn off the leader election.
+	if runLocalBuild {
+		options.LeaderElection = false
 	}
 
 	// Create a new Cmd to provide shared dependencies and start components

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -76,7 +76,7 @@ func main() {
 	pflag.BoolVar(&logAPIRequests, "logAPIRequests", false, "Log API requests performed by the operator.")
 
 	var leaderElect bool
-	pflag.BoolVar(&leaderElect, "leader-elect", true, "Enable a leader election option in the operator manager.")
+	pflag.BoolVar(&leaderElect, "leader-elect", true, "Enable leader election for this operator. Enabling this will ensure there is only one active controller manager.")
 
 	// config file
 	configFile := ""
@@ -137,7 +137,7 @@ func main() {
 		Port:                   admissionControllerPort,
 		MetricsBindAddress:     net.JoinHostPort(metricsHost, fmt.Sprint(metricsPort)),
 		HealthProbeBindAddress: healthProbeBindAddress,
-		LeaderElection:         true,
+		LeaderElection:         leaderElect,
 		LeaderElectionID:       "istio-operator-lock",
 	}
 
@@ -148,11 +148,6 @@ func main() {
 	if strings.Contains(namespace, ",") {
 		options.Namespace = ""
 		options.NewCache = cache.MultiNamespacedCacheBuilder(strings.Split(namespace, ","))
-	}
-
-	// When you run the operator locally in debug mode, turn off the leader election.
-	if !leaderElect {
-		options.LeaderElection = false
 	}
 
 	// Create a new Cmd to provide shared dependencies and start components

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -75,8 +75,8 @@ func main() {
 	var logAPIRequests bool
 	pflag.BoolVar(&logAPIRequests, "logAPIRequests", false, "Log API requests performed by the operator.")
 
-	var runLocalBuild bool
-	pflag.BoolVar(&runLocalBuild, "runLocalBuild", false, "Run the operator locally.")
+	var leaderElect bool
+	pflag.BoolVar(&leaderElect, "leader-elect", true, "Enable a leader election option in the operator manager.")
 
 	// config file
 	configFile := ""
@@ -151,7 +151,7 @@ func main() {
 	}
 
 	// When you run the operator locally in debug mode, turn off the leader election.
-	if runLocalBuild {
+	if !leaderElect {
 		options.LeaderElection = false
 	}
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
-	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
 	"github.com/spf13/pflag"
@@ -128,13 +127,6 @@ func main() {
 	}
 
 	ctx := context.Background()
-	// Become the leader before proceeding
-	err = leader.Become(ctx, "istio-operator-lock")
-
-	if err != nil {
-		log.Error(err, "")
-		os.Exit(1)
-	}
 
 	// Set default manager options
 	options := manager.Options{
@@ -142,6 +134,8 @@ func main() {
 		Port:                   admissionControllerPort,
 		MetricsBindAddress:     net.JoinHostPort(metricsHost, fmt.Sprint(metricsPort)),
 		HealthProbeBindAddress: healthProbeBindAddress,
+		LeaderElection:         true,
+		LeaderElectionID:       "istio-operator-lock",
 	}
 
 	// Add support for MultiNamespace set in WATCH_NAMESPACE (e.g ns1,ns2)


### PR DESCRIPTION
This issue and workaround are described in OSSM-5541.
It was caused by the version of operator-sdk library we use in our operator.

The operator-sdk library leader selection method is waiting when the pod is not the leader.
However, in case a node stopped this causes a hanging of waiting.
reference: operator-sdk pkg/leader/leader.go Become  line 136

~I am adding a 5 minutes timeout case in our cmd/manager for that call.~

This PR replaces the leader election implementation with leader-with-lease option.  
reference: https://sdk.operatorframework.io/docs/building-operators/golang/advanced-topics/#leader-with-lease 