### PR TITLE
OSSM-6696: Disable repair controller in istio-cni

### DIFF
--- a/resources/helm/overlays/istio_cni/templates/daemonset-v2.6.yaml
+++ b/resources/helm/overlays/istio_cni/templates/daemonset-v2.6.yaml
@@ -96,6 +96,8 @@ spec:
             # Deploy as a standalone CNI plugin or as chained?
             - name: CHAINED_CNI_PLUGIN
               value: "{{ .Values.cni.chained }}"
+            - name: REPAIR_ENABLED
+              value: "{{ .Values.cni.repair.enabled }}"
             # Directory in which the CNI config file should be created (host path mounted in the container)
             - name: MOUNTED_CNI_NET_DIR
               value: {{ default "/host/etc/cni/net.d" .Values.cni.mountedCniConfDir }}

--- a/resources/helm/overlays/istio_cni/values.yaml
+++ b/resources/helm/overlays/istio_cni/values.yaml
@@ -1,3 +1,5 @@
 cni:
   defaultResourceName: ossm-cni
   enabled: false
+  repair:
+    enabled: false

--- a/resources/helm/v2.6/istio_cni/templates/daemonset-v2.6.yaml
+++ b/resources/helm/v2.6/istio_cni/templates/daemonset-v2.6.yaml
@@ -97,6 +97,8 @@ spec:
             # Deploy as a standalone CNI plugin or as chained?
             - name: CHAINED_CNI_PLUGIN
               value: "{{ .Values.cni.chained }}"
+            - name: REPAIR_ENABLED
+              value: "{{ .Values.cni.repair.enabled }}"
             # Directory in which the CNI config file should be created (host path mounted in the container)
             - name: MOUNTED_CNI_NET_DIR
               value: {{ default "/host/etc/cni/net.d" .Values.cni.mountedCniConfDir }}

--- a/resources/helm/v2.6/istio_cni/values.yaml
+++ b/resources/helm/v2.6/istio_cni/values.yaml
@@ -1,3 +1,5 @@
 cni:
   defaultResourceName: ossm-cni
   enabled: false
+  repair:
+    enabled: false


### PR DESCRIPTION
Istio CNI pods log errors like below, because the repair controller requires permissions for watch and list operations, but repairing relies on checking status of istio-validation init containers that we removed, so enabling repairing does not make any sense. Therefore instead of adding missing permissions I disabled the repair controller.
```
2024-06-19T08:25:04.529176Z	info	CNI race repair configuration: 
Enabled: true
NodeName: 
LabelKey: cni.istio.io/uninitialized
LabelValue: true
DeletePods: false
LabelPods: false
SidecarAnnotation: sidecar.istio.io/status
InitContainerName: istio-validation
InitTerminationMsg: 
InitExitCode: 126
LabelSelectors: 
FieldSelectors: 

2024-06-19T08:25:04.529398Z	info	Start a UDS server for CNI plugin logs
2024-06-19T08:25:04.529604Z	info	repair	Start CNI race condition repair.
2024-06-19T08:25:04.530923Z	info	cluster "" kube client started
2024-06-19T08:25:04.540517Z	info	klog	k8s.io/client-go@v0.28.3/tools/cache/reflector.go:229: failed to list *v1.Pod: pods is forbidden: User "system:serviceaccount:istio-operator:ossm-cni" cannot list resource "pods" in API group "" at the cluster scope
2024-06-19T08:25:04.540552Z	error	watch error in cluster : failed to list *v1.Pod: pods is forbidden: User "system:serviceaccount:istio-operator:ossm-cni" cannot list resource "pods" in API group "" at the cluster scope
2024-06-19T08:25:05.517537Z	info	klog	k8s.io/client-go@v0.28.3/tools/cache/reflector.go:229: failed to list *v1.Pod: pods is forbidden: User "system:serviceaccount:istio-operator:ossm-cni" cannot list resource "pods" in API group "" at the cluster scope
2024-06-19T08:25:05.517642Z	error	watch error in cluster : failed to list *v1.Pod: pods is forbidden: User "system:serviceaccount:istio-operator:ossm-cni" cannot list resource "pods" in API group "" at the cluster scope
2024-06-19T08:25:07.302274Z	info	klog	k8s.io/client-go@v0.28.3/tools/cache/reflector.go:229: failed to list *v1.Pod: pods is forbidden: User "system:serviceaccount:istio-operator:ossm-cni" cannot list resource "pods" in API group "" at the cluster scope
2024-06-19T08:25:07.302306Z	error	watch error in cluster : failed to list *v1.Pod: pods is forbidden: User "system:serviceaccount:istio-operator:ossm-cni" cannot list resource "pods" in API group "" at the cluster scope
2024-06-19T08:25:08.993926Z	info	waiting for sync...	name=repair controller attempt=50 time=4.462966788s
```