### PR TITLE
OSSM-6397: Revert OSSM-5541: istio-operator leader election change

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
+	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
 	"github.com/spf13/pflag"
@@ -75,10 +76,6 @@ func main() {
 	var logAPIRequests bool
 	pflag.BoolVar(&logAPIRequests, "logAPIRequests", false, "Log API requests performed by the operator.")
 
-	var leaderElect bool
-	pflag.BoolVar(&leaderElect, "leader-elect", true, "Enable leader election for this operator. "+
-		"Enabling this will ensure there is only one active controller manager.")
-
 	// config file
 	configFile := ""
 	pflag.StringVar(&configFile, "config", "/etc/istio-operator/config.properties", "The root location of the user supplied templates.")
@@ -131,6 +128,13 @@ func main() {
 	}
 
 	ctx := context.Background()
+	// Become the leader before proceeding
+	err = leader.Become(ctx, "istio-operator-lock")
+
+	if err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
 
 	// Set default manager options
 	options := manager.Options{
@@ -138,8 +142,6 @@ func main() {
 		Port:                   admissionControllerPort,
 		MetricsBindAddress:     net.JoinHostPort(metricsHost, fmt.Sprint(metricsPort)),
 		HealthProbeBindAddress: healthProbeBindAddress,
-		LeaderElection:         leaderElect,
-		LeaderElectionID:       "istio-operator-lock",
 	}
 
 	// Add support for MultiNamespace set in WATCH_NAMESPACE (e.g ns1,ns2)


### PR DESCRIPTION
…(#1665)"

This reverts commit d387067ef47d27dc950bc5139ff4eca083fec537.

The Leader with lease implementation is only applicable in "sigs.k8s.io/controller-runtime v0.7.0 and above".
Upgrade that dependency from v0.6.3 needs major operator code refactoring. That's a not applicable in OSSM operator 2.5.x branch.
So I reverted the code change of #1665 in order to avoiding OSSM-6397 error.

Reference: https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.7.0/pkg/manager

```
// Note: before controller-runtime version v0.7, the resource lock was set to "configmaps".
// Please keep this in mind, when planning a proper migration path for your controller.
LeaderElectionResourceLock [string](https://pkg.go.dev/builtin#string)
```