### PR TITLE
[maistra-2.4] OSSM-6857 Ensure validating webhook works when both 2.x and 3.x are installed

### DIFF
--- a/resources/helm/overlays/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
+++ b/resources/helm/overlays/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
@@ -4,7 +4,6 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: istio-validator-{{ .Values.revision | default "default" }}-{{ .Release.Namespace }}
   labels:
-    maistra-version: "2.4.9"
     app: istiod
     release: {{ .Release.Name }}
     istio: istiod


### PR DESCRIPTION
When you install 3.x, the default version for some CRDs changes from e.g. v1beta1 to v1. This causes kubectl to default to using the v1 version. But this caused the validating webhook in 2.x to fail, because it was invoked with the v1 version of the resource, which it doesn't understand. The root cause was that the validatingwebhookconfiguration previously specified that it supports all apiVersions.

In this commit, we specify the actual apiVersions that the webhook supports. For example, for DestinationRules, the updated validatingwebhookconfiguration causes kubernetes to convert the DestinationRule from v1 to v1beta before invoking the webhook.