### PR TITLE
OSSM-5556: append control plane namespace to discovery selectors

### DIFF
--- a/pkg/controller/servicemesh/controlplane/reconciler.go
+++ b/pkg/controller/servicemesh/controlplane/reconciler.go
@@ -146,6 +146,10 @@ func (r *controlPlaneInstanceReconciler) Reconcile(ctx context.Context) (result 
 			return
 		}
 
+		if r.Instance.Spec.Mode == v2.ClusterWideMode {
+			overrideDiscoverySelectors(&r.Instance.Spec, r.Instance.Namespace)
+		}
+
 		// Render the templates
 		r.renderings, err = version.Strategy().Render(ctx, &r.ControllerResources, r.cniConfig, r.Instance)
 		// always set these, especially if rendering failed, as these are useful for debugging
@@ -183,10 +187,6 @@ func (r *controlPlaneInstanceReconciler) Reconcile(ctx context.Context) (result 
 			reconciliationMessage = "Error updating labels on mesh namespace"
 			err = errors.Wrap(err, reconciliationMessage)
 			return
-		}
-
-		if r.Instance.Spec.Mode == v2.ClusterWideMode {
-			overrideDiscoverySelectors(&r.Instance.Spec, r.Instance.Namespace)
 		}
 
 		// initialize new Status


### PR DESCRIPTION
**Background context:**
When discovery selectors are configured, then must include the control plane namespace. Otherwise, gateways in the control plane namespace with unprivileged port, i.e. the default ingress and egress gateways, will not receive `Gateway` configurations.

Previously, I tried to change `gateways` charts to not use unprivileged ports, but that change broken many tests, so that issue still exists and users must be aware of that and properly configure `discoverySelectors`.

**Proposed solution:**
The operator can append the control plane namespace to `meshConfig.discoverySelectors` if this field is configured.