### PR TITLE
Run integration tests with ginkgo instead of go test and ensure logs go to GinkgoWriter instead of stdout

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -152,7 +152,7 @@ test.unit:  ## Run unit tests.
 .PHONY: test.integration
 test.integration: envtest ## Run integration tests located in the tests/integration directory.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
-	go test --tags=integration $(VERBOSE_FLAG) ./tests/integration/...
+	go run github.com/onsi/ginkgo/v2/ginkgo --tags=integration $(VERBOSE_FLAG) ./tests/integration/...
 
 .PHONY: test.scorecard
 test.scorecard: operator-sdk ## Run the operator scorecard test.

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -15,6 +15,7 @@
 package test
 
 import (
+	"io"
 	"path"
 
 	"github.com/istio-ecosystem/sail-operator/pkg/common"
@@ -26,8 +27,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-func SetupEnv() (*envtest.Environment, client.Client, *rest.Config) {
-	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+func SetupEnv(logWriter io.Writer) (*envtest.Environment, client.Client, *rest.Config) {
+	logf.SetLogger(zap.New(zap.WriteTo(logWriter), zap.UseDevMode(true)))
 
 	testEnv := &envtest.Environment{
 		CRDDirectoryPaths:     []string{path.Join(common.RepositoryRoot, "chart", "crds")},

--- a/tests/integration/api/suite_test.go
+++ b/tests/integration/api/suite_test.go
@@ -36,8 +36,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -58,8 +56,7 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	testEnv, k8sClient, cfg = test.SetupEnv()
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	testEnv, k8sClient, cfg = test.SetupEnv(GinkgoWriter)
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,


### PR DESCRIPTION
Ginkgo displays progress, whereas go test doesn't.