### PR TITLE
Keep 2.2 manifests for upgrade testing from 2.2 to 2.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ test:
 # Helm charts generation and templates processing
 ################################################################################
 
-SUPPORTED_VERSIONS := 2.3 2.4 2.5
+SUPPORTED_VERSIONS := 2.2 2.3 2.4 2.5
 
 $(addprefix update-remote-maistra-,$(SUPPORTED_VERSIONS)): update-remote-maistra-%:
 	$(eval version:=$*)
@@ -183,10 +183,10 @@ endif
 # resource collection
 ################################################################################
 .PHONY: collect-charts
-collect-charts: collect-charts-2.3 collect-charts-2.4 collect-charts-2.5
+collect-charts: collect-charts-2.2 collect-charts-2.3 collect-charts-2.4 collect-charts-2.5
 
 .PHONY: collect-templates
-collect-templates: collect-templates-2.3 collect-templates-2.4 collect-templates-2.5
+collect-templates: collect-templates-2.2 collect-templates-2.3 collect-templates-2.4 collect-templates-2.5
 
 .PHONY: collect-olm-manifests
 collect-olm-manifests:

--- a/build/build.sh
+++ b/build/build.sh
@@ -35,7 +35,7 @@ fi
 LD_EXTRAFLAGS+=" -X ${REPO_PATH}/pkg/version.buildStatus=${GITSTATUS}"
 
 : "${GITTAG:=$(git describe 2> /dev/null || echo "unknown")}"
-: "${MINIMUM_SUPPORTED_VERSION:=v2.3}"
+: "${MINIMUM_SUPPORTED_VERSION:=v2.2}"
 LD_EXTRAFLAGS+=" -X ${REPO_PATH}/pkg/version.buildTag=${GITTAG} -X ${REPO_PATH}/pkg/version.minimumSupportedVersion=${MINIMUM_SUPPORTED_VERSION}"
 
 LDFLAGS="-extldflags -static ${LD_EXTRAFLAGS} -s -w"

--- a/deploy/maistra-operator.yaml
+++ b/deploy/maistra-operator.yaml
@@ -11035,6 +11035,14 @@ spec:
         name: istio-operator
       annotations:
 
+        olm.relatedImage.v2_2.cni: quay.io/maistra/istio-cni-ubi8:2.2.2
+        olm.relatedImage.v2_2.grafana: quay.io/maistra/grafana-ubi8:2.2.2
+        olm.relatedImage.v2_2.pilot: quay.io/maistra/pilot-ubi8:2.2.2
+        olm.relatedImage.v2_2.prometheus: quay.io/maistra/prometheus-ubi8:2.2.2
+        olm.relatedImage.v2_2.proxyv2: quay.io/maistra/proxyv2-ubi8:2.2.2
+        olm.relatedImage.v2_2.wasm-cacher: quay.io/maistra/pilot-ubi8:2.2.2
+        olm.relatedImage.v2_2.rls: quay.io/maistra/ratelimit-ubi8:2.2.2
+
         olm.relatedImage.v2_3.cni: quay.io/maistra/istio-cni-ubi8:2.3.0
         olm.relatedImage.v2_3.grafana: quay.io/maistra/grafana-ubi8:2.3.0
         olm.relatedImage.v2_3.pilot: quay.io/maistra/pilot-ubi8:2.3.0

--- a/deploy/servicemesh-operator.yaml
+++ b/deploy/servicemesh-operator.yaml
@@ -11034,6 +11034,14 @@ spec:
       labels:
         name: istio-operator
       annotations:
+        # 2.2 images
+        olm.relatedImage.v2_2.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_22}
+        olm.relatedImage.v2_2.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_22}
+        olm.relatedImage.v2_2.pilot: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_22}
+        olm.relatedImage.v2_2.prometheus: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-prometheus-rhel8:${OSSM_22}
+        olm.relatedImage.v2_2.proxyv2: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxyv2-rhel8:${OSSM_22}
+        olm.relatedImage.v2_2.wasm-cacher: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_22}
+        olm.relatedImage.v2_2.rls: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-ratelimit-rhel8:${OSSM_22}
         # 2.3 images
         olm.relatedImage.v2_3.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_23}
         olm.relatedImage.v2_3.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_23}

