### PR TITLE
[maistra-2.5] OSSM-6857 Ensure validating webhook works when both 2.x and 3.x are installed

### DIFF
--- a/build/patch-charts.sh
+++ b/build/patch-charts.sh
@@ -103,51 +103,6 @@ gatewayAPI:
 }
 
 function patchGalley() {
-  echo "patching Galley specific Helm charts"
-  # galley
-  # Webhooks are not namespaced!  we do this to ensure we're not setting owner references on them
-  # add namespace selectors
-  # remove define block
-  webhookconfig=${HELM_DIR}/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
-
-  # remove original objectSelector
-  sed_wrap -i '/.*objectSelector:/,/.*{{- end }}/d' "${webhookconfig}"
-
-  # replace namespaceSelector and insert maistra objectSelector
-  sed_wrap -i -e 's|\(\(^ *\)rules:\)|\2namespaceSelector:\
-\2  matchExpressions:\
-\2  - key: maistra.io/member-of\
-\2    operator: In\
-\2    values:\
-\2    - {{ .Release.Namespace }}\
-\2objectSelector:\
-\2  matchExpressions:\
-\2  - key: maistra-version\
-\2    operator: DoesNotExist\
-\1|' "${webhookconfig}"
-  sed_wrap -i -e '/rules:/ a\
-      - operations:\
-        - CREATE\
-        - UPDATE\
-        apiGroups:\
-        - authentication.maistra.io\
-        apiVersions:\
-        - "*"\
-        resources:\
-        - "*"\
-      - operations:\
-        - CREATE\
-        - UPDATE\
-        apiGroups:\
-        - rbac.maistra.io\
-        apiVersions:\
-        - "*"\
-        resources:\
-        - "*"' "${webhookconfig}"
-
-  # ensure resource updates fail if the webhook is offline
-  sed_wrap -i -e 's/failurePolicy: Ignore/failurePolicy: Fail/' "${webhookconfig}"
-
   # add name to webhook port (XXX: move upstream)
   # change the location of the healthCheckFile from /health to /tmp/health
   # add --validation-port=8443

--- a/resources/helm/overlays/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
+++ b/resources/helm/overlays/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
@@ -4,7 +4,6 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: istio-validator-{{ .Values.revision | default "default" }}-{{ .Release.Namespace }}
   labels:
-    maistra-version: "2.5.3"
     app: istiod
     release: {{ .Release.Name }}
     istio: istiod


### PR DESCRIPTION
When you install 3.x, the default version for some CRDs changes from e.g. v1beta1 to v1. This causes kubectl to default to using the v1 version. But this caused the validating webhook in 2.x to fail, because it was invoked with the v1 version of the resource, which it doesn't understand. The root cause was that the validatingwebhookconfiguration previously specified that it supports all apiVersions.

In this commit, we specify the actual apiVersions that the webhook supports. For example, for DestinationRules, the updated validatingwebhookconfiguration causes kubernetes to convert the DestinationRule from v1 to v1beta before invoking the webhook.