### PR TITLE
OSSM-6757 Ensure CNI pod starts when using older images

### DIFF
--- a/resources/helm/overlays/istio_cni/templates/daemonset-v2.4.yaml
+++ b/resources/helm/overlays/istio_cni/templates/daemonset-v2.4.yaml
@@ -110,9 +110,13 @@ spec:
                 ;;
               esac
 
-              # Move the source binary to where install-cni expects it to be located and clean up unused binaries
-              mv $sourcebin /opt/cni/bin/istio-cni
-              rm /opt/cni/bin/istio-cni-rhel*
+              if [ -e "$sourcebin" ]; then
+                # Move the source binary to where install-cni expects it to be located and clean up unused binaries
+                mv "$sourcebin" /opt/cni/bin/istio-cni
+                rm /opt/cni/bin/istio-cni-rhel*
+              else
+                echo "WARNING: $sourcebin does not exist. Using original file /opt/cni/bin/istio-cni."
+              fi
 
               install-cni
           securityContext:

--- a/resources/helm/overlays/istio_cni/templates/daemonset-v2.5.yaml
+++ b/resources/helm/overlays/istio_cni/templates/daemonset-v2.5.yaml
@@ -119,9 +119,13 @@ spec:
                 ;;
               esac
 
-              # Move the source binary to where install-cni expects it to be located and clean up unused binaries
-              mv $sourcebin /opt/cni/bin/istio-cni
-              rm /opt/cni/bin/istio-cni-rhel*
+              if [ -e "$sourcebin" ]; then
+                # Move the source binary to where install-cni expects it to be located and clean up unused binaries
+                mv "$sourcebin" /opt/cni/bin/istio-cni
+                rm /opt/cni/bin/istio-cni-rhel*
+              else
+                echo "WARNING: $sourcebin does not exist. Using original file /opt/cni/bin/istio-cni."
+              fi
 
               install-cni
           securityContext:

--- a/resources/helm/overlays/istio_cni/templates/daemonset-v2.6.yaml
+++ b/resources/helm/overlays/istio_cni/templates/daemonset-v2.6.yaml
@@ -119,9 +119,13 @@ spec:
                 ;;
               esac
 
-              # Move the source binary to where install-cni expects it to be located and clean up unused binaries
-              mv $sourcebin /opt/cni/bin/istio-cni
-              rm /opt/cni/bin/istio-cni-rhel*
+              if [ -e "$sourcebin" ]; then
+                # Move the source binary to where install-cni expects it to be located and clean up unused binaries
+                mv "$sourcebin" /opt/cni/bin/istio-cni
+                rm /opt/cni/bin/istio-cni-rhel*
+              else
+                echo "WARNING: $sourcebin does not exist. Using original file /opt/cni/bin/istio-cni."
+              fi
 
               install-cni
           securityContext:

--- a/resources/helm/v2.6/istio_cni/templates/daemonset-v2.4.yaml
+++ b/resources/helm/v2.6/istio_cni/templates/daemonset-v2.4.yaml
@@ -111,9 +111,13 @@ spec:
                 ;;
               esac
 
-              # Move the source binary to where install-cni expects it to be located and clean up unused binaries
-              mv $sourcebin /opt/cni/bin/istio-cni
-              rm /opt/cni/bin/istio-cni-rhel*
+              if [ -e "$sourcebin" ]; then
+                # Move the source binary to where install-cni expects it to be located and clean up unused binaries
+                mv "$sourcebin" /opt/cni/bin/istio-cni
+                rm /opt/cni/bin/istio-cni-rhel*
+              else
+                echo "WARNING: $sourcebin does not exist. Using original file /opt/cni/bin/istio-cni."
+              fi
 
               install-cni
           securityContext:

--- a/resources/helm/v2.6/istio_cni/templates/daemonset-v2.5.yaml
+++ b/resources/helm/v2.6/istio_cni/templates/daemonset-v2.5.yaml
@@ -120,9 +120,13 @@ spec:
                 ;;
               esac
 
-              # Move the source binary to where install-cni expects it to be located and clean up unused binaries
-              mv $sourcebin /opt/cni/bin/istio-cni
-              rm /opt/cni/bin/istio-cni-rhel*
+              if [ -e "$sourcebin" ]; then
+                # Move the source binary to where install-cni expects it to be located and clean up unused binaries
+                mv "$sourcebin" /opt/cni/bin/istio-cni
+                rm /opt/cni/bin/istio-cni-rhel*
+              else
+                echo "WARNING: $sourcebin does not exist. Using original file /opt/cni/bin/istio-cni."
+              fi
 
               install-cni
           securityContext:

--- a/resources/helm/v2.6/istio_cni/templates/daemonset-v2.6.yaml
+++ b/resources/helm/v2.6/istio_cni/templates/daemonset-v2.6.yaml
@@ -120,9 +120,13 @@ spec:
                 ;;
               esac
 
-              # Move the source binary to where install-cni expects it to be located and clean up unused binaries
-              mv $sourcebin /opt/cni/bin/istio-cni
-              rm /opt/cni/bin/istio-cni-rhel*
+              if [ -e "$sourcebin" ]; then
+                # Move the source binary to where install-cni expects it to be located and clean up unused binaries
+                mv "$sourcebin" /opt/cni/bin/istio-cni
+                rm /opt/cni/bin/istio-cni-rhel*
+              else
+                echo "WARNING: $sourcebin does not exist. Using original file /opt/cni/bin/istio-cni."
+              fi
 
               install-cni
           securityContext:


### PR DESCRIPTION
Instead of failing with `mv: cannot stat '/opt/cni/bin/istio-cni-rhel9': No such file or directory`, the startup script now emits a warning and tries to use the original `/opt/cni/bin/istio-cni` binary.