### PR TITLE
OSSM-6385 Make sure to remove kiali annotation when kiali is disabled

### DIFF
--- a/pkg/controller/servicemesh/memberroll/controller.go
+++ b/pkg/controller/servicemesh/memberroll/controller.go
@@ -379,6 +379,8 @@ func (r *MemberRollReconciler) reconcileObject(ctx context.Context, roll *maistr
 		} else {
 			kialiErr = r.kialiReconciler.reconcileKiali(ctx, kialiName, meshNamespace, allKnownMembers.List(), []string{})
 		}
+	} else if mesh != nil && !mesh.Status.AppliedSpec.IsKialiEnabled() {
+		roll.Status.RemoveAnnotation(statusAnnotationKialiName)
 	}
 
 	// 7. tell Prometheus about all the namespaces in the mesh
@@ -394,6 +396,8 @@ func (r *MemberRollReconciler) reconcileObject(ctx context.Context, roll *maistr
 			roll.Status.SetAnnotation(statusAnnotationPrometheus, strings.Join(scrapingNamespaces, ","))
 			prometheusErr = r.prometheusReconciler.reconcilePrometheus(ctx, prometheusConfigMapName, meshNamespace, scrapingNamespaces)
 		}
+	} else if mesh != nil && !mesh.Status.AppliedSpec.IsPrometheusEnabled() {
+		roll.Status.RemoveAnnotation(statusAnnotationPrometheus)
 	}
 
 	// 7. update the status


### PR DESCRIPTION
We didn't delete this previously, which caused the operator to still reconcile a Kiali resource even though Kiali was disabled in the SMCP - so we ended up making changes to an externally managed Kiali.

While at it, I also made the change for prometheus.