### PR TITLE
Don't silently ignore errors in docker build/push

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -242,10 +242,10 @@ endif
 docker-buildx: test build-all ## Build and push docker image with cross-platform support.
 	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
-	- docker buildx create --name project-v4-builder
+	docker buildx ls --format "{{.Name}}" | grep project-v4-builder || docker buildx create --name project-v4-builder
 	docker buildx use project-v4-builder
-	- docker buildx build $(BUILDX_OUTPUT) --platform=$(PLATFORMS) --tag ${IMAGE} $(BUILDX_ADDITIONAL_TAGS) $(BUILDX_BUILD_ARGS) -f Dockerfile.cross .
-	- docker buildx rm project-v4-builder
+	docker buildx build $(BUILDX_OUTPUT) --platform=$(PLATFORMS) --tag ${IMAGE} $(BUILDX_ADDITIONAL_TAGS) $(BUILDX_BUILD_ARGS) -f Dockerfile.cross .
+	docker buildx rm project-v4-builder
 	rm Dockerfile.cross
 
 ##@ Deployment


### PR DESCRIPTION
Nightly builds are failing for a while and we never noticed that:
```
------
 > exporting to image:
------
ERROR: failed to solve: failed to push quay.io/maistra-dev/sail-operator:3.0-latest: unexpected status from POST request to https://quay.io/v2/maistra-dev/sail-operator/blobs/uploads/: 401 UNAUTHORIZED
docker buildx rm project-v4-builder
make: [Makefile.core.mk:247: docker-buildx] Error 1 (ignored)
```