### PR TITLE
Prepare for fork

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -48,7 +48,7 @@ GIT_STATUS := $(shell git diff-index --quiet HEAD -- 2> /dev/null; if [ "$$?" = 
 endif
 
 # Linker flags for the go builds
-GO_MODULE ?= github.com/istio-ecosystem/sail-operator
+GO_MODULE = github.com/istio-ecosystem/sail-operator
 LD_EXTRAFLAGS  = -X ${GO_MODULE}/pkg/version.buildVersion=${VERSION}
 LD_EXTRAFLAGS += -X ${GO_MODULE}/pkg/version.buildGitRevision=${GIT_REVISION}
 LD_EXTRAFLAGS += -X ${GO_MODULE}/pkg/version.buildTag=${GIT_TAG}
@@ -303,17 +303,17 @@ ISTIO_REPO_BASE=https://raw.githubusercontent.com/istio/istio/0e7ecbd31f9524b063
 API_REPO_BASE=https://raw.githubusercontent.com/istio/api/ccd5cd40965ccba232d1f7c3b0e4ecacd0f6ceda
 .PHONY: gen-api
 gen-api: ## Generate API types from upstream files.
-	@# TODO: should we get these files from the local filesystem by inspecting go.mod?
-	@echo Generating API types from upstream files
-	@curl -sSLfo /tmp/values_types.pb.go $(ISTIO_REPO_BASE)/operator/pkg/apis/istio/v1alpha1/values_types.pb.go
-	@curl -sSLfo /tmp/config.pb.go $(API_REPO_BASE)/mesh/v1alpha1/config.pb.go
-	@curl -sSLfo /tmp/network.pb.go $(API_REPO_BASE)/mesh/v1alpha1/network.pb.go
-	@curl -sSLfo /tmp/proxy.pb.go $(API_REPO_BASE)/mesh/v1alpha1/proxy.pb.go
-	@curl -sSLfo /tmp/proxy_config.pb.go $(API_REPO_BASE)/networking/v1beta1/proxy_config.pb.go
-	@curl -sSLfo /tmp/selector.pb.go $(API_REPO_BASE)/type/v1beta1/selector.pb.go
-	@curl -sSLfo /tmp/destination_rule.pb.go $(API_REPO_BASE)/networking/v1alpha3/destination_rule.pb.go
-	@curl -sSLfo /tmp/virtual_service.pb.go $(API_REPO_BASE)/networking/v1alpha3/virtual_service.pb.go
-	@go run hack/api_transformer/main.go hack/api_transformer/transform.yaml
+	# TODO: should we get these files from the local filesystem by inspecting go.mod?
+	echo Generating API types from upstream files
+	curl -sSLfo /tmp/values_types.pb.go $(ISTIO_REPO_BASE)/operator/pkg/apis/istio/v1alpha1/values_types.pb.go
+	curl -sSLfo /tmp/config.pb.go $(API_REPO_BASE)/mesh/v1alpha1/config.pb.go
+	curl -sSLfo /tmp/network.pb.go $(API_REPO_BASE)/mesh/v1alpha1/network.pb.go
+	curl -sSLfo /tmp/proxy.pb.go $(API_REPO_BASE)/mesh/v1alpha1/proxy.pb.go
+	curl -sSLfo /tmp/proxy_config.pb.go $(API_REPO_BASE)/networking/v1beta1/proxy_config.pb.go
+	curl -sSLfo /tmp/selector.pb.go $(API_REPO_BASE)/type/v1beta1/selector.pb.go
+	curl -sSLfo /tmp/destination_rule.pb.go $(API_REPO_BASE)/networking/v1alpha3/destination_rule.pb.go
+	curl -sSLfo /tmp/virtual_service.pb.go $(API_REPO_BASE)/networking/v1alpha3/virtual_service.pb.go
+	go run hack/api_transformer/main.go hack/api_transformer/transform.yaml
 
 .PHONY: gen-code
 gen-code: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
@@ -520,7 +520,7 @@ lint: lint-scripts lint-copyright-banner lint-go lint-yaml lint-helm lint-bundle
 .PHONY: format
 format: format-go tidy-go ## Auto-format all code. This should be run before sending a PR.
 
-.SILENT: helm $(HELM) $(LOCALBIN) deploy-yaml
+.SILENT: helm $(HELM) $(LOCALBIN) deploy-yaml gen-api
 
 COMMON_IMPORTS ?= lint-all lint-scripts lint-copyright-banner lint-go lint-yaml lint-helm format-go tidy-go check-clean-repo update-common
 .PHONY: $(COMMON_IMPORTS)

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -12,16 +12,18 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 
-# VERSION defines the project version for the bundle.
-# Update this value when you upgrade the version of your project.
-# To re-generate a bundle for another specific version without changing the standard setup, you can:
-# - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
-# - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
+# Save the current, builtin variables so we can filter them out in the `print-variables` target
+OLD_VARS := $(.VARIABLES)
+
+# Most variables defined in this Makefile can be overriden in Makefile.vendor.mk
+# Use `make print-variables` to inspect the values of the variables
+-include Makefile.vendor.mk
+
 VERSION ?= 3.0.0
 MINOR_VERSION := $(shell v='$(VERSION)'; echo "$${v%.*}")
 
 OPERATOR_NAME ?= sailoperator
-
+VERSIONS_YAML_FILE ?= versions.yaml
 
 # Istio images names
 ISTIO_CNI_IMAGE_NAME ?= install-cni
@@ -46,7 +48,7 @@ GIT_STATUS := $(shell git diff-index --quiet HEAD -- 2> /dev/null; if [ "$$?" = 
 endif
 
 # Linker flags for the go builds
-GO_MODULE = github.com/istio-ecosystem/sail-operator
+GO_MODULE ?= github.com/istio-ecosystem/sail-operator
 LD_EXTRAFLAGS  = -X ${GO_MODULE}/pkg/version.buildVersion=${VERSION}
 LD_EXTRAFLAGS += -X ${GO_MODULE}/pkg/version.buildGitRevision=${GIT_REVISION}
 LD_EXTRAFLAGS += -X ${GO_MODULE}/pkg/version.buildTag=${GIT_TAG}
@@ -64,7 +66,7 @@ IMAGE ?= ${HUB}/${IMAGE_BASE}:${TAG}
 # Namespace to deploy the controller in
 NAMESPACE ?= sail-operator
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.26.0
+ENVTEST_K8S_VERSION ?= 1.29.0
 
 # Set DOCKER_BUILD_FLAGS to specify flags to pass to 'docker build', default to empty. Example: --platform=linux/arm64
 DOCKER_BUILD_FLAGS ?= "--platform=$(TARGET_OS)/$(TARGET_ARCH)"
@@ -113,13 +115,9 @@ ifeq ($(USE_IMAGE_DIGESTS), true)
 	BUNDLE_GEN_FLAGS += --use-image-digests
 endif
 
-# Default flags used when rendering chart templates locally
-HELM_TEMPL_DEF_FLAGS = --include-crds
-
-# VALUES_FILE defines a values file to be used to overwrite default values from chart
-ifdef VALUES_FILE
-	HELM_TEMPL_DEF_FLAGS += --values $(VALUES_FILE)
-endif
+# Default values and flags used when rendering chart templates locally
+HELM_VALUES_FILE ?= chart/values.yaml
+HELM_TEMPL_DEF_FLAGS ?= --include-crds --values $(HELM_VALUES_FILE)
 
 TODAY ?= $(shell date -I)
 
@@ -305,16 +303,17 @@ ISTIO_REPO_BASE=https://raw.githubusercontent.com/istio/istio/0e7ecbd31f9524b063
 API_REPO_BASE=https://raw.githubusercontent.com/istio/api/ccd5cd40965ccba232d1f7c3b0e4ecacd0f6ceda
 .PHONY: gen-api
 gen-api: ## Generate API types from upstream files.
-	# TODO: should we get these files from the local filesystem by inspecting go.mod?
-	curl -o /tmp/values_types.pb.go $(ISTIO_REPO_BASE)/operator/pkg/apis/istio/v1alpha1/values_types.pb.go
-	curl -o /tmp/config.pb.go $(API_REPO_BASE)/mesh/v1alpha1/config.pb.go
-	curl -o /tmp/network.pb.go $(API_REPO_BASE)/mesh/v1alpha1/network.pb.go
-	curl -o /tmp/proxy.pb.go $(API_REPO_BASE)/mesh/v1alpha1/proxy.pb.go
-	curl -o /tmp/proxy_config.pb.go $(API_REPO_BASE)/networking/v1beta1/proxy_config.pb.go
-	curl -o /tmp/selector.pb.go $(API_REPO_BASE)/type/v1beta1/selector.pb.go
-	curl -o /tmp/destination_rule.pb.go $(API_REPO_BASE)/networking/v1alpha3/destination_rule.pb.go
-	curl -o /tmp/virtual_service.pb.go $(API_REPO_BASE)/networking/v1alpha3/virtual_service.pb.go
-	go run hack/api_transformer/main.go hack/api_transformer/transform.yaml
+	@# TODO: should we get these files from the local filesystem by inspecting go.mod?
+	@echo Generating API types from upstream files
+	@curl -sSLfo /tmp/values_types.pb.go $(ISTIO_REPO_BASE)/operator/pkg/apis/istio/v1alpha1/values_types.pb.go
+	@curl -sSLfo /tmp/config.pb.go $(API_REPO_BASE)/mesh/v1alpha1/config.pb.go
+	@curl -sSLfo /tmp/network.pb.go $(API_REPO_BASE)/mesh/v1alpha1/network.pb.go
+	@curl -sSLfo /tmp/proxy.pb.go $(API_REPO_BASE)/mesh/v1alpha1/proxy.pb.go
+	@curl -sSLfo /tmp/proxy_config.pb.go $(API_REPO_BASE)/networking/v1beta1/proxy_config.pb.go
+	@curl -sSLfo /tmp/selector.pb.go $(API_REPO_BASE)/type/v1beta1/selector.pb.go
+	@curl -sSLfo /tmp/destination_rule.pb.go $(API_REPO_BASE)/networking/v1alpha3/destination_rule.pb.go
+	@curl -sSLfo /tmp/virtual_service.pb.go $(API_REPO_BASE)/networking/v1alpha3/virtual_service.pb.go
+	@go run hack/api_transformer/main.go hack/api_transformer/transform.yaml
 
 .PHONY: gen-code
 gen-code: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
@@ -325,7 +324,7 @@ gen-charts: ## Pull charts from istio repository.
 	@# use yq to generate a list of download-charts.sh commands for each version in versions.yaml; these commands are
 	@# passed to sh and executed; in a nutshell, the yq command generates commands like:
 	@# ./hack/download-charts.sh <version> <git repo> <commit> [chart1] [chart2] ...
-	@yq eval '.versions[] | "./hack/download-charts.sh " + .name + " " + .repo + " " + .commit + " " + ((.charts // []) | join(" "))' < versions.yaml | sh
+	@yq eval '.versions[] | "./hack/download-charts.sh " + .name + " " + .repo + " " + .commit + " " + ((.charts // []) | join(" "))' < $(VERSIONS_YAML_FILE) | sh
 
 	@# remove old version directories
 	@hack/remove-old-versions.sh
@@ -337,7 +336,7 @@ gen-charts: ## Pull charts from istio repository.
 	@hack/update-version-list.sh
 
 	@# calls copy-crds.sh with the version specified in the .crdSourceVersion field in versions.yaml
-	@hack/copy-crds.sh "resources/$$(yq eval '.crdSourceVersion' versions.yaml)/charts"
+	@hack/copy-crds.sh "resources/$$(yq eval '.crdSourceVersion' $(VERSIONS_YAML_FILE))/charts"
 
 .PHONY: gen
 gen: controller-gen gen-api gen-charts gen-manifests gen-code bundle ## Generate everything.
@@ -355,6 +354,13 @@ endif
 update-istio: ## Update the Istio commit hash in the 'latest' entry in versions.yaml to the latest commit in the branch.
 	@hack/update-istio.sh
 
+.PHONY: print-variables
+print-variables: ## Print all Makefile variables; Useful to inspect overrides of variables.
+	$(foreach v,                                        \
+  $(filter-out $(OLD_VARS) OLD_VARS,$(.VARIABLES)), \
+  $(info $(v) = $($(v))))
+	@echo
+
 ##@ Build Dependencies
 
 ## Location to install dependencies to
@@ -370,10 +376,10 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 OPM ?= $(LOCALBIN)/opm
 
 ## Tool Versions
-  OPERATOR_SDK_VERSION ?= v1.34.1
-  HELM_VERSION ?= v3.14.2
-  CONTROLLER_TOOLS_VERSION ?= v0.14.0
-  OPM_VERSION ?= v1.36.0
+OPERATOR_SDK_VERSION ?= v1.34.1
+HELM_VERSION ?= v3.14.2
+CONTROLLER_TOOLS_VERSION ?= v0.14.0
+OPM_VERSION ?= v1.36.0
 
 .PHONY: helm $(HELM)
 helm: $(HELM) ## Download helm to bin directory. If wrong version is installed, it will be overwritten.
@@ -405,7 +411,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup to bin directory.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	@test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 .PHONY: bundle
 bundle: gen helm operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
@@ -516,7 +522,7 @@ format: format-go tidy-go ## Auto-format all code. This should be run before sen
 
 .SILENT: helm $(HELM) $(LOCALBIN) deploy-yaml
 
-COMMON_IMPORTS = lint-all lint-scripts lint-copyright-banner lint-go lint-yaml lint-helm format-go tidy-go check-clean-repo update-common
+COMMON_IMPORTS ?= lint-all lint-scripts lint-copyright-banner lint-go lint-yaml lint-helm format-go tidy-go check-clean-repo update-common
 .PHONY: $(COMMON_IMPORTS)
 $(COMMON_IMPORTS):
 	@$(MAKE) --no-print-directory -f common/Makefile.common.mk $@

--- a/hack/patch-istio-crd.sh
+++ b/hack/patch-istio-crd.sh
@@ -14,13 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e -u
+set -euo pipefail
 
 CUR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+VERSIONS_YAML_FILE=${VERSIONS_YAML_FILE:-"versions.yaml"}
 
 : "${YQ:=yq}"
 : "${API_VERSION:=v1alpha1}"
-: "${VERSIONS_FILE:=${CUR_DIR}/../versions.yaml}"
 : "${CRD_FILE:=${CUR_DIR}/../chart/crds/operator.istio.io_istios.yaml}"
 
 values_yaml_path=".spec.versions.[] | select(.name == \"${API_VERSION}\") | .schema.openAPIV3Schema.properties.spec.properties.values"
@@ -47,7 +47,7 @@ function download_values_types_proto_file() {
 
   # Getting the values_types.proto url from the latest version
   # shellcheck disable=SC2016
-  values_types_proto_file_url="$(${YQ} '.crdSourceVersion as $crdSourceVersion | .versions[] | select(.name == $crdSourceVersion) | .repo + "/" + .commit + "/operator/pkg/apis/istio/v1alpha1/values_types.proto"' "${VERSIONS_FILE}"  | sed "s/github.com/raw.githubusercontent.com/")"
+  values_types_proto_file_url="$(${YQ} '.crdSourceVersion as $crdSourceVersion | .versions[] | select(.name == $crdSourceVersion) | .repo + "/" + .commit + "/operator/pkg/apis/istio/v1alpha1/values_types.proto"' "${VERSIONS_YAML_FILE}"  | sed "s/github.com/raw.githubusercontent.com/")"
   curl --silent "${values_types_proto_file_url}" --output "${dst_dir}/values_types.proto"
   echo "${dst_dir}/values_types.proto"
 }

--- a/hack/remove-old-versions.sh
+++ b/hack/remove-old-versions.sh
@@ -14,8 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -euo pipefail
+
+VERSIONS_YAML_FILE=${VERSIONS_YAML_FILE:-"versions.yaml"}
+
 function removeOldVersions() {
-    versions=$(yq eval '.versions[].name' versions.yaml | tr $'\n' ' ')
+    versions=$(yq eval '.versions[].name' "${VERSIONS_YAML_FILE}" | tr $'\n' ' ')
     for subdirectory in resources/*/; do
         version=$(basename "$subdirectory")
         if [[ ! " ${versions} " == *" $version "* ]]; then

--- a/hack/update-istio.sh
+++ b/hack/update-istio.sh
@@ -17,12 +17,13 @@
 set -euo pipefail
 
 SLEEP_TIME=10
+VERSIONS_YAML_FILE=${VERSIONS_YAML_FILE:-"versions.yaml"}
 
-COMMIT=$(yq '.versions[] | select(.name == "latest") | "git ls-remote --heads " + .repo + ".git " + .branch + " | cut -f 1"' versions.yaml | sh)
-CURRENT=$(yq '.versions[] | select(.name == "latest") | .commit' versions.yaml)
+COMMIT=$(yq '.versions[] | select(.name == "latest") | "git ls-remote --heads " + .repo + ".git " + .branch + " | cut -f 1"' "${VERSIONS_YAML_FILE}" | sh)
+CURRENT=$(yq '.versions[] | select(.name == "latest") | .commit' "${VERSIONS_YAML_FILE}")
 
 if [ "${COMMIT}" == "${CURRENT}" ]; then
-  echo "versions.yaml is already up-to-date with latest commit ${COMMIT}."
+  echo "${VERSIONS_YAML_FILE} is already up-to-date with latest commit ${COMMIT}."
   exit 0
 fi
 
@@ -39,7 +40,7 @@ echo
 FULL_VERSION=$(curl -sSfL "${URL}")
 echo Full version: "${FULL_VERSION}"
 
-yq -i '(.versions[] | select(.name == "latest") | .commit) = "'"${COMMIT}"'"' versions.yaml
+yq -i '(.versions[] | select(.name == "latest") | .commit) = "'"${COMMIT}"'"' "${VERSIONS_YAML_FILE}"
 yq -i '
     (.versions[] | select(.name == "latest") | .charts) = [
         "https://storage.googleapis.com/istio-build/dev/'"${FULL_VERSION}"'/helm/base-'"${FULL_VERSION}"'.tgz",
@@ -47,4 +48,4 @@ yq -i '
         "https://storage.googleapis.com/istio-build/dev/'"${FULL_VERSION}"'/helm/gateway-'"${FULL_VERSION}"'.tgz",
         "https://storage.googleapis.com/istio-build/dev/'"${FULL_VERSION}"'/helm/istiod-'"${FULL_VERSION}"'.tgz",
         "https://storage.googleapis.com/istio-build/dev/'"${FULL_VERSION}"'/helm/ztunnel-'"${FULL_VERSION}"'.tgz"
-    ]' versions.yaml
+    ]' "${VERSIONS_YAML_FILE}"

--- a/hack/update-profiles-list.sh
+++ b/hack/update-profiles-list.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -euo pipefail
+
 # generate a comma-separated list of all profiles across all versions in resources/
 profiles=$(find resources/*/profiles -type f -name "*.yaml" -print0 | xargs -0 -n1 basename | sort | uniq | sed 's/\.yaml$//' | tr $'\n' ',' | sed 's/,$//')
 

--- a/tests/integration/api/versions.go
+++ b/tests/integration/api/versions.go
@@ -29,7 +29,12 @@ var (
 )
 
 func init() {
-	versionsFile := filepath.Join("..", "..", "..", "versions.yaml")
+	versionsFile := os.Getenv("VERSIONS_YAML_FILE")
+	if len(versionsFile) == 0 {
+		versionsFile = "versions.yaml"
+	}
+	versionsFile = filepath.Join("..", "..", "..", versionsFile)
+
 	versionsBytes, err := os.ReadFile(versionsFile)
 	if err != nil {
 		panic(err)

--- a/tests/integration/common-operator-integ-suite.sh
+++ b/tests/integration/common-operator-integ-suite.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # To be able to run this script, it's needed to pass the flag --ocp or --kind
-set -eu -o pipefail
+set -euo pipefail
 
 check_arguments() {
   if [ $# -eq 0 ]; then
@@ -58,6 +58,7 @@ initialize_variables() {
   WD=$(dirname "$0")
   WD=$(cd "${WD}" || exit; pwd)
 
+  VERSIONS_YAML_FILE=${VERSIONS_YAML_FILE:-"versions.yaml"}
   NAMESPACE="${NAMESPACE:-sail-operator}"
   DEPLOYMENT_NAME="${DEPLOYMENT_NAME:-sail-operator}"
   CONTROL_PLANE_NS="${CONTROL_PLANE_NS:-istio-system}"
@@ -191,7 +192,7 @@ main_test() {
   check_ready "${NAMESPACE}" "${DEPLOYMENT_NAME}" "${DEPLOYMENT_NAME}"
   
   # Deploy and test every istio version inside versions.yaml
-  versions=$(yq eval '.versions[].name' versions.yaml)
+  versions=$(yq eval '.versions[].name' "${VERSIONS_YAML_FILE}")
   echo "Versions to test: ${versions//$'\n'/ }"
   for ver in ${versions}; do
     echo "--------------------------------------------------------------"


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/OSSM-5393

This prepares Makefile and scripts to rely on environment variables for certain values and files, instead of hard coding them.

It allows vendors to create a `Makefile.vendor.mk` to override variables.

Once we migrate to ecosystem and create the fork in our organization, we will change community values in the main repo (e.g. set `VERSION ?= 0.1`) in Makefile.core.mk and will have a `Makefile.vendor.mk` in the forked repo with contents similar to this:
```
VERSION = 3.0.0
OPERATOR_NAME = servicemeshoperator3
HUB = quay.io/maistra-dev
CHANNELS = 3.0
HELM_VALUES_FILE = chart/product-values.yaml
VERSIONS_YAML_FILE = product-versions.yaml
```