--- a/deploy/src/deployment-maistra.yaml
+++ b/deploy/src/deployment-maistra.yaml
@@ -16,6 +16,14 @@ spec:
         name: istio-operator
       annotations:
 
+        olm.relatedImage.v2_2.cni: quay.io/maistra/istio-cni-ubi8:2.2.2
+        olm.relatedImage.v2_2.grafana: quay.io/maistra/grafana-ubi8:2.2.2
+        olm.relatedImage.v2_2.pilot: quay.io/maistra/pilot-ubi8:2.2.2
+        olm.relatedImage.v2_2.prometheus: quay.io/maistra/prometheus-ubi8:2.2.2
+        olm.relatedImage.v2_2.proxyv2: quay.io/maistra/proxyv2-ubi8:2.2.2
+        olm.relatedImage.v2_2.wasm-cacher: quay.io/maistra/pilot-ubi8:2.2.2
+        olm.relatedImage.v2_2.rls: quay.io/maistra/ratelimit-ubi8:2.2.2
+
         olm.relatedImage.v2_3.cni: quay.io/maistra/istio-cni-ubi8:2.3.0
         olm.relatedImage.v2_3.grafana: quay.io/maistra/grafana-ubi8:2.3.0
         olm.relatedImage.v2_3.pilot: quay.io/maistra/pilot-ubi8:2.3.0

--- a/deploy/src/deployment-servicemesh.yaml
+++ b/deploy/src/deployment-servicemesh.yaml
@@ -15,6 +15,14 @@ spec:
       labels:
         name: istio-operator
       annotations:
+        # 2.2 images
+        olm.relatedImage.v2_2.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_22}
+        olm.relatedImage.v2_2.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_22}
+        olm.relatedImage.v2_2.pilot: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_22}
+        olm.relatedImage.v2_2.prometheus: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-prometheus-rhel8:${OSSM_22}
+        olm.relatedImage.v2_2.proxyv2: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxyv2-rhel8:${OSSM_22}
+        olm.relatedImage.v2_2.wasm-cacher: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_22}
+        olm.relatedImage.v2_2.rls: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-ratelimit-rhel8:${OSSM_22}
         # 2.3 images
         olm.relatedImage.v2_3.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_23}
         olm.relatedImage.v2_3.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_23}

--- a/manifests-maistra/2.5.2/maistraoperator.v2.5.2.clusterserviceversion.yaml
+++ b/manifests-maistra/2.5.2/maistraoperator.v2.5.2.clusterserviceversion.yaml
@@ -221,6 +221,20 @@ spec:
   - type: AllNamespaces
     supported: true
   relatedImages:
+  - name: v2_2.cni
+    image: quay.io/maistra/istio-cni-ubi8:2.2.2
+  - name: v2_2.grafana
+    image: quay.io/maistra/grafana-ubi8:2.2.2
+  - name: v2_2.pilot
+    image: quay.io/maistra/pilot-ubi8:2.2.2
+  - name: v2_2.prometheus
+    image: quay.io/maistra/prometheus-ubi8:2.2.2
+  - name: v2_2.proxyv2
+    image: quay.io/maistra/proxyv2-ubi8:2.2.2
+  - name: v2_2.wasm-cacher
+    image: quay.io/maistra/pilot-ubi8:2.2.2
+  - name: v2_2.rls
+    image: quay.io/maistra/ratelimit-ubi8:2.2.2
   - name: v2_3.cni
     image: quay.io/maistra/istio-cni-ubi8:2.3.0
   - name: v2_3.grafana
@@ -520,6 +534,13 @@ spec:
               labels:
                 name: istio-operator
               annotations:
