### PR TITLE
Remove 2.2 version from 2.6 manifests

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -35,7 +35,7 @@ fi
 LD_EXTRAFLAGS+=" -X ${REPO_PATH}/pkg/version.buildStatus=${GITSTATUS}"
 
 : "${GITTAG:=$(git describe 2> /dev/null || echo "unknown")}"
-: "${MINIMUM_SUPPORTED_VERSION:=v2.2}"
+: "${MINIMUM_SUPPORTED_VERSION:=v2.3}"
 LD_EXTRAFLAGS+=" -X ${REPO_PATH}/pkg/version.buildTag=${GITTAG} -X ${REPO_PATH}/pkg/version.minimumSupportedVersion=${MINIMUM_SUPPORTED_VERSION}"
 
 LDFLAGS="-extldflags -static ${LD_EXTRAFLAGS} -s -w"

--- a/deploy/maistra-operator.yaml
+++ b/deploy/maistra-operator.yaml
@@ -11035,14 +11035,6 @@ spec:
         name: istio-operator
       annotations:
 
-        olm.relatedImage.v2_2.cni: quay.io/maistra/istio-cni-ubi8:2.2.2
-        olm.relatedImage.v2_2.grafana: quay.io/maistra/grafana-ubi8:2.2.2
-        olm.relatedImage.v2_2.pilot: quay.io/maistra/pilot-ubi8:2.2.2
-        olm.relatedImage.v2_2.prometheus: quay.io/maistra/prometheus-ubi8:2.2.2
-        olm.relatedImage.v2_2.proxyv2: quay.io/maistra/proxyv2-ubi8:2.2.2
-        olm.relatedImage.v2_2.wasm-cacher: quay.io/maistra/pilot-ubi8:2.2.2
-        olm.relatedImage.v2_2.rls: quay.io/maistra/ratelimit-ubi8:2.2.2
-
         olm.relatedImage.v2_3.cni: quay.io/maistra/istio-cni-ubi8:2.3.0
         olm.relatedImage.v2_3.grafana: quay.io/maistra/grafana-ubi8:2.3.0
         olm.relatedImage.v2_3.pilot: quay.io/maistra/pilot-ubi8:2.3.0

--- a/deploy/servicemesh-operator.yaml
+++ b/deploy/servicemesh-operator.yaml
@@ -11034,14 +11034,6 @@ spec:
       labels:
         name: istio-operator
       annotations:
-        # 2.2 images
-        olm.relatedImage.v2_2.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_22}
-        olm.relatedImage.v2_2.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_22}
-        olm.relatedImage.v2_2.pilot: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_22}
-        olm.relatedImage.v2_2.prometheus: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-prometheus-rhel8:${OSSM_22}
-        olm.relatedImage.v2_2.proxyv2: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxyv2-rhel8:${OSSM_22}
-        olm.relatedImage.v2_2.wasm-cacher: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_22}
-        olm.relatedImage.v2_2.rls: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-ratelimit-rhel8:${OSSM_22}
         # 2.3 images
         olm.relatedImage.v2_3.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_23}
         olm.relatedImage.v2_3.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_23}

--- a/deploy/src/deployment-maistra.yaml
+++ b/deploy/src/deployment-maistra.yaml
@@ -16,14 +16,6 @@ spec:
         name: istio-operator
       annotations:
 
-        olm.relatedImage.v2_2.cni: quay.io/maistra/istio-cni-ubi8:2.2.2
-        olm.relatedImage.v2_2.grafana: quay.io/maistra/grafana-ubi8:2.2.2
-        olm.relatedImage.v2_2.pilot: quay.io/maistra/pilot-ubi8:2.2.2
-        olm.relatedImage.v2_2.prometheus: quay.io/maistra/prometheus-ubi8:2.2.2
-        olm.relatedImage.v2_2.proxyv2: quay.io/maistra/proxyv2-ubi8:2.2.2
-        olm.relatedImage.v2_2.wasm-cacher: quay.io/maistra/pilot-ubi8:2.2.2
-        olm.relatedImage.v2_2.rls: quay.io/maistra/ratelimit-ubi8:2.2.2
-
         olm.relatedImage.v2_3.cni: quay.io/maistra/istio-cni-ubi8:2.3.0
         olm.relatedImage.v2_3.grafana: quay.io/maistra/grafana-ubi8:2.3.0
         olm.relatedImage.v2_3.pilot: quay.io/maistra/pilot-ubi8:2.3.0

