### PR TITLE
[OSSM-6331] Add istiod logLevel validation

### DIFF
--- a/pkg/apis/maistra/v2/logging.go
+++ b/pkg/apis/maistra/v2/logging.go
@@ -47,6 +47,10 @@ const (
 	LogLevelError LogLevel = "error"
 	// LogLevelCritical critical logging level
 	LogLevelCritical LogLevel = "critical"
+	// LogLevelFatal critical logging level
+	LogLevelFatal LogLevel = "fatal"
+	// LogLevelNone disable logging
+	LogLevelNone LogLevel = "none"
 	// LogLevelOff disable logging
 	LogLevelOff LogLevel = "off"
 )

--- a/pkg/controller/versions/strategy_v2_5.go
+++ b/pkg/controller/versions/strategy_v2_5.go
@@ -135,6 +135,7 @@ func (v *versionStrategyV2_5) ValidateV2(ctx context.Context, cl client.Client, 
 	allErrors = v.validateAddons(spec, allErrors)
 	allErrors = v.validateExtensionProviders(spec, allErrors)
 	allErrors = v.validateExtensionProviderZipkin(spec, allErrors)
+	allErrors = v.validateGeneralLoggingComponentLevels(spec, allErrors)
 	return NewValidationError(allErrors...)
 }
 
@@ -253,6 +254,25 @@ func (v *versionStrategyV2_5) validateExtensionProviderZipkin(spec *v2.ControlPl
 		}
 	}
 
+	return allErrors
+}
+
+func (v *versionStrategyV2_5) validateGeneralLoggingComponentLevels(spec *v2.ControlPlaneSpec, allErrors []error) []error {
+	if spec.General == nil || spec.General.Logging == nil || spec.General.Logging.ComponentLevels == nil {
+		return allErrors
+	}
+	componentLevelLogging := spec.General.Logging.ComponentLevels
+
+	// istiod support only these logLevel, other logLevel would cause crash in istiod discovery container
+	istiodSupportedLogLevels := []v2.LogLevel{v2.LogLevelDebug, v2.LogLevelError, v2.LogLevelWarning, v2.LogLevelInfo, v2.LogLevelFatal, v2.LogLevelNone}
+
+	// go through the filed map of filed component log levels
+	for _, logLevel := range componentLevelLogging {
+		// if the filed log level is not in the supported log level list, append the error
+		if !containsLogLevel(istiodSupportedLogLevels, logLevel) {
+			allErrors = append(allErrors, fmt.Errorf("istiod doesn't support '%s' log level", logLevel))
+		}
+	}
 	return allErrors
 }
 

--- a/pkg/controller/versions/util.go
+++ b/pkg/controller/versions/util.go
@@ -380,3 +380,13 @@ func GetMissingDependency(err error) string {
 	}
 	return ""
 }
+
+// slices.Contains function is available only for Go1.18+
+func containsLogLevel(logLevelArray []v2.LogLevel, logLevel v2.LogLevel) bool {
+	for _, v := range logLevelArray {
+		if v == logLevel {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
The [LogLevel constants](https://github.com/maistra/istio-operator/blob/maistra-2.5/pkg/apis/maistra/v2/logging.go#L35) are common for [proxy logging](https://github.com/maistra/istio-operator/blob/maistra-2.5/pkg/apis/maistra/v2/logging.go#L17) as well as [global logging](https://github.com/maistra/istio-operator/blob/maistra-2.5/pkg/apis/maistra/v2/logging.go#L4C6-L4C19). When the global logging level is set (e.g. `spec.general.logging.componentLevels="default:warn"`), the value is passed into the istiod discovery container [as an argument of](https://github.com/maistra/istio-operator/blob/maistra-2.5/resources/helm/v2.5/istio-control/istio-discovery/templates/deployment.yaml#L106) `--log_output_level`.
However, according to [Component logging Istio page](https://istio.io/v1.18/docs/ops/diagnostic-tools/component-logging/#logging-scopes), it supports only `none,error,warn,info,debug`, so specifying other values (e.g. `trace`) causes a crash of discovery container with an error:
```
2024-04-25T08:48:44.054252Z error invalid output level 'default:trace'
Error: invalid output level 'default:trace'
```
ref.: https://issues.redhat.com/browse/OSSM-6331


This PR adds validation whether only supported log levels were specified in the SMCP  `spec.general.logging.componentLevels`  ( for 2.5, 2.4 and 2.3 SMCP )

----

Tested with multiple values ( `panic` `trace` are invalid, `warn` is valid ):
![Screenshot from 2024-04-29 11-09-14](https://github.com/maistra/istio-operator/assets/16251792/2b8ddb0d-c1b9-4e23-aa8f-c9ab8e2d97fa)


