### PR TITLE
OSSM-6717 Ensure istio-cni is invoked

### DIFF
--- a/pkg/controller/versions/strategy_v2_6.go
+++ b/pkg/controller/versions/strategy_v2_6.go
@@ -426,6 +426,10 @@ func (v *versionStrategyV2_6) Render(ctx context.Context, cr *common.ControllerR
 	if err != nil {
 		return nil, fmt.Errorf("could not set field status.lastAppliedConfiguration.istio.istio_cni.enabled: %v", err)
 	}
+	err = spec.Istio.SetField("istio_cni.chained", !cniConfig.UseMultus)
+	if err != nil {
+		return nil, fmt.Errorf("could not set value istio.istio_cni.chained: %v", err)
+	}
 	err = spec.Istio.SetField("istio_cni.istio_cni_network", v.GetCNINetworkName())
 	if err != nil {
 		return nil, fmt.Errorf("could not set field status.lastAppliedConfiguration.istio.istio_cni.istio_cni_network: %v", err)


### PR DESCRIPTION
In 2.5 and earlier versions, the istio-control/istio-discovery/values.yaml does not set any default values for `istio_cni`. In 2.6, it sets `enabled` to `false` and `chained` to `true`. Because chained is now true, sidecar injection no longer adds the `k8s.v1.cni.cncf.io/networks` annotation and thus istio-cni is never invoked.

 To fix this, the operator now ensures that `istio_cni.chained` is set correctly, depending on whether Multus is enabled.