### PR TITLE
OSSM-6697 Fix duplicate caCertConfigMapName env var

### DIFF
--- a/build/patch-charts.sh
+++ b/build/patch-charts.sh
@@ -224,8 +224,6 @@ function patchGalley() {
 {{- end }}\
           - name: ENABLE_IOR\
             value: "{{ $iorEnabled }}"\
-          - name: PILOT_CA_CERT_CONFIG_MAP_NAME\
-            value: "{{ .Values.global.caCertConfigMapName }}"\
 {{- if .Values.gatewayAPI.enabled }}\
 {{- if .Values.gatewayAPI.controllerMode }}\
           - name: PILOT_ENABLE_GATEWAY_CONTROLLER_MODE\

--- a/resources/helm/v2.6/istio-control/istio-discovery/templates/deployment.yaml
+++ b/resources/helm/v2.6/istio-control/istio-discovery/templates/deployment.yaml
@@ -153,8 +153,6 @@ spec:
 {{- end }}
           - name: ENABLE_IOR
             value: "{{ $iorEnabled }}"
-          - name: PILOT_CA_CERT_CONFIG_MAP_NAME
-            value: "{{ .Values.global.caCertConfigMapName }}"
 {{- if .Values.gatewayAPI.enabled }}
 {{- if .Values.gatewayAPI.controllerMode }}
           - name: PILOT_ENABLE_GATEWAY_CONTROLLER_MODE
@@ -203,6 +201,10 @@ spec:
                 fieldPath: spec.serviceAccountName
           - name: KUBECONFIG
             value: /var/run/secrets/remote/config
+          {{- if .Values.global.caCertConfigMapName }}
+          - name: PILOT_CA_CERT_CONFIG_MAP_NAME
+            value: {{ .Values.global.caCertConfigMapName }}
+          {{- end }}
           {{- if .Values.pilot.env }}
           {{- range $key, $val := .Values.pilot.env }}
           - name: {{ $key }}


### PR DESCRIPTION
As part of #1035 I had to move the addition of the environment variable into the maistra/istio repository and forgot to update the patch script in the operator repo. Without the move, the field would not have been available during integration tests. In the past we usually made all chart changes in the patch script, but then we had to reimplement parts of that to simulate OSSM behavior in the maistra/istio integration tests, which I wanted to avoid.