### PR TITLE
OSSM-6267 Fix Grafana 9.2 datasource query error

### DIFF
--- a/pkg/controller/servicemesh/controlplane/htpasswd.go
+++ b/pkg/controller/servicemesh/controlplane/htpasswd.go
@@ -17,6 +17,8 @@ import (
 	"github.com/maistra/istio-operator/pkg/controller/versions"
 )
 
+var username = "internal"
+
 func (r *controlPlaneInstanceReconciler) patchHtpasswdSecret(ctx context.Context, object *unstructured.Unstructured) error {
 	var rawPassword, auth string
 	log := common.LogFromContext(ctx)
@@ -51,6 +53,7 @@ func (r *controlPlaneInstanceReconciler) patchHtpasswdSecret(ctx context.Context
 	b64Password := base64.StdEncoding.EncodeToString([]byte(rawPassword))
 	b64Auth := base64.StdEncoding.EncodeToString([]byte(auth))
 
+	// b/c Keep rawPassword for previous release Kiali, Prometheus and Grafana patching
 	// We store the raw password in order to be able to retrieve it below, when patching Grafana ConfigMap
 	err = unstructured.SetNestedField(object.UnstructuredContent(), b64Password, "data", "rawPassword")
 	if err != nil {
@@ -64,12 +67,21 @@ func (r *controlPlaneInstanceReconciler) patchHtpasswdSecret(ctx context.Context
 		return err
 	}
 
+	// OSSM-6267 Grafana 9.2: We store the username:rawPassword in order to be able to retrieve it below,
+	// when patching Grafana ConfigMap
+	authToken := username + ":" + rawPassword
+	b64authToken := base64.StdEncoding.EncodeToString([]byte(authToken))
+	err = unstructured.SetNestedField(object.UnstructuredContent(), b64authToken, "data", "authToken")
+	if err != nil {
+		log.Error(err, "failed to set htpasswd authToken")
+		return err
+	}
+
 	return nil
 }
 
 func hashPassword(version versions.Version, rawPass string) (string, error) {
 	var auth, hashedPassword string
-	username := "internal"
 
 	// For SMCP versions 2.4 and above, use bcrypt hashing.
 	if version.AtLeast(versions.V2_4) {
@@ -89,6 +101,7 @@ func hashPassword(version versions.Version, rawPass string) (string, error) {
 	return auth, nil
 }
 
+// b/c Keep rawPassword for previous release Kiali, Prometheus and Grafana patching
 func (r *controlPlaneInstanceReconciler) getRawHtPasswd(ctx context.Context) (string, error) {
 	log := common.LogFromContext(ctx)
 	htSecret := &corev1.Secret{}
@@ -101,6 +114,18 @@ func (r *controlPlaneInstanceReconciler) getRawHtPasswd(ctx context.Context) (st
 	return string(htSecret.Data["rawPassword"]), nil
 }
 
+func (r *controlPlaneInstanceReconciler) getHtauthToken(ctx context.Context) (string, error) {
+	log := common.LogFromContext(ctx)
+	htSecret := &corev1.Secret{}
+	err := r.Client.Get(ctx, client.ObjectKey{Namespace: r.Instance.GetNamespace(), Name: "htpasswd"}, htSecret)
+	if err != nil {
+		log.Error(err, "error retrieving htpasswd Secret")
+		return "", err
+	}
+
+	return string(htSecret.Data["authToken"]), nil
+}
+
 func (r *controlPlaneInstanceReconciler) patchGrafanaConfig(ctx context.Context, object *unstructured.Unstructured) error {
 	log := common.LogFromContext(ctx)
 	dsYaml, found, err := unstructured.NestedString(object.UnstructuredContent(), "data", "datasources.yaml")
@@ -111,13 +136,14 @@ func (r *controlPlaneInstanceReconciler) patchGrafanaConfig(ctx context.Context,
 
 	log.Info("patching Grafana-Prometheus link", object.GetKind(), object.GetName())
 
-	rawPassword, err := r.getRawHtPasswd(ctx)
+	authToken, err := r.getHtauthToken(ctx)
 	if err != nil {
 		return err
 	}
+	b64authToken := base64.StdEncoding.EncodeToString([]byte(authToken))
 
-	re := regexp.MustCompile("(?s)(basicAuthPassword:).*?\n")
-	dsYaml = re.ReplaceAllString(dsYaml, fmt.Sprintf("${1} %s\n", rawPassword))
+	re := regexp.MustCompile("(?s)({AuthToken}).*?\n")
+	dsYaml = re.ReplaceAllString(dsYaml, fmt.Sprintf("Basic %s'\n", b64authToken))
 	err = unstructured.SetNestedField(object.UnstructuredContent(), dsYaml, "data", "datasources.yaml")
 	if err != nil {
 		log.Error(err, "failed to set datasources.yaml")

--- a/pkg/controller/servicemesh/controlplane/htpasswd.go
+++ b/pkg/controller/servicemesh/controlplane/htpasswd.go
@@ -53,8 +53,7 @@ func (r *controlPlaneInstanceReconciler) patchHtpasswdSecret(ctx context.Context
 	b64Password := base64.StdEncoding.EncodeToString([]byte(rawPassword))
 	b64Auth := base64.StdEncoding.EncodeToString([]byte(auth))
 
-	// b/c Keep rawPassword for previous release Kiali, Prometheus and Grafana patching
-	// We store the raw password in order to be able to retrieve it below, when patching Grafana ConfigMap
+	// we store the raw password in order to be able to retrieve it below, when patching ConfigMap for Grafana 7.5
 	err = unstructured.SetNestedField(object.UnstructuredContent(), b64Password, "data", "rawPassword")
 	if err != nil {
 		log.Error(err, "failed to set htpasswd raw password")
@@ -67,8 +66,7 @@ func (r *controlPlaneInstanceReconciler) patchHtpasswdSecret(ctx context.Context
 		return err
 	}
 
-	// OSSM-6267 Grafana 9.2: We store the username:rawPassword in order to be able to retrieve it below,
-	// when patching Grafana ConfigMap
+	// we store the username:rawPassword in order to be able to retrieve it below, when patching ConfigMap for Grafana 9.2+
 	authToken := username + ":" + rawPassword
 	b64authToken := base64.StdEncoding.EncodeToString([]byte(authToken))
 	err = unstructured.SetNestedField(object.UnstructuredContent(), b64authToken, "data", "authToken")
@@ -101,7 +99,6 @@ func hashPassword(version versions.Version, rawPass string) (string, error) {
 	return auth, nil
 }
 
-// b/c Keep rawPassword for previous release Kiali, Prometheus and Grafana patching
 func (r *controlPlaneInstanceReconciler) getRawHtPasswd(ctx context.Context) (string, error) {
 	log := common.LogFromContext(ctx)
 	htSecret := &corev1.Secret{}

--- a/resources/helm/overlays/istio-telemetry/grafana/templates/deployment.yaml
+++ b/resources/helm/overlays/istio-telemetry/grafana/templates/deployment.yaml
@@ -175,6 +175,8 @@ spec:
           - name: config
             mountPath: "/etc/grafana/provisioning/dashboards/dashboardproviders.yaml"
             subPath: dashboardproviders.yaml
+          - name: config
+            mountPath: /etc/grafana/provisioning/alerting
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}

--- a/resources/helm/overlays/istio-telemetry/grafana/values.yaml
+++ b/resources/helm/overlays/istio-telemetry/grafana/values.yaml
@@ -66,15 +66,14 @@ grafana:
           # XXX: is this still needed?
           # we should be using the CA cert in /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
           tlsSkipVerify: true
+          # OSSM-6267 Grafana 9.2 data source query request: Use a header for oauth proxy authentication
+          httpHeaderName1: 'Authorization'
         name: Prometheus
         orgId: 1
         type: prometheus
         url: https://prometheus:9090
-        basicAuth: true
-        "secureJsonData": {
-          basicAuthPassword: ""
-        }
-        basicAuthUser: internal
+        secureJsonData:
+          httpHeaderValue1: '{AuthToken}'
         version: 1
 
   dashboardProviders:

--- a/resources/helm/overlays/istio-telemetry/telemetry-common/templates/htpasswd-secret.yaml
+++ b/resources/helm/overlays/istio-telemetry/telemetry-common/templates/htpasswd-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 data:
   auth: ""
   rawPassword: ""
+  authToken: ""
 kind: Secret
 metadata:
   name: htpasswd

--- a/resources/helm/v2.3/istio-telemetry/grafana/templates/deployment.yaml
+++ b/resources/helm/v2.3/istio-telemetry/grafana/templates/deployment.yaml
@@ -177,6 +177,8 @@ spec:
           - name: config
             mountPath: "/etc/grafana/provisioning/dashboards/dashboardproviders.yaml"
             subPath: dashboardproviders.yaml
+          - name: config
+            mountPath: /etc/grafana/provisioning/alerting
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}

--- a/resources/helm/v2.3/istio-telemetry/grafana/values.yaml
+++ b/resources/helm/v2.3/istio-telemetry/grafana/values.yaml
@@ -69,15 +69,14 @@ grafana:
           # XXX: is this still needed?
           # we should be using the CA cert in /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
           tlsSkipVerify: true
+          # OSSM-6267 Grafana 9.2 data source query request: Use a header for oauth proxy authentication
+          httpHeaderName1: 'Authorization'
         name: Prometheus
         orgId: 1
         type: prometheus
         url: https://prometheus:9090
-        basicAuth: true
-        "secureJsonData": {
-          basicAuthPassword: ""
-        }
-        basicAuthUser: internal
+        secureJsonData:
+          httpHeaderValue1: '{AuthToken}'
         version: 1
 
   dashboardProviders:

--- a/resources/helm/v2.3/istio-telemetry/telemetry-common/templates/htpasswd-secret.yaml
+++ b/resources/helm/v2.3/istio-telemetry/telemetry-common/templates/htpasswd-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 data:
   auth: ""
   rawPassword: ""
+  authToken: ""
 kind: Secret
 metadata:
   name: htpasswd

--- a/resources/helm/v2.4/istio-telemetry/grafana/templates/deployment.yaml
+++ b/resources/helm/v2.4/istio-telemetry/grafana/templates/deployment.yaml
@@ -177,6 +177,8 @@ spec:
           - name: config
             mountPath: "/etc/grafana/provisioning/dashboards/dashboardproviders.yaml"
             subPath: dashboardproviders.yaml
+          - name: config
+            mountPath: /etc/grafana/provisioning/alerting
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}

--- a/resources/helm/v2.4/istio-telemetry/grafana/values.yaml
+++ b/resources/helm/v2.4/istio-telemetry/grafana/values.yaml
@@ -69,15 +69,14 @@ grafana:
           # XXX: is this still needed?
           # we should be using the CA cert in /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
           tlsSkipVerify: true
+          # OSSM-6267 Grafana 9.2 data source query request: Use a header for oauth proxy authentication
+          httpHeaderName1: 'Authorization'
         name: Prometheus
         orgId: 1
         type: prometheus
         url: https://prometheus:9090
-        basicAuth: true
-        "secureJsonData": {
-          basicAuthPassword: ""
-        }
-        basicAuthUser: internal
+        secureJsonData:
+          httpHeaderValue1: '{AuthToken}'
         version: 1
 
   dashboardProviders:

--- a/resources/helm/v2.4/istio-telemetry/telemetry-common/templates/htpasswd-secret.yaml
+++ b/resources/helm/v2.4/istio-telemetry/telemetry-common/templates/htpasswd-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 data:
   auth: ""
   rawPassword: ""
+  authToken: ""
 kind: Secret
 metadata:
   name: htpasswd

--- a/resources/helm/v2.5/istio-telemetry/grafana/templates/deployment.yaml
+++ b/resources/helm/v2.5/istio-telemetry/grafana/templates/deployment.yaml
@@ -177,6 +177,8 @@ spec:
           - name: config
             mountPath: "/etc/grafana/provisioning/dashboards/dashboardproviders.yaml"
             subPath: dashboardproviders.yaml
+          - name: config
+            mountPath: /etc/grafana/provisioning/alerting
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}

--- a/resources/helm/v2.5/istio-telemetry/grafana/values.yaml
+++ b/resources/helm/v2.5/istio-telemetry/grafana/values.yaml
@@ -69,15 +69,14 @@ grafana:
           # XXX: is this still needed?
           # we should be using the CA cert in /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
           tlsSkipVerify: true
+          # OSSM-6267 Grafana 9.2 data source query request: Use a header for oauth proxy authentication
+          httpHeaderName1: 'Authorization'
         name: Prometheus
         orgId: 1
         type: prometheus
         url: https://prometheus:9090
-        basicAuth: true
-        "secureJsonData": {
-          basicAuthPassword: ""
-        }
-        basicAuthUser: internal
+        secureJsonData:
+          httpHeaderValue1: '{AuthToken}'
         version: 1
 
   dashboardProviders:

--- a/resources/helm/v2.5/istio-telemetry/telemetry-common/templates/htpasswd-secret.yaml
+++ b/resources/helm/v2.5/istio-telemetry/telemetry-common/templates/htpasswd-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 data:
   auth: ""
   rawPassword: ""
+  authToken: ""
 kind: Secret
 metadata:
   name: htpasswd


### PR DESCRIPTION
The first commit is fixing a missing mount when deploying Grafana 9.2. Alerting is a new feature introduced in Grafana 9.
The second commit is using an additional custom header when configuring Prometheus data source in Grafana.
The previous basic auth config is not fully working in Grafana 9.2.10
   It works in data source metrics data and it is not working when Grafana sends a query request.
 So I replace the basic auth configmap field with a custom authorization header in data source. 