### PR TITLE
OSSM-6132 Split make test targets

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -143,9 +143,20 @@ export
 ##@ Testing
 
 .PHONY: test
-test: envtest ## Run unit tests.
+test: envtest ## Run both unit tests and integration test.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
 	go test $(VERBOSE_FLAG) ./... -coverprofile cover.out
+
+.PHONY: test.unit
+test.unit:  ## Run unit tests. This will exclude the integration tests.
+	$(eval TEST_PACKAGES=$(shell go list ./... | grep -v /tests/integration/))
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
+	go test $(VERBOSE_FLAG) $(TEST_PACKAGES) -coverprofile cover.out
+
+.PHONY: test.integration
+test.integration: ## Run integration tests located in the tests/integration directory.
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
+	go test $(VERBOSE_FLAG) ./tests/integration/... -coverprofile cover.out
 
 .PHONY: test.scorecard
 test.scorecard: operator-sdk ## Run the operator scorecard test.

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -143,18 +143,16 @@ export
 ##@ Testing
 
 .PHONY: test
-test: envtest ## Run both unit tests and integration test.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
-	go test $(VERBOSE_FLAG) ./... -coverprofile cover.out
+test: envtest test.unit test.integration ## Run both unit tests and integration test.
 
 .PHONY: test.unit
-test.unit:  ## Run unit tests. This will exclude the integration tests.
+test.unit: envtest  ## Run unit tests. This will exclude the integration tests.
 	$(eval TEST_PACKAGES=$(shell go list ./... | grep -v /tests/integration/))
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
 	go test $(VERBOSE_FLAG) $(TEST_PACKAGES) -coverprofile cover.out
 
 .PHONY: test.integration
-test.integration: ## Run integration tests located in the tests/integration directory.
+test.integration: envtest ## Run integration tests located in the tests/integration directory.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
 	go test $(VERBOSE_FLAG) ./tests/integration/... -coverprofile cover.out
 

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -143,11 +143,10 @@ export
 ##@ Testing
 
 .PHONY: test
-test: envtest test.unit test.integration ## Run both unit tests and integration test.
+test: test.unit test.integration ## Run both unit tests and integration test.
 
 .PHONY: test.unit
-test.unit: envtest  ## Run unit tests. This will exclude the integration tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
+test.unit:  ## Run unit tests.
 	go test $(VERBOSE_FLAG) ./... -coverprofile cover.out
 
 .PHONY: test.integration

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -147,14 +147,13 @@ test: envtest test.unit test.integration ## Run both unit tests and integration 
 
 .PHONY: test.unit
 test.unit: envtest  ## Run unit tests. This will exclude the integration tests.
-	$(eval TEST_PACKAGES=$(shell go list ./... | grep -v /tests/integration/))
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
-	go test $(VERBOSE_FLAG) $(TEST_PACKAGES) -coverprofile cover.out
+	go test $(VERBOSE_FLAG) ./... -coverprofile cover.out
 
 .PHONY: test.integration
 test.integration: envtest ## Run integration tests located in the tests/integration directory.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
-	go test $(VERBOSE_FLAG) ./tests/integration/... -coverprofile cover.out
+	go test --tags=integration $(VERBOSE_FLAG) ./tests/integration/... -coverprofile cover.out
 
 .PHONY: test.scorecard
 test.scorecard: operator-sdk ## Run the operator scorecard test.

--- a/tests/integration/api/istio_test.go
+++ b/tests/integration/api/istio_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/api/istiocni_test.go
+++ b/tests/integration/api/istiocni_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/api/istiorevision_test.go
+++ b/tests/integration/api/istiorevision_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/api/suite_test.go
+++ b/tests/integration/api/suite_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Changes added:
* `make test` will continue running both unit test and the api integration test
* Adding `make test.unit` and `make test.integration` to run specifically each test suite type separated 