### PR TITLE
OSSM-6762 Move webhook management from the operator to OLM

### DIFF
--- a/build/generate-crds.sh
+++ b/build/generate-crds.sh
@@ -32,7 +32,7 @@ function generateCRDs() {
   # Add maistra-version label
   sed -i -e "s/^  annotations:/  labels:\n    maistra-version: $MAISTRA_VERSION\n\\0/" deploy/crds/*
 
-  sed -i -e 's/^  annotations:/  annotations:\n    service.beta.openshift.io\/inject-cabundle: "true"/' \
+  sed -i -e 's/^  annotations:/  annotations:\n    service.beta.openshift.io\/inject-cabundle: "false"/' \
       deploy/crds/maistra.io_servicemeshcontrolplanes.yaml
 
   for bundle_dir in ${BUNDLE_DIRS}; do

--- a/build/manifest-templates/clusterserviceversion.yaml
+++ b/build/manifest-templates/clusterserviceversion.yaml
@@ -305,3 +305,101 @@ __DEPLOYMENT_SPEC__
       kind: ServiceMeshMemberRoll
       displayName: Istio Service Mesh Member Roll
       description: A list of namespaces in Service Mesh
+  webhookdefinitions:
+  - type: ValidatingAdmissionWebhook
+    admissionReviewVersions: ["v1beta1"]
+    generateName: smcp.validation.maistra.io
+    deploymentName: istio-operator
+    rules:
+    - operations: ["CREATE", "UPDATE"]
+      apiGroups: ["maistra.io"]
+      apiVersions: ["v1", "v2"]
+      resources: ["servicemeshcontrolplanes"]
+      scope: "*"
+    sideEffects: None
+    timeoutSeconds: 10
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    containerPort: 443
+    targetPort: 11999
+    webhookPath: /validate-smcp
+  - type: ValidatingAdmissionWebhook
+    admissionReviewVersions: ["v1beta1"]
+    generateName: smmr.validation.maistra.io
+    deploymentName: istio-operator
+    rules:
+    - operations: ["CREATE", "UPDATE"]
+      apiGroups: ["maistra.io"]
+      apiVersions: ["v1"]
+      resources: ["servicemeshmemberrolls"]
+      scope: "*"
+    sideEffects: None
+    timeoutSeconds: 10
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    containerPort: 443
+    targetPort: 11999
+    webhookPath: /validate-smmr
+  - type: ValidatingAdmissionWebhook
+    admissionReviewVersions: ["v1beta1"]
+    generateName: smm.validation.maistra.io
+    deploymentName: istio-operator
+    rules:
+    - operations: ["CREATE", "UPDATE"]
+      apiGroups: ["maistra.io"]
+      apiVersions: ["v1"]
+      resources: ["servicemeshmembers"]
+      scope: "*"
+    sideEffects: None
+    timeoutSeconds: 10
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    containerPort: 443
+    targetPort: 11999
+    webhookPath: /validate-smm
+  - type: MutatingAdmissionWebhook
+    admissionReviewVersions: ["v1beta1"]
+    generateName: smcp.mutation.maistra.io
+    deploymentName: istio-operator
+    rules:
+    - operations: ["CREATE", "UPDATE"]
+      apiGroups: ["maistra.io"]
+      apiVersions: ["v1", "v2"]
+      resources: ["servicemeshcontrolplanes"]
+      scope: "*"
+    sideEffects: NoneOnDryRun
+    timeoutSeconds: 10
+    failurePolicy: Fail
+    reinvocationPolicy: Never
+    matchPolicy: Equivalent
+    containerPort: 443
+    targetPort: 11999
+    webhookPath: /mutate-smcp
+  - type: MutatingAdmissionWebhook
+    admissionReviewVersions: ["v1beta1"]
+    generateName: smmr.mutation.maistra.io
+    deploymentName: istio-operator
+    rules:
+    - operations: ["CREATE", "UPDATE"]
+      apiGroups: ["maistra.io"]
+      apiVersions: ["v1"]
+      resources: ["servicemeshmemberrolls"]
+      scope: "*"
+    sideEffects: NoneOnDryRun
+    timeoutSeconds: 10
+    failurePolicy: Fail
+    reinvocationPolicy: Never
+    matchPolicy: Equivalent
+    containerPort: 443
+    targetPort: 11999
+    webhookPath: /mutate-smmr
+  - type: ConversionWebhook
+    conversionCRDs:
+    - servicemeshcontrolplanes.maistra.io
+    admissionReviewVersions: ["v1beta1"]
+    generateName: smcp.conversion.maistra.io
+    deploymentName: istio-operator
+    containerPort: 443
+    targetPort: 11999
+    webhookPath: /convert-smcp
+    sideEffects: NoneOnDryRun

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -36,6 +36,7 @@ import (
 	maistrav2 "github.com/maistra/istio-operator/pkg/apis/maistra/v2"
 	"github.com/maistra/istio-operator/pkg/controller"
 	"github.com/maistra/istio-operator/pkg/controller/common"
+	"github.com/maistra/istio-operator/pkg/controller/servicemesh/webhooks"
 	"github.com/maistra/istio-operator/pkg/version"
 )
 
@@ -190,9 +191,21 @@ func main() {
 	// Add the Metrics Service
 	addMetrics(ctx, cfg)
 
+	webhookCleanupRunnable := webhooks.NewCleanupRunnable(mgr.GetClient())
+	err = mgr.Add(webhookCleanupRunnable)
+	if err != nil {
+		log.Error(err, "error adding webhook cleanup")
+		os.Exit(1)
+	}
+
 	err = mgr.AddReadyzCheck("readiness", func(req *http.Request) error {
-		// no need to check anything; the readyz probe succeeds only when the
-		// webhooks are running (which only happens when the serving secret is present)
+		// The operator reports being ready only after the webhooks have been cleaned up.
+		// This is necessary to prevent the API server from invoking the webhooks
+		// with an invalid certificate, which would cause TLS cert errors being
+		// logged in the operator logs.
+		if !webhookCleanupRunnable.Done() {
+			return errors.New("webhook cleanup is still running")
+		}
 		return nil
 	})
 	if err != nil {
@@ -200,7 +213,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	log.Info("Starting the Cmd.")
+	log.Info("Starting controllers...")
 
 	// Start the Cmd
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {

--- a/deploy/maistra-operator.yaml
+++ b/deploy/maistra-operator.yaml
@@ -10999,13 +10999,12 @@ metadata:
 
 ---
 
+# NOTE: this is only needed on vanilla Kubernetes; On OpenShift, the Operator Lifecycle Manager (OLM) creates the service automatically
 apiVersion: v1
 kind: Service
 metadata:
-  name: maistra-admission-controller
+  name: istio-operator-service
   namespace: istio-operator
-  annotations:
-    service.beta.openshift.io/serving-cert-secret-name: maistra-operator-serving-cert
 spec:
   ports:
   - port: 443

--- a/deploy/maistra-operator.yaml
+++ b/deploy/maistra-operator.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     maistra-version: 2.6.0
   annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
+    service.beta.openshift.io/inject-cabundle: "false"
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: servicemeshcontrolplanes.maistra.io
@@ -11103,9 +11103,6 @@ spec:
         - name: operator-olm-config
           mountPath: /etc/operator/olm
           readOnly: true
-        - name: webhook-tls-volume
-          readOnly: true
-          mountPath: /tmp/k8s-webhook-server/serving-certs
         - name: smcp-templates
           readOnly: true
           mountPath: /usr/local/share/istio-operator/templates/
@@ -11117,10 +11114,6 @@ spec:
           - fieldRef:
               fieldPath: metadata.annotations
             path: config.properties
-      - name: webhook-tls-volume
-        secret:
-          secretName: maistra-operator-serving-cert
-          optional: true # this won't be available until service-ca creates the secret
       - name: smcp-templates
         configMap:
           name: smcp-templates

--- a/deploy/servicemesh-operator.yaml
+++ b/deploy/servicemesh-operator.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     maistra-version: 2.6.0
   annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
+    service.beta.openshift.io/inject-cabundle: "false"
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: servicemeshcontrolplanes.maistra.io
@@ -11109,9 +11109,6 @@ spec:
         - name: operator-olm-config
           mountPath: /etc/operator/olm
           readOnly: true
-        - name: webhook-tls-volume
-          readOnly: true
-          mountPath: /tmp/k8s-webhook-server/serving-certs
         - name: smcp-templates
           readOnly: true
           mountPath: /usr/local/share/istio-operator/templates/
@@ -11123,10 +11120,6 @@ spec:
           - fieldRef:
               fieldPath: metadata.annotations
             path: config.properties
-      - name: webhook-tls-volume
-        secret:
-          secretName: maistra-operator-serving-cert
-          optional: true # this won't be available until service-ca creates the secret
       - name: smcp-templates
         configMap:
           name: smcp-templates

--- a/deploy/servicemesh-operator.yaml
+++ b/deploy/servicemesh-operator.yaml
@@ -10999,13 +10999,12 @@ metadata:
 
 ---
 
+# NOTE: this is only needed on vanilla Kubernetes; On OpenShift, the Operator Lifecycle Manager (OLM) creates the service automatically
 apiVersion: v1
 kind: Service
 metadata:
-  name: maistra-admission-controller
+  name: istio-operator-service
   namespace: istio-operator
-  annotations:
-    service.beta.openshift.io/serving-cert-secret-name: maistra-operator-serving-cert
 spec:
   ports:
   - port: 443

--- a/deploy/src/crd.yaml
+++ b/deploy/src/crd.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     maistra-version: 2.6.0
   annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
+    service.beta.openshift.io/inject-cabundle: "false"
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: servicemeshcontrolplanes.maistra.io

--- a/deploy/src/deployment-maistra.yaml
+++ b/deploy/src/deployment-maistra.yaml
@@ -84,9 +84,6 @@ spec:
         - name: operator-olm-config
           mountPath: /etc/operator/olm
           readOnly: true
-        - name: webhook-tls-volume
-          readOnly: true
-          mountPath: /tmp/k8s-webhook-server/serving-certs
         - name: smcp-templates
           readOnly: true
           mountPath: /usr/local/share/istio-operator/templates/
@@ -98,10 +95,6 @@ spec:
           - fieldRef:
               fieldPath: metadata.annotations
             path: config.properties
-      - name: webhook-tls-volume
-        secret:
-          secretName: maistra-operator-serving-cert
-          optional: true # this won't be available until service-ca creates the secret
       - name: smcp-templates
         configMap:
           name: smcp-templates

--- a/deploy/src/deployment-servicemesh.yaml
+++ b/deploy/src/deployment-servicemesh.yaml
@@ -90,9 +90,6 @@ spec:
         - name: operator-olm-config
           mountPath: /etc/operator/olm
           readOnly: true
-        - name: webhook-tls-volume
-          readOnly: true
-          mountPath: /tmp/k8s-webhook-server/serving-certs
         - name: smcp-templates
           readOnly: true
           mountPath: /usr/local/share/istio-operator/templates/
@@ -104,10 +101,6 @@ spec:
           - fieldRef:
               fieldPath: metadata.annotations
             path: config.properties
-      - name: webhook-tls-volume
-        secret:
-          secretName: maistra-operator-serving-cert
-          optional: true # this won't be available until service-ca creates the secret
       - name: smcp-templates
         configMap:
           name: smcp-templates

--- a/deploy/src/mutatingwebhookconfigurations.yaml
+++ b/deploy/src/mutatingwebhookconfigurations.yaml
@@ -1,0 +1,65 @@
+# NOTE: these are only needed on vanilla Kubernetes; On OpenShift, the Operator Lifecycle Manager (OLM) creates them automatically
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: smcp.mutation.maistra.io
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    caBundle: CA_BUNDLE
+    service:
+      name: istio-operator-service
+      namespace: openshift-operators
+      path: /mutate-smcp
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: smcp.mutation.maistra.io
+  reinvocationPolicy: Never
+  rules:
+  - apiGroups:
+    - maistra.io
+    apiVersions:
+    - v1
+    - v2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - servicemeshcontrolplanes
+    scope: '*'
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: smmr.mutation.maistra.io
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    caBundle: CA_BUNDLE
+    service:
+      name: istio-operator-service
+      namespace: openshift-operators
+      path: /mutate-smmr
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: smmr.mutation.maistra.io
+  reinvocationPolicy: Never
+  rules:
+  - apiGroups:
+    - maistra.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - servicemeshmemberrolls
+    scope: '*'
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10

--- a/deploy/src/service.yaml
+++ b/deploy/src/service.yaml
@@ -1,10 +1,9 @@
+# NOTE: this is only needed on vanilla Kubernetes; On OpenShift, the Operator Lifecycle Manager (OLM) creates the service automatically
 apiVersion: v1
 kind: Service
 metadata:
-  name: maistra-admission-controller
+  name: istio-operator-service
   namespace: istio-operator
-  annotations:
-    service.beta.openshift.io/serving-cert-secret-name: maistra-operator-serving-cert
 spec:
   ports:
   - port: 443

--- a/deploy/src/validatingwebhookconfigurations.yaml
+++ b/deploy/src/validatingwebhookconfigurations.yaml
@@ -1,0 +1,94 @@
+# NOTE: these are only needed on vanilla Kubernetes; On OpenShift, the Operator Lifecycle Manager (OLM) creates them automatically
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: smcp.validation.maistra.io
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    caBundle: CA_BUNDLE
+    service:
+      name: istio-operator-service
+      namespace: openshift-operators
+      path: /validate-smcp
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: smcp.validation.maistra.io
+  rules:
+  - apiGroups:
+    - maistra.io
+    apiVersions:
+    - v1
+    - v2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - servicemeshcontrolplanes
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: smmr.validation.maistra.io
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    caBundle: CA_BUNDLE
+    service:
+      name: istio-operator-service
+      namespace: openshift-operators
+      path: /validate-smmr
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: smmr.validation.maistra.io
+  rules:
+  - apiGroups:
+    - maistra.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - servicemeshmemberrolls
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: smm.validation.maistra.io
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    caBundle: CA_BUNDLE
+    service:
+      name: istio-operator-service
+      namespace: openshift-operators
+      path: /validate-smm
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: smm.validation.maistra.io
+  rules:
+  - apiGroups:
+    - maistra.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - servicemeshmembers
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10

--- a/manifests-maistra/2.6.0/maistraoperator.v2.6.0.clusterserviceversion.yaml
+++ b/manifests-maistra/2.6.0/maistraoperator.v2.6.0.clusterserviceversion.yaml
@@ -15,7 +15,7 @@ metadata:
       The Maistra Operator enables you to install, configure, and manage an instance of Maistra service mesh. Maistra is based on the open source Istio project.
 
     containerImage: quay.io/maistra/istio-ubi8-operator:2.6.0
-    createdAt: 2024-06-27T09:46:40CEST
+    createdAt: 2024-07-02T10:41:36CEST
     support: Red Hat, Inc. 
     olm.skipRange: ">=1.0.2 <2.6.0-0"
     operators.openshift.io/infrastructure-features: '[]'
@@ -587,9 +587,6 @@ spec:
                     - name: operator-olm-config
                       mountPath: /etc/operator/olm
                       readOnly: true
-                    - name: webhook-tls-volume
-                      readOnly: true
-                      mountPath: /tmp/k8s-webhook-server/serving-certs
                     - name: smcp-templates
                       readOnly: true
                       mountPath: /usr/local/share/istio-operator/templates/
@@ -601,10 +598,6 @@ spec:
                       - fieldRef:
                           fieldPath: metadata.annotations
                         path: config.properties
-                - name: webhook-tls-volume
-                  secret:
-                    secretName: maistra-operator-serving-cert
-                    optional: true # this won't be available until service-ca creates the secret
                 - name: smcp-templates
                   configMap:
                     name: smcp-templates
@@ -728,3 +721,101 @@ spec:
       kind: ServiceMeshMemberRoll
       displayName: Istio Service Mesh Member Roll
       description: A list of namespaces in Service Mesh
+  webhookdefinitions:
+  - type: ValidatingAdmissionWebhook
+    admissionReviewVersions: ["v1beta1"]
+    generateName: smcp.validation.maistra.io
+    deploymentName: istio-operator
+    rules:
+    - operations: ["CREATE", "UPDATE"]
+      apiGroups: ["maistra.io"]
+      apiVersions: ["v1", "v2"]
+      resources: ["servicemeshcontrolplanes"]
+      scope: "*"
+    sideEffects: None
+    timeoutSeconds: 10
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    containerPort: 443
+    targetPort: 11999
+    webhookPath: /validate-smcp
+  - type: ValidatingAdmissionWebhook
+    admissionReviewVersions: ["v1beta1"]
+    generateName: smmr.validation.maistra.io
+    deploymentName: istio-operator
+    rules:
+    - operations: ["CREATE", "UPDATE"]
+      apiGroups: ["maistra.io"]
+      apiVersions: ["v1"]
+      resources: ["servicemeshmemberrolls"]
+      scope: "*"
+    sideEffects: None
+    timeoutSeconds: 10
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    containerPort: 443
+    targetPort: 11999
+    webhookPath: /validate-smmr
+  - type: ValidatingAdmissionWebhook
+    admissionReviewVersions: ["v1beta1"]
+    generateName: smm.validation.maistra.io
+    deploymentName: istio-operator
+    rules:
+    - operations: ["CREATE", "UPDATE"]
+      apiGroups: ["maistra.io"]
+      apiVersions: ["v1"]
+      resources: ["servicemeshmembers"]
+      scope: "*"
+    sideEffects: None
+    timeoutSeconds: 10
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    containerPort: 443
+    targetPort: 11999
+    webhookPath: /validate-smm
+  - type: MutatingAdmissionWebhook
+    admissionReviewVersions: ["v1beta1"]
+    generateName: smcp.mutation.maistra.io
+    deploymentName: istio-operator
+    rules:
+    - operations: ["CREATE", "UPDATE"]
+      apiGroups: ["maistra.io"]
+      apiVersions: ["v1", "v2"]
+      resources: ["servicemeshcontrolplanes"]
+      scope: "*"
+    sideEffects: NoneOnDryRun
+    timeoutSeconds: 10
+    failurePolicy: Fail
+    reinvocationPolicy: Never
+    matchPolicy: Equivalent
+    containerPort: 443
+    targetPort: 11999
+    webhookPath: /mutate-smcp
+  - type: MutatingAdmissionWebhook
+    admissionReviewVersions: ["v1beta1"]
+    generateName: smmr.mutation.maistra.io
+    deploymentName: istio-operator
+    rules:
+    - operations: ["CREATE", "UPDATE"]
+      apiGroups: ["maistra.io"]
+      apiVersions: ["v1"]
+      resources: ["servicemeshmemberrolls"]
+      scope: "*"
+    sideEffects: NoneOnDryRun
+    timeoutSeconds: 10
+    failurePolicy: Fail
+    reinvocationPolicy: Never
+    matchPolicy: Equivalent
+    containerPort: 443
+    targetPort: 11999
+    webhookPath: /mutate-smmr
+  - type: ConversionWebhook
+    conversionCRDs:
+    - servicemeshcontrolplanes.maistra.io
+    admissionReviewVersions: ["v1beta1"]
+    generateName: smcp.conversion.maistra.io
+    deploymentName: istio-operator
+    containerPort: 443
+    targetPort: 11999
+    webhookPath: /convert-smcp
+    sideEffects: NoneOnDryRun

--- a/manifests-maistra/2.6.0/servicemeshcontrolplanes.crd.yaml
+++ b/manifests-maistra/2.6.0/servicemeshcontrolplanes.crd.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     maistra-version: 2.6.0
   annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
+    service.beta.openshift.io/inject-cabundle: "false"
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: servicemeshcontrolplanes.maistra.io

--- a/manifests-servicemesh/2.6.0/servicemeshcontrolplanes.crd.yaml
+++ b/manifests-servicemesh/2.6.0/servicemeshcontrolplanes.crd.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     maistra-version: 2.6.0
   annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
+    service.beta.openshift.io/inject-cabundle: "false"
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: servicemeshcontrolplanes.maistra.io

--- a/manifests-servicemesh/2.6.0/servicemeshoperator.v2.6.0.clusterserviceversion.yaml
+++ b/manifests-servicemesh/2.6.0/servicemeshoperator.v2.6.0.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
       The OpenShift Service Mesh Operator enables you to install, configure, and manage an instance of Red Hat OpenShift Service Mesh. OpenShift Service Mesh is based on the open source Istio project.
 
     containerImage: ${OSSM_OPERATOR_IMAGE}
-    createdAt: 2024-06-25T18:09:37CEST
+    createdAt: 2024-07-02T10:41:37CEST
     support: Red Hat, Inc. 
     olm.skipRange: ">=1.0.2 <2.6.0-0"
     operators.openshift.io/infrastructure-features: '["Disconnected","fips"]'
@@ -592,9 +592,6 @@ spec:
                     - name: operator-olm-config
                       mountPath: /etc/operator/olm
                       readOnly: true
-                    - name: webhook-tls-volume
-                      readOnly: true
-                      mountPath: /tmp/k8s-webhook-server/serving-certs
                     - name: smcp-templates
                       readOnly: true
                       mountPath: /usr/local/share/istio-operator/templates/
@@ -606,10 +603,6 @@ spec:
                       - fieldRef:
                           fieldPath: metadata.annotations
                         path: config.properties
-                - name: webhook-tls-volume
-                  secret:
-                    secretName: maistra-operator-serving-cert
-                    optional: true # this won't be available until service-ca creates the secret
                 - name: smcp-templates
                   configMap:
                     name: smcp-templates
@@ -733,3 +726,101 @@ spec:
       kind: ServiceMeshMemberRoll
       displayName: Istio Service Mesh Member Roll
       description: A list of namespaces in Service Mesh
+  webhookdefinitions:
+  - type: ValidatingAdmissionWebhook
+    admissionReviewVersions: ["v1beta1"]
+    generateName: smcp.validation.maistra.io
+    deploymentName: istio-operator
+    rules:
+    - operations: ["CREATE", "UPDATE"]
+      apiGroups: ["maistra.io"]
+      apiVersions: ["v1", "v2"]
+      resources: ["servicemeshcontrolplanes"]
+      scope: "*"
+    sideEffects: None
+    timeoutSeconds: 10
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    containerPort: 443
+    targetPort: 11999
+    webhookPath: /validate-smcp
+  - type: ValidatingAdmissionWebhook
+    admissionReviewVersions: ["v1beta1"]
+    generateName: smmr.validation.maistra.io
+    deploymentName: istio-operator
+    rules:
+    - operations: ["CREATE", "UPDATE"]
+      apiGroups: ["maistra.io"]
+      apiVersions: ["v1"]
+      resources: ["servicemeshmemberrolls"]
+      scope: "*"
+    sideEffects: None
+    timeoutSeconds: 10
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    containerPort: 443
+    targetPort: 11999
+    webhookPath: /validate-smmr
+  - type: ValidatingAdmissionWebhook
+    admissionReviewVersions: ["v1beta1"]
+    generateName: smm.validation.maistra.io
+    deploymentName: istio-operator
+    rules:
+    - operations: ["CREATE", "UPDATE"]
+      apiGroups: ["maistra.io"]
+      apiVersions: ["v1"]
+      resources: ["servicemeshmembers"]
+      scope: "*"
+    sideEffects: None
+    timeoutSeconds: 10
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    containerPort: 443
+    targetPort: 11999
+    webhookPath: /validate-smm
+  - type: MutatingAdmissionWebhook
+    admissionReviewVersions: ["v1beta1"]
+    generateName: smcp.mutation.maistra.io
+    deploymentName: istio-operator
+    rules:
+    - operations: ["CREATE", "UPDATE"]
+      apiGroups: ["maistra.io"]
+      apiVersions: ["v1", "v2"]
+      resources: ["servicemeshcontrolplanes"]
+      scope: "*"
+    sideEffects: NoneOnDryRun
+    timeoutSeconds: 10
+    failurePolicy: Fail
+    reinvocationPolicy: Never
+    matchPolicy: Equivalent
+    containerPort: 443
+    targetPort: 11999
+    webhookPath: /mutate-smcp
+  - type: MutatingAdmissionWebhook
+    admissionReviewVersions: ["v1beta1"]
+    generateName: smmr.mutation.maistra.io
+    deploymentName: istio-operator
+    rules:
+    - operations: ["CREATE", "UPDATE"]
+      apiGroups: ["maistra.io"]
+      apiVersions: ["v1"]
+      resources: ["servicemeshmemberrolls"]
+      scope: "*"
+    sideEffects: NoneOnDryRun
+    timeoutSeconds: 10
+    failurePolicy: Fail
+    reinvocationPolicy: Never
+    matchPolicy: Equivalent
+    containerPort: 443
+    targetPort: 11999
+    webhookPath: /mutate-smmr
+  - type: ConversionWebhook
+    conversionCRDs:
+    - servicemeshcontrolplanes.maistra.io
+    admissionReviewVersions: ["v1beta1"]
+    generateName: smcp.conversion.maistra.io
+    deploymentName: istio-operator
+    containerPort: 443
+    targetPort: 11999
+    webhookPath: /convert-smcp
+    sideEffects: NoneOnDryRun

--- a/pkg/bootstrap/crds.go
+++ b/pkg/bootstrap/crds.go
@@ -27,8 +27,6 @@ import (
 
 	"github.com/maistra/istio-operator/pkg/controller/common"
 	"github.com/maistra/istio-operator/pkg/controller/hacks"
-	"github.com/maistra/istio-operator/pkg/controller/servicemesh/webhookca"
-	"github.com/maistra/istio-operator/pkg/controller/servicemesh/webhooks"
 )
 
 var (
@@ -61,13 +59,6 @@ func InstallCRDs(ctx context.Context, cl client.Client, chartsDir string) error 
 		}
 		return processCRDFile(ctx, cl, path)
 	})
-	if err != nil {
-		return err
-	}
-
-	// Register conversion webhooks for control plane CRD's - currently only ServiceMeshExtension
-	err = webhooks.RegisterConversionWebhook(ctx, cl, log, common.GetOperatorNamespace(),
-		&webhooks.SmeConverterServicePath, webhookca.ServiceMeshExtensionCRDName, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/servicemesh/webhooks/hacks.go
+++ b/pkg/controller/servicemesh/webhooks/hacks.go
@@ -3,396 +3,150 @@ package webhooks
 import (
 	"context"
 	"fmt"
-	"os"
-	"time"
+	"sync/atomic"
 
-	"github.com/go-logr/logr"
-	pkgerrors "github.com/pkg/errors"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
-	apixv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	maistrav1 "github.com/maistra/istio-operator/pkg/apis/maistra/v1"
-	maistrav2 "github.com/maistra/istio-operator/pkg/apis/maistra/v2"
 	"github.com/maistra/istio-operator/pkg/controller/common"
 	"github.com/maistra/istio-operator/pkg/controller/servicemesh/webhookca"
 )
-
-// XXX: this entire file can be removed once ValidatingWebhookConfiguration and
-// Service definitions are moved into the operator's CSV file.
-
-var webhookFailurePolicy = admissionv1.Fail
 
 const (
 	webhookSecretName    = "maistra-operator-serving-cert"
 	webhookConfigMapName = "maistra-operator-cabundle"
 	webhookServiceName   = "maistra-admission-controller"
+
+	injectCABundleKey = "service.beta.openshift.io/inject-cabundle"
 )
 
-func createWebhookResources(ctx context.Context, mgr manager.Manager, log logr.Logger, operatorNamespace string) error {
-	cl, err := client.New(mgr.GetConfig(), client.Options{Scheme: mgr.GetScheme()})
-	if err != nil {
-		return pkgerrors.Wrap(err, "error creating k8s client")
-	}
+// Returns a Runnable that will remove the resources that previous versions of
+// the operator created for webhooks, so that they don't conflict with the
+// new resources that are deployed by OLM.
+func NewCleanupRunnable(cl client.Client) *WebhookCleanupRunnable {
+	return &WebhookCleanupRunnable{client: cl}
+}
 
-	webhookServiceCreated := false
-	log.Info("Creating Maistra webhook Service")
-	if err := cl.Create(context.TODO(), newWebhookService(operatorNamespace)); err == nil {
-		webhookServiceCreated = true
-	} else {
-		if errors.IsAlreadyExists(err) {
-			log.Info("Maistra webhook Service already exists")
-		} else {
-			return pkgerrors.Wrap(err, "error creating Maistra webhook Service")
-		}
-	}
+type WebhookCleanupRunnable struct {
+	client client.Client
+	done   atomic.Bool
+}
 
-	log.Info("Creating Maistra webhook CA bundle ConfigMap")
-	if err := cl.Create(context.TODO(), newCABundleConfigMap(operatorNamespace)); err != nil {
-		if errors.IsAlreadyExists(err) {
-			log.Info("Maistra webhook CA bundle ConfigMap already exists")
-		} else {
-			return pkgerrors.Wrap(err, "error creating Maistra webhook CA bundle ConfigMap")
-		}
-	}
+var (
+	_ manager.Runnable               = &WebhookCleanupRunnable{}
+	_ manager.LeaderElectionRunnable = &WebhookCleanupRunnable{}
+)
 
-	log.Info("Creating Maistra ValidatingWebhookConfiguration")
-	validatingWebhookConfiguration := newValidatingWebhookConfiguration(operatorNamespace)
-	if err := cl.Create(context.TODO(), validatingWebhookConfiguration); err != nil {
-		if errors.IsAlreadyExists(err) {
-			// the cache is not available until the manager is started, so webhook update needs to be done during startup.
-			log.Info("Updating existing Maistra ValidatingWebhookConfiguration")
-			existing := &admissionv1.ValidatingWebhookConfiguration{}
-			if err := cl.Get(context.TODO(), types.NamespacedName{Name: validatingWebhookConfiguration.GetName()}, existing); err != nil {
-				return pkgerrors.Wrap(err, "error retrieving existing Maistra ValidatingWebhookConfiguration")
-			}
-			validatingWebhookConfiguration.SetResourceVersion(existing.GetResourceVersion())
-			if err := cl.Update(context.TODO(), validatingWebhookConfiguration); err != nil {
-				return pkgerrors.Wrap(err, "error updating existing Maistra ValidatingWebhookConfiguration")
-			}
-		} else {
-			return err
-		}
-	}
+func (r *WebhookCleanupRunnable) Start(_ <-chan struct{}) error {
+	ctx := common.NewContextWithLog(common.NewContext(), logf.Log.WithName("webhook-cleanup"))
 
-	log.Info("Registering Maistra ValidatingWebhookConfiguration with CABundle reconciler")
-	if err := webhookca.WebhookCABundleManagerInstance.ManageWebhookCABundle(
-		validatingWebhookConfiguration,
-		&webhookca.ConfigMapCABundleSource{
-			Namespace:     operatorNamespace,
-			ConfigMapName: webhookConfigMapName,
-			Key:           common.ServiceCABundleKey,
-		}); err != nil {
+	if err := removeObsoleteWebhookResources(ctx, r.client); err != nil {
+		return err
+	}
+	if err := disableCRDBundleInjection(ctx, r.client); err != nil {
 		return err
 	}
 
-	log.Info("Creating Maistra MutatingWebhookConfiguration")
-	mutatingWebhookConfiguration := newMutatingWebhookConfiguration(operatorNamespace)
-	if err := cl.Create(context.TODO(), mutatingWebhookConfiguration); err != nil {
-		if errors.IsAlreadyExists(err) {
-			// the cache is not available until the manager is started, so webhook update needs to be done during startup.
-			log.Info("Updating existing Maistra MutatingWebhookConfiguration")
-			existing := &admissionv1.MutatingWebhookConfiguration{}
-			if err := cl.Get(context.TODO(), types.NamespacedName{Name: mutatingWebhookConfiguration.GetName()}, existing); err != nil {
-				return pkgerrors.Wrap(err, "error retrieving existing Maistra MutatingWebhookConfiguration")
-			}
-			mutatingWebhookConfiguration.SetResourceVersion(existing.GetResourceVersion())
-			if err := cl.Update(context.TODO(), mutatingWebhookConfiguration); err != nil {
-				return pkgerrors.Wrap(err, "error updating existing Maistra MutatingWebhookConfiguration")
-			}
-		} else {
-			return err
-		}
-	}
-
-	log.Info("Registering Maistra MutatingWebhookConfiguration with CABundle reconciler")
-	if err := webhookca.WebhookCABundleManagerInstance.ManageWebhookCABundle(
-		mutatingWebhookConfiguration,
-		&webhookca.ConfigMapCABundleSource{
-			Namespace:     operatorNamespace,
-			ConfigMapName: webhookConfigMapName,
-			Key:           common.ServiceCABundleKey,
-		}); err != nil {
-		return err
-	}
-
-	if err := RegisterConversionWebhook(ctx, cl, log, operatorNamespace, &smcpConverterServicePath, webhookca.ServiceMeshControlPlaneCRDName, true); err != nil {
-		return err
-	}
-
-	if err := RegisterConversionWebhook(ctx, cl, log, operatorNamespace, &SmeConverterServicePath, webhookca.ServiceMeshExtensionCRDName, false); err != nil {
-		return err
-	}
-
-	// wait for secret to become available to prevent the operator from bouncing
-	// we don't worry about any errors here, as the worst thing that will happen
-	// is that the operator might restart.
-	coreclient, err := clientcorev1.NewForConfig(mgr.GetConfig())
-	if err != nil {
-		log.Info("error occurred creating client for watching Maistra webhook Secret")
-		return nil
-	}
-	secretwatch, err := coreclient.Secrets(operatorNamespace).Watch(ctx, metav1.ListOptions{FieldSelector: fmt.Sprintf("metadata.name=%s", webhookSecretName)})
-	if err != nil {
-		log.Info("error occurred creating watch for Maistra webhook Secret")
-		return nil
-	}
-	func() {
-		defer secretwatch.Stop()
-		for {
-			select {
-			case <-secretwatch.ResultChan():
-				return
-			case <-time.After(1 * time.Second):
-				log.Info("Waiting for Maistra webhook Secret to become available", "Secret", webhookSecretName)
-			}
-		}
-	}()
-	log.Info("Maistra webhook Secret is ready", "Secret", webhookSecretName)
-
-	configMapWatch, err := coreclient.ConfigMaps(operatorNamespace).Watch(ctx,
-		metav1.ListOptions{FieldSelector: fmt.Sprintf("metadata.name=%s", webhookConfigMapName)})
-	if err != nil {
-		log.Info("error occurred creating watch for Maistra webhook CA bundle ConfigMap")
-		return nil
-	}
-	func() {
-		defer configMapWatch.Stop()
-		for {
-			select {
-			case <-configMapWatch.ResultChan():
-				return
-			case <-time.After(1 * time.Second):
-				log.Info("Waiting for Maistra webhook CA bundle ConfigMap to become available", "ConfigMap", webhookConfigMapName)
-			}
-		}
-	}()
-	log.Info("Maistra webhook CA bundle ConfigMap is ready", "ConfigMap", webhookConfigMapName)
-
-	// If we have just created the webhook Service, then the Secret didn't exist
-	// when the operator Pod was created and so the Secret couldn't have been
-	// mounted. We exit so that the container is restarted. In the next run of
-	// the container, the Secret will be mounted.
-	if webhookServiceCreated {
-		log.Info("Restarting to obtain the Maistra webhook Secret and CA bundle ConfigMap...")
-		os.Exit(0)
-	}
-
+	r.done.Store(true)
 	return nil
 }
 
-func RegisterConversionWebhook(
-	ctx context.Context,
-	cl client.Client,
-	log logr.Logger,
-	operatorNamespace string,
-	path *string,
-	crdName string,
-	crdMustExist bool,
-) error {
-	log.Info(fmt.Sprintf("Adding conversion webhook to %s CRD", crdName))
+// NeedLeaderElection returns false because it needs to run before the operator
+// becomes the leader, since the operator also starts serving webhooks before
+// it becomes the leader. If the webhooks are cleaned up as soon as the operator
+// starts, then the webhook server will log TLS certificate errors because the
+// old certificate is still being used.
+// With NeedLeaderElection being false, if multiple instances of the operator
+// start at the same time, they will all try to delete these resources, but this
+// shouldn't be an issue because the code that deletes them handles conflicts.
+func (r *WebhookCleanupRunnable) NeedLeaderElection() bool {
+	return false
+}
 
-	crd := &apixv1.CustomResourceDefinition{}
-	if err := cl.Get(ctx, client.ObjectKey{Name: crdName}, crd); err != nil {
-		if !crdMustExist && errors.IsNotFound(err) {
-			log.Info(fmt.Sprintf("Not registering conversion webhook for CRD %q as it doesn't exist yet.", crdName))
-			return nil
+func (r *WebhookCleanupRunnable) Done() bool {
+	return r.done.Load()
+}
+
+// removeObsoleteWebhookResources removes the Validating/MutatingWebhookConfiguration,
+// and the associated Service, Secret, and ConfigMap that were created by previous
+// versions of the operator.
+func removeObsoleteWebhookResources(ctx context.Context, cl client.Client) error {
+	operatorNamespace := common.GetOperatorNamespace()
+
+	type webhookResource struct {
+		obj       runtime.Object
+		name      string
+		namespace string
+	}
+	webhookResources := []webhookResource{
+		{obj: &corev1.Service{}, name: webhookServiceName, namespace: operatorNamespace},
+		{obj: &corev1.Secret{}, name: webhookSecretName, namespace: operatorNamespace},
+		{obj: &corev1.ConfigMap{}, name: webhookConfigMapName, namespace: operatorNamespace},
+		{obj: &admissionv1.ValidatingWebhookConfiguration{}, name: validatingWebhookConfigName(operatorNamespace)},
+		{obj: &admissionv1.MutatingWebhookConfiguration{}, name: mutatingWebhookConfigName(operatorNamespace)},
+	}
+	for _, res := range webhookResources {
+		if err := deleteObject(ctx, cl, res.obj, res.name, res.namespace); err != nil {
+			return err
 		}
-
-		return err
 	}
-
-	newCrd := crd.DeepCopy()
-	newCrd.Spec.Conversion = &apixv1.CustomResourceConversion{
-		Strategy: apixv1.WebhookConverter,
-		Webhook: &apixv1.WebhookConversion{
-			ConversionReviewVersions: []string{"v1beta1"},
-			ClientConfig: &apixv1.WebhookClientConfig{
-				URL: nil,
-				Service: &apixv1.ServiceReference{
-					Name:      webhookServiceName,
-					Namespace: operatorNamespace,
-					Path:      path,
-				},
-			},
-		},
-	}
-
-	log.Info(fmt.Sprintf("Registering Maistra %s CRD conversion webhook with CABundle reconciler", crdName))
-	if err := webhookca.WebhookCABundleManagerInstance.ManageWebhookCABundle(
-		newCrd,
-		&webhookca.ConfigMapCABundleSource{
-			Namespace:     operatorNamespace,
-			ConfigMapName: webhookConfigMapName,
-			Key:           common.ServiceCABundleKey,
-		}); err != nil {
-		return fmt.Errorf("error registering %s CRD conversion webhook with CABundle reconciler: %v", crdName, err)
-	}
-
-	if err := cl.Patch(ctx, newCrd, client.MergeFrom(crd), client.FieldOwner(common.FinalizerName)); err != nil {
-		return fmt.Errorf("error patching CRD %s: %v", crdName, err)
-	}
-
 	return nil
 }
 
-func newWebhookService(namespace string) *corev1.Service {
-	return &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      webhookServiceName,
-			Namespace: namespace,
-			Annotations: map[string]string{
-				"service.beta.openshift.io/serving-cert-secret-name": webhookSecretName,
-			},
-		},
-		Spec: corev1.ServiceSpec{
-			Selector: map[string]string{
-				"name": "istio-operator",
-			},
-			Ports: []corev1.ServicePort{
-				{
-					Name:       "validation",
-					Port:       443,
-					TargetPort: intstr.FromInt(11999),
-				},
-			},
-		},
-	}
+func deleteObject(ctx context.Context, cl client.Client, obj runtime.Object, name, ns string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if err := cl.Get(ctx, client.ObjectKey{Name: name, Namespace: ns}, obj); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+
+		log := common.LogFromContext(ctx)
+		if err := cl.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+		log.Info("Deleted old webhook object", "kind", obj.GetObjectKind().GroupVersionKind(), "name", name, "namespace", ns)
+		return nil
+	})
 }
 
-func newCABundleConfigMap(namespace string) *corev1.ConfigMap {
-	return &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      webhookConfigMapName,
-			Namespace: namespace,
-			Annotations: map[string]string{
-				"service.beta.openshift.io/inject-cabundle": "true",
-			},
-		},
-	}
+// disableCRDBundleInjection removes the annotation that causes the CA bundle to
+// be injected into the servicemeshcontrolplanes CRD. This must be done so that
+// OLM and the service-ca operator don't fight over the CA bundle, causing the
+// CRD to be updated continuously.
+// Note: the CRD definition bundled with the operator already has this annotation
+// set to false, but since it's critical for this annotation to be false to prevent
+// the issue described above, we set it to false here as well.
+func disableCRDBundleInjection(ctx context.Context, cl client.Client) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		crd := &apiextensionsv1.CustomResourceDefinition{}
+		if err := cl.Get(ctx, client.ObjectKey{Name: webhookca.ServiceMeshControlPlaneCRDName}, crd); err != nil {
+			return err
+		}
+
+		if crd.Annotations != nil && crd.Annotations[injectCABundleKey] == "true" {
+			crd.Annotations[injectCABundleKey] = "false"
+			if err := cl.Update(ctx, crd); err != nil {
+				return err
+			}
+			log.Info("Updated CRD annotation value from true to false", "annotation", injectCABundleKey, "crd", webhookca.ServiceMeshControlPlaneCRDName)
+		}
+		return nil
+	})
 }
 
-func newValidatingWebhookConfiguration(namespace string) *admissionv1.ValidatingWebhookConfiguration {
-	noneSideEffects := admissionv1.SideEffectClassNone
-	return &admissionv1.ValidatingWebhookConfiguration{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%s.servicemesh-resources.maistra.io", namespace),
-			Annotations: map[string]string{
-				"service.beta.openshift.io/inject-cabundle": "true",
-			},
-		},
-		Webhooks: []admissionv1.ValidatingWebhook{
-			{
-				Name: "smcp.validation.maistra.io",
-				Rules: rulesFor("servicemeshcontrolplanes",
-					[]string{maistrav1.SchemeGroupVersion.Version, maistrav2.SchemeGroupVersion.Version},
-					admissionv1.Create, admissionv1.Update),
-				FailurePolicy:           &webhookFailurePolicy,
-				SideEffects:             &noneSideEffects,
-				AdmissionReviewVersions: []string{"v1beta1"},
-				ClientConfig: admissionv1.WebhookClientConfig{
-					Service: &admissionv1.ServiceReference{
-						Path:      &smcpValidatorServicePath,
-						Name:      webhookServiceName,
-						Namespace: namespace,
-					},
-				},
-			},
-			{
-				Name: "smmr.validation.maistra.io",
-				Rules: rulesFor("servicemeshmemberrolls",
-					[]string{maistrav1.SchemeGroupVersion.Version}, admissionv1.Create, admissionv1.Update),
-				FailurePolicy:           &webhookFailurePolicy,
-				SideEffects:             &noneSideEffects,
-				AdmissionReviewVersions: []string{"v1beta1"},
-				ClientConfig: admissionv1.WebhookClientConfig{
-					Service: &admissionv1.ServiceReference{
-						Path:      &smmrValidatorServicePath,
-						Name:      webhookServiceName,
-						Namespace: namespace,
-					},
-				},
-			},
-			{
-				Name: "smm.validation.maistra.io",
-				Rules: rulesFor("servicemeshmembers",
-					[]string{maistrav1.SchemeGroupVersion.Version}, admissionv1.Create, admissionv1.Update),
-				FailurePolicy:           &webhookFailurePolicy,
-				SideEffects:             &noneSideEffects,
-				AdmissionReviewVersions: []string{"v1beta1"},
-				ClientConfig: admissionv1.WebhookClientConfig{
-					Service: &admissionv1.ServiceReference{
-						Path:      &smmValidatorServicePath,
-						Name:      webhookServiceName,
-						Namespace: namespace,
-					},
-				},
-			},
-		},
-	}
+func validatingWebhookConfigName(ns string) string {
+	return fmt.Sprintf("%s.servicemesh-resources.maistra.io", ns)
 }
 
-func newMutatingWebhookConfiguration(namespace string) *admissionv1.MutatingWebhookConfiguration {
-	noneOnDryRunSideEffects := admissionv1.SideEffectClassNoneOnDryRun
-	return &admissionv1.MutatingWebhookConfiguration{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%s.servicemesh-resources.maistra.io", namespace),
-			Annotations: map[string]string{
-				"service.beta.openshift.io/inject-cabundle": "true",
-			},
-		},
-		Webhooks: []admissionv1.MutatingWebhook{
-			{
-				Name: "smcp.mutation.maistra.io",
-				Rules: rulesFor("servicemeshcontrolplanes",
-					[]string{maistrav1.SchemeGroupVersion.Version, maistrav2.SchemeGroupVersion.Version},
-					admissionv1.Create, admissionv1.Update),
-				FailurePolicy:           &webhookFailurePolicy,
-				SideEffects:             &noneOnDryRunSideEffects,
-				AdmissionReviewVersions: []string{"v1beta1"},
-				ClientConfig: admissionv1.WebhookClientConfig{
-					Service: &admissionv1.ServiceReference{
-						Path:      &smcpMutatorServicePath,
-						Name:      webhookServiceName,
-						Namespace: namespace,
-					},
-				},
-			},
-			{
-				Name: "smmr.mutation.maistra.io",
-				Rules: rulesFor("servicemeshmemberrolls",
-					[]string{maistrav1.SchemeGroupVersion.Version}, admissionv1.Create, admissionv1.Update),
-				FailurePolicy:           &webhookFailurePolicy,
-				SideEffects:             &noneOnDryRunSideEffects,
-				AdmissionReviewVersions: []string{"v1beta1"},
-				ClientConfig: admissionv1.WebhookClientConfig{
-					Service: &admissionv1.ServiceReference{
-						Path:      &smmrMutatorServicePath,
-						Name:      webhookServiceName,
-						Namespace: namespace,
-					},
-				},
-			},
-		},
-	}
-}
-
-func rulesFor(resource string, versions []string, operations ...admissionv1.OperationType) []admissionv1.RuleWithOperations {
-	return []admissionv1.RuleWithOperations{
-		{
-			Rule: admissionv1.Rule{
-				APIGroups:   []string{maistrav1.SchemeGroupVersion.Group},
-				APIVersions: versions,
-				Resources:   []string{resource},
-			},
-			Operations: operations,
-		},
-	}
+func mutatingWebhookConfigName(namespace string) string {
+	return fmt.Sprintf("%s.servicemesh-resources.maistra.io", namespace)
 }

--- a/pkg/controller/servicemesh/webhooks/server.go
+++ b/pkg/controller/servicemesh/webhooks/server.go
@@ -9,7 +9,6 @@ import (
 
 	// This is required to ensure v1.ConverterV1V2 and v1.ConverterV2V1 are properly initialized
 	_ "github.com/maistra/istio-operator/pkg/apis/maistra/conversion"
-	"github.com/maistra/istio-operator/pkg/controller/common"
 	webhookcommon "github.com/maistra/istio-operator/pkg/controller/servicemesh/webhooks/common"
 	"github.com/maistra/istio-operator/pkg/controller/servicemesh/webhooks/mutation"
 	"github.com/maistra/istio-operator/pkg/controller/servicemesh/webhooks/validation"
@@ -31,17 +30,7 @@ var (
 
 // Add webhook handlers
 func Add(mgr manager.Manager) error {
-	ctx := common.NewContextWithLog(common.NewContext(), log)
 	log.Info("Configuring Maistra webhooks")
-
-	if !common.Config.Controller.WebhookManagementEnabled {
-		log.Info("Webhook Config Management is disabled via olm configuration")
-	} else {
-		operatorNamespace := common.GetOperatorNamespace()
-		if err := createWebhookResources(ctx, mgr, log, operatorNamespace); err != nil {
-			return err
-		}
-	}
 
 	watchNamespaceStr, err := k8sutil.GetWatchNamespace()
 	if err != nil {

--- a/tests/integration/operator-integ-suite-kind.sh
+++ b/tests/integration/operator-integ-suite-kind.sh
@@ -58,9 +58,6 @@ echo "--------------------------------"
 echo "Deploy istio operator in kind"
 echo "--------------------------------"
 "${WD}"/deploy-operator.sh
-# wait for validation webhook
-echo "Wait 30s for validation webhook..."
-sleep 30
 
 # create a SMCP and test httpbin
 echo "--------------------------------"


### PR DESCRIPTION
- The operator will no longer create the Mutating/ValidatingWebhookConfigurations and associated Service, Secret, and ConfigMap, as they will now be created by OLM.
- On startup, the operator will delete these old resources so that they don't conflict with the ones created by OLM.
- Previously, the operator had to restart after creating the resources so that the Secret holding the certificate and private key was injected into the operator pod. As this secret is now created by OLM before the operator starts, the operator no longer needs to restart on its first run.
- The servicemeshcontrolplanes CRD must have CA injection disabled so that OLM and the service-ca operator don't both inject the CA bundle into the CRD.