### PR TITLE
OSSM-6774 Use the existing kube clients to create metrics resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -84,6 +84,6 @@ replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v4.9.0+in
 // pkg disappeard from bitbucket
 replace bitbucket.org/ww/goautoneg => github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d
 
-replace github.com/operator-framework/operator-sdk => github.com/maistra/operator-sdk v0.0.0-20210824135520-3b25565223d4
+replace github.com/operator-framework/operator-sdk => github.com/maistra/operator-sdk v0.0.0-20240705083128-74426394d845
 
 replace github.com/mikefarah/yaml/v2 => gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -669,8 +669,8 @@ github.com/mailru/easyjson v0.7.0 h1:aizVhC/NAAcKWb+5QsU1iNOZb4Yws5UO2I+aIprQITM
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/maistra/kubernetes-client-go v0.0.0-20240704065002-d72687b232f2 h1:MDYbFkdrlp/b4t2xIkd+ItCeBoA+HAs5IbrPK8yYwCg=
 github.com/maistra/kubernetes-client-go v0.0.0-20240704065002-d72687b232f2/go.mod h1:4a/dpQEvzAhT1BbuWW09qvIaGw6Gbu1gZYiQZIi1DMw=
-github.com/maistra/operator-sdk v0.0.0-20210824135520-3b25565223d4 h1:xokmdp2Sq11u/2yH+dLUWu27BUchnYWwGKhQZZeHycM=
-github.com/maistra/operator-sdk v0.0.0-20210824135520-3b25565223d4/go.mod h1:xP/DNvnYnIoGK1bLKiD0s7aYZp2fa4AI6t1v3INaoZg=
+github.com/maistra/operator-sdk v0.0.0-20240705083128-74426394d845 h1:R1BK+pCN+HYgMEI7wLpLT/sUZsHde6rv1WqPFCezlAw=
+github.com/maistra/operator-sdk v0.0.0-20240705083128-74426394d845/go.mod h1:Ro01yPRKVIqTg2e7vSs8wcFTpqfWwojN5TCV/wWMFts=
 github.com/markbates/inflect v1.0.4 h1:5fh1gzTFhfae06u3hzHYO9xe3l3v3nW5Pwt3naLTP5g=
 github.com/markbates/inflect v1.0.4/go.mod h1:1fR9+pO2KHEO9ZRtto13gDwwZaAKstQzferVeWqbgNs=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=

--- a/pkg/controller/common/discovery.go
+++ b/pkg/controller/common/discovery.go
@@ -3,5 +3,5 @@ package common
 import "k8s.io/client-go/discovery"
 
 type DiscoveryClientProvider interface {
-	GetDiscoveryClient() (discovery.DiscoveryInterface, error)
+	GetDiscoveryClient() discovery.DiscoveryInterface
 }

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -335,6 +335,6 @@ func (m EnhancedManager) GetLogger() logr.Logger {
 	return m.delegate.GetLogger()
 }
 
-func (m EnhancedManager) GetDiscoveryClient() (discovery.DiscoveryInterface, error) {
-	return m.dc, nil
+func (m EnhancedManager) GetDiscoveryClient() discovery.DiscoveryInterface {
+	return m.dc
 }

--- a/pkg/controller/servicemesh/controlplane/controller.go
+++ b/pkg/controller/servicemesh/controlplane/controller.go
@@ -43,11 +43,7 @@ func Add(mgr manager.Manager) error {
 	if !ok {
 		return fmt.Errorf("expected mgr to be a DiscoveryClientProvider")
 	}
-	dc, err := dcProvider.GetDiscoveryClient()
-	if err != nil {
-		return err
-	}
-
+	dc := dcProvider.GetDiscoveryClient()
 	reconciler := newReconciler(mgr.GetClient(), mgr.GetScheme(), mgr.GetEventRecorderFor(controllerName), operatorNamespace, cni.GetConfig(mgr), dc)
 	return add(mgr, reconciler)
 }


### PR DESCRIPTION
Previously, during startup, the operator instantiated a separate kube client and a separate discovery client to create the Service and ServiceMonitor for metrics. Now, the existing clients provided by the controller manager are used to create these two resources.

However, since these clients are only initialized when the manager is started, the code that creates the two metrics resources is now invoked by a runnable registered with the manager via `mgr.Add()`.