### PR TITLE
Remove error logging for expected failures, add requeues

### DIFF
--- a/controllers/istio/istio_controller_test.go
+++ b/controllers/istio/istio_controller_test.go
@@ -699,7 +699,7 @@ func TestReconcileActiveRevision(t *testing.T) {
 					cl := newFakeClientBuilder().WithObjects(initObjs...).Build()
 					reconciler := NewIstioReconciler(cl, scheme.Scheme, resourceDir, nil)
 
-					err := reconciler.reconcileActiveRevision(ctx, istio, &tc.istioValues)
+					_, err := reconciler.reconcileActiveRevision(ctx, istio, &tc.istioValues)
 					if err != nil {
 						t.Errorf("Expected no error, but got: %v", err)
 					}

--- a/controllers/istiorevision/istiorevision_controller.go
+++ b/controllers/istiorevision/istiorevision_controller.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
@@ -140,6 +141,10 @@ func (r *IstioRevisionReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	log.Info("Reconciliation done. Updating status.")
 	err = r.updateStatus(ctx, &rev, err)
+	if errors.IsConflict(err) {
+		log.Info("Status update failed. Requeuing reconciliation")
+		return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+	}
 
 	return ctrl.Result{}, err
 }


### PR DESCRIPTION
Previously, we were stack-tracing quite regularly in circumstances that are to be expected, especially in a two-controller setup like we have.

This also adds a requeue (with info log) for the rare case where we see the RESTMapper of the gc admission plugin being out of date. This mostly happened in CI - I wasn't able to reproduce locally, even after 50 attempts.