### PR TITLE
Ensure test error messages are printed to stdout

### DIFF
--- a/pkg/controller/common/test/cache.go
+++ b/pkg/controller/common/test/cache.go
@@ -150,7 +150,7 @@ func (c *FakeCache) createListWatcher(gvk schema.GroupVersionKind) (*toolscache.
 			// TODO: OSSM-1925
 			err := c.client.List(context.TODO(), res, &client.ListOptions{Namespace: c.namespace, Raw: &opts})
 			if err != nil {
-				log.Error(err, "OSSM-1925 Error listing resources", "listGVK", listGVK)
+				fmt.Println("OSSM-1925 Error listing resources: listGVK:", listGVK, "; error: ", err)
 			}
 			return res, nil
 		},

--- a/pkg/controller/common/test/client.go
+++ b/pkg/controller/common/test/client.go
@@ -36,12 +36,9 @@ import (
 	"k8s.io/client-go/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // XXX: look for the XXX comments to see how this has changed from sigs.k8s.io/controller-runtime/pkg/client/fake/client.go
-
-var log = logf.Log.WithName("fake-client")
 
 type fakeClient struct {
 	*testing.Fake
@@ -77,7 +74,7 @@ func NewFakeClientWithSchemeAndTracker(clientScheme *runtime.Scheme, tracker tes
 		}
 		err := tracker.Add(obj)
 		if err != nil {
-			log.Error(err, "failed to add object to fake client", "object", obj)
+			fmt.Println("failed to add object to fake client: object: ", obj, "; error: ", err)
 			os.Exit(1)
 			return nil
 		}


### PR DESCRIPTION
If a test tried to create a fake client by passing in two instances of the same object, the test would fail, but without any error messages, since the logs weren't written to stdout. Instead of using a logger, the tests now print to stdout directly.