### PR TITLE
OSSM-6336 Deploy istio-cni ClusterRoleBinding and ServiceAccount only when required

### DIFF
--- a/resources/helm/overlays/istio_cni/templates/clusterrolebinding.yaml
+++ b/resources/helm/overlays/istio_cni/templates/clusterrolebinding.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.cni.enabled }}
+{{ if or (eq .Values.cni.instanceVersion "v2.0") (eq .Values.cni.instanceVersion "v2.1") (eq .Values.cni.instanceVersion "v2.2") (eq .Values.cni.instanceVersion "v2.3")}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -11,4 +12,5 @@ subjects:
   - kind: ServiceAccount
     name: istio-cni
     namespace: {{ .Release.Namespace }}
+{{ end }}
 {{ end }}

--- a/resources/helm/overlays/istio_cni/templates/serviceaccount.yaml
+++ b/resources/helm/overlays/istio_cni/templates/serviceaccount.yaml
@@ -1,7 +1,9 @@
 {{ if .Values.cni.enabled }}
+{{ if or (eq .Values.cni.instanceVersion "v2.0") (eq .Values.cni.instanceVersion "v2.1") (eq .Values.cni.instanceVersion "v2.2") (eq .Values.cni.instanceVersion "v2.3")}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: istio-cni
   namespace: {{ .Release.Namespace }}
+{{ end }}
 {{ end }}

--- a/resources/helm/v2.6/istio_cni/templates/clusterrolebinding.yaml
+++ b/resources/helm/v2.6/istio_cni/templates/clusterrolebinding.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.cni.enabled }}
+{{ if or (eq .Values.cni.instanceVersion "v2.0") (eq .Values.cni.instanceVersion "v2.1") (eq .Values.cni.instanceVersion "v2.2") (eq .Values.cni.instanceVersion "v2.3")}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -13,4 +14,5 @@ subjects:
   - kind: ServiceAccount
     name: istio-cni
     namespace: {{ .Release.Namespace }}
+{{ end }}
 {{ end }}

--- a/resources/helm/v2.6/istio_cni/templates/serviceaccount.yaml
+++ b/resources/helm/v2.6/istio_cni/templates/serviceaccount.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.cni.enabled }}
+{{ if or (eq .Values.cni.instanceVersion "v2.0") (eq .Values.cni.instanceVersion "v2.1") (eq .Values.cni.instanceVersion "v2.2") (eq .Values.cni.instanceVersion "v2.3")}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -6,4 +7,5 @@ metadata:
     maistra-version: "2.6.0"
   name: istio-cni
   namespace: {{ .Release.Namespace }}
+{{ end }}
 {{ end }}


### PR DESCRIPTION
Previously, the istio-cni ClusterRoleBinding and the istio-cni ServiceAccount were always created, regardless of the version being deployed. However, they were are only used by version v2.3 and earlier. Now they are only created when necessary.