--- a/deploy/src/deployment-servicemesh.yaml
+++ b/deploy/src/deployment-servicemesh.yaml
@@ -15,14 +15,6 @@ spec:
       labels:
         name: istio-operator
       annotations:
-        # 2.2 images
-        olm.relatedImage.v2_2.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_22}
-        olm.relatedImage.v2_2.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_22}
-        olm.relatedImage.v2_2.pilot: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_22}
-        olm.relatedImage.v2_2.prometheus: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-prometheus-rhel8:${OSSM_22}
-        olm.relatedImage.v2_2.proxyv2: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxyv2-rhel8:${OSSM_22}
-        olm.relatedImage.v2_2.wasm-cacher: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_22}
-        olm.relatedImage.v2_2.rls: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-ratelimit-rhel8:${OSSM_22}
         # 2.3 images
         olm.relatedImage.v2_3.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_23}
         olm.relatedImage.v2_3.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_23}

--- a/manifests-maistra/2.6.0/maistraoperator.v2.6.0.clusterserviceversion.yaml
+++ b/manifests-maistra/2.6.0/maistraoperator.v2.6.0.clusterserviceversion.yaml
@@ -15,7 +15,7 @@ metadata:
       The Maistra Operator enables you to install, configure, and manage an instance of Maistra service mesh. Maistra is based on the open source Istio project.
 
     containerImage: quay.io/maistra/istio-ubi8-operator:2.6.0
-    createdAt: 2024-06-14T11:54:17CEST
+    createdAt: 2024-06-27T09:46:40CEST
     support: Red Hat, Inc. 
     olm.skipRange: ">=1.0.2 <2.6.0-0"
     operators.openshift.io/infrastructure-features: '[]'
@@ -221,20 +221,6 @@ spec:
   - type: AllNamespaces
     supported: true
   relatedImages:
-  - name: v2_2.cni
-    image: quay.io/maistra/istio-cni-ubi8:2.2.2
-  - name: v2_2.grafana
-    image: quay.io/maistra/grafana-ubi8:2.2.2
-  - name: v2_2.pilot
-    image: quay.io/maistra/pilot-ubi8:2.2.2
-  - name: v2_2.prometheus
-    image: quay.io/maistra/prometheus-ubi8:2.2.2
-  - name: v2_2.proxyv2
-    image: quay.io/maistra/proxyv2-ubi8:2.2.2
-  - name: v2_2.wasm-cacher
-    image: quay.io/maistra/pilot-ubi8:2.2.2
-  - name: v2_2.rls
-    image: quay.io/maistra/ratelimit-ubi8:2.2.2
   - name: v2_3.cni
     image: quay.io/maistra/istio-cni-ubi8:2.3.0
   - name: v2_3.grafana
@@ -548,13 +534,6 @@ spec:
               labels:
                 name: istio-operator
               annotations:
-                olm.relatedImage.v2_2.cni: quay.io/maistra/istio-cni-ubi8:2.2.2
-                olm.relatedImage.v2_2.grafana: quay.io/maistra/grafana-ubi8:2.2.2
-                olm.relatedImage.v2_2.pilot: quay.io/maistra/pilot-ubi8:2.2.2
-                olm.relatedImage.v2_2.prometheus: quay.io/maistra/prometheus-ubi8:2.2.2
-                olm.relatedImage.v2_2.proxyv2: quay.io/maistra/proxyv2-ubi8:2.2.2
-                olm.relatedImage.v2_2.wasm-cacher: quay.io/maistra/pilot-ubi8:2.2.2
-                olm.relatedImage.v2_2.rls: quay.io/maistra/ratelimit-ubi8:2.2.2
                 olm.relatedImage.v2_3.cni: quay.io/maistra/istio-cni-ubi8:2.3.0
                 olm.relatedImage.v2_3.grafana: quay.io/maistra/grafana-ubi8:2.3.0
                 olm.relatedImage.v2_3.pilot: quay.io/maistra/pilot-ubi8:2.3.0

--- a/manifests-servicemesh/2.6.0/servicemeshoperator.v2.6.0.clusterserviceversion.yaml
+++ b/manifests-servicemesh/2.6.0/servicemeshoperator.v2.6.0.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
       The OpenShift Service Mesh Operator enables you to install, configure, and manage an instance of Red Hat OpenShift Service Mesh. OpenShift Service Mesh is based on the open source Istio project.
 
     containerImage: ${OSSM_OPERATOR_IMAGE}
-    createdAt: 2024-06-25T10:46:05CEST
+    createdAt: 2024-06-25T18:09:37CEST
     support: Red Hat, Inc. 
     olm.skipRange: ">=1.0.2 <2.6.0-0"
     operators.openshift.io/infrastructure-features: '["Disconnected","fips"]'
@@ -529,14 +529,6 @@ spec:
               labels:
                 name: istio-operator
               annotations:
-                # 2.2 images
-                olm.relatedImage.v2_2.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_22}
-                olm.relatedImage.v2_2.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_22}
-                olm.relatedImage.v2_2.pilot: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_22}
-                olm.relatedImage.v2_2.prometheus: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-prometheus-rhel8:${OSSM_22}
-                olm.relatedImage.v2_2.proxyv2: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-proxyv2-rhel8:${OSSM_22}
-                olm.relatedImage.v2_2.wasm-cacher: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-pilot-rhel8:${OSSM_22}
-                olm.relatedImage.v2_2.rls: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-ratelimit-rhel8:${OSSM_22}
                 # 2.3 images
                 olm.relatedImage.v2_3.cni: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-istio-cni-rhel8:${OSSM_23}
                 olm.relatedImage.v2_3.grafana: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-grafana-rhel8:${OSSM_23}

--- a/pkg/bootstrap/cni_test.go
+++ b/pkg/bootstrap/cni_test.go
@@ -32,13 +32,6 @@ func TestCNISupportedVersionRendering(t *testing.T) {
 		daemonsetName     string
 	}{
 		{
-			name:              "Default Supported Versions SMCP v2.2",
-			supportedVersions: versions.GetSupportedVersions(),
-			instanceVersion:   versions.V2_2.Version(),
-			containerNames:    []string{"install-cni-v2-2"},
-			daemonsetName:     "istio-cni-node",
-		},
-		{
 			name:              "Default Supported Versions SMCP v2.3",
 			supportedVersions: versions.GetSupportedVersions(),
 			instanceVersion:   versions.V2_3.Version(),
@@ -51,13 +44,6 @@ func TestCNISupportedVersionRendering(t *testing.T) {
 			instanceVersion:   versions.V2_4.Version(),
 			containerNames:    []string{"install-cni"},
 			daemonsetName:     "istio-cni-node-v2-4",
-		},
-		{
-			name:              "v2.2 only",
-			supportedVersions: []versions.Version{versions.V2_2},
-			instanceVersion:   versions.V2_2.Version(),
-			containerNames:    []string{"install-cni-v2-2"},
-			daemonsetName:     "istio-cni-node",
 		},
 		{
 			name:              "v2.3 only",

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -13,8 +13,8 @@ var (
 	buildStatus      = "unknown"
 	buildTag         = "unknown"
 
-	// Minimum supported mesh version (nil (all), "v2_0", "v2_1" etc)
-	minimumSupportedVersion = "v2.2"
+	// Minimum supported mesh version (nil (all), "v2_3", "v2_4" etc)
+	minimumSupportedVersion = "v2.3"
 
 	// Info exports the build version information.
 	Info BuildInfo


### PR DESCRIPTION
- Removes 2.2 from maistra and servicemesh 2.6 manifests
- bumps min supported version
- removes 2.2 cni tests
- does not touch code

I'm not sure if this is enough or we also need to remove it from helm templates [here](https://github.com/maistra/istio-operator/tree/maistra-2.6/resources/helm/v2.6/istio_cni/templates).