+                olm.relatedImage.v2_2.cni: quay.io/maistra/istio-cni-ubi8:2.2.2
+                olm.relatedImage.v2_2.grafana: quay.io/maistra/grafana-ubi8:2.2.2
+                olm.relatedImage.v2_2.pilot: quay.io/maistra/pilot-ubi8:2.2.2
+                olm.relatedImage.v2_2.prometheus: quay.io/maistra/prometheus-ubi8:2.2.2
+                olm.relatedImage.v2_2.proxyv2: quay.io/maistra/proxyv2-ubi8:2.2.2
+                olm.relatedImage.v2_2.wasm-cacher: quay.io/maistra/pilot-ubi8:2.2.2
+                olm.relatedImage.v2_2.rls: quay.io/maistra/ratelimit-ubi8:2.2.2
                 olm.relatedImage.v2_3.cni: quay.io/maistra/istio-cni-ubi8:2.3.0
                 olm.relatedImage.v2_3.grafana: quay.io/maistra/grafana-ubi8:2.3.0
                 olm.relatedImage.v2_3.pilot: quay.io/maistra/pilot-ubi8:2.3.0

--- a/manifests-servicemesh/2.5.2/servicemeshoperator.v2.5.2.clusterserviceversion.yaml
+++ b/manifests-servicemesh/2.5.2/servicemeshoperator.v2.5.2.clusterserviceversion.yaml
@@ -529,6 +529,14 @@ spec:
               labels:
                 name: istio-operator
               annotations:
+                # 2.2 images
+                olm.relatedImage.v2_2.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_22}
+                olm.relatedImage.v2_2.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_22}
+                olm.relatedImage.v2_2.pilot: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_22}
+                olm.relatedImage.v2_2.prometheus: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-prometheus-rhel8:${OSSM_22}
+                olm.relatedImage.v2_2.proxyv2: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxyv2-rhel8:${OSSM_22}
+                olm.relatedImage.v2_2.wasm-cacher: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_22}
+                olm.relatedImage.v2_2.rls: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-ratelimit-rhel8:${OSSM_22}
                 # 2.3 images
                 olm.relatedImage.v2_3.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_23}
                 olm.relatedImage.v2_3.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_23}

--- a/pkg/bootstrap/cni_test.go
+++ b/pkg/bootstrap/cni_test.go
@@ -32,6 +32,13 @@ func TestCNISupportedVersionRendering(t *testing.T) {
 		daemonsetName     string
 	}{
 		{
+			name:              "Default Supported Versions SMCP v2.2",
+			supportedVersions: versions.GetSupportedVersions(),
+			instanceVersion:   versions.V2_2.Version(),
+			containerNames:    []string{"install-cni-v2-2"},
+			daemonsetName:     "istio-cni-node",
+		},
+		{
 			name:              "Default Supported Versions SMCP v2.3",
 			supportedVersions: versions.GetSupportedVersions(),
 			instanceVersion:   versions.V2_3.Version(),
@@ -44,6 +51,13 @@ func TestCNISupportedVersionRendering(t *testing.T) {
 			instanceVersion:   versions.V2_4.Version(),
 			containerNames:    []string{"install-cni"},
 			daemonsetName:     "istio-cni-node-v2-4",
+		},
+		{
+			name:              "v2.2 only",
+			supportedVersions: []versions.Version{versions.V2_2},
+			instanceVersion:   versions.V2_2.Version(),
+			containerNames:    []string{"install-cni-v2-2"},
+			daemonsetName:     "istio-cni-node",
 		},
 		{
 			name:              "v2.3 only",

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -13,8 +13,8 @@ var (
 	buildStatus      = "unknown"
 	buildTag         = "unknown"
 
-	// Minimum supported mesh version (nil (all), "v2_3", "v2_4" etc)
-	minimumSupportedVersion = "v2.3"
+	// Minimum supported mesh version (nil (all), "v2_0", "v2_1" etc)
+	minimumSupportedVersion = "v2.2"
 
 	// Info exports the build version information.
 	Info BuildInfo


### PR DESCRIPTION
This is a revert of #1778 . 
Matej slacked me about a testing job failure when they still need to test an upgrade to the minimum supported version ( from v2.2 to v2.3)
So I am going to keep 2.2 manifests in this 2.5 branch.