### PR TITLE
OSSM-6153 Simplify error handling around updateStatus()

### DIFF
--- a/controllers/istio/istio_controller_test.go
+++ b/controllers/istio/istio_controller_test.go
@@ -271,7 +271,7 @@ func TestUpdateStatus(t *testing.T) {
 		{
 			name:              "reconciliation error",
 			reconciliationErr: fmt.Errorf("reconciliation error"),
-			wantErr:           true,
+			wantErr:           false,
 			expectedStatus: v1alpha1.IstioStatus{
 				State:              v1alpha1.IstioReasonReconcileError,
 				ObservedGeneration: generation,


### PR DESCRIPTION
Previously, when both a reconcile and a status update error occurred, we logged the update error and returned the reconcile error. Now, we simply return a composite of both errors.

This commit also removes unneeded conflict handling, since status is always updated via PATCH, which does not return 409 Conflict.