### PR TITLE
OSSM-4055: Revert "OSSM-3986: Reconcile role bindings for Prometheus (#1194)"

### DIFF
--- a/pkg/controller/servicemesh/member/namespace_reconciler.go
+++ b/pkg/controller/servicemesh/member/namespace_reconciler.go
@@ -238,8 +238,14 @@ func (r *namespaceReconciler) reconcileNamespaceInMesh(ctx context.Context, name
 
 	allErrors := []error{}
 
-	if err := r.reconcileRoleBindings(ctx, namespace); err != nil {
-		allErrors = append(allErrors, err)
+	// if SMCP version is 2.4+ and cluster-wide mode is enabled, istiod is given
+	// cluster-wide permissions via ClusterRoleBindings, so there's no need to
+	// create RoleBindings in member namespaces
+	if !r.clusterWideMode || r.meshVersion.LessThan(versions.V2_4) {
+		err = r.reconcileRoleBindings(ctx, namespace)
+		if err != nil {
+			allErrors = append(allErrors, err)
+		}
 	}
 
 	if r.isCNIEnabled {
@@ -294,12 +300,6 @@ func (r *namespaceReconciler) reconcileRoleBindings(ctx context.Context, namespa
 		// since we don't copy Roles from istio-system to member namespace, there's no sense in copying RoleBindings
 		// that reference them; instead, we only need to copy RoleBindings that reference ClusterRoles
 		if meshRoleBinding.RoleRef.Kind == "Role" {
-			continue
-		}
-		// if cluster-wide mode is enabled, istiod is given cluster-wide permissions via ClusterRoleBindings,
-		// so there's no need to create RoleBindings in member namespaces, but we still have to create RoleBinding
-		// for Prometheus, otherwise it won't be able to scrape metrics from workloads in member namespaces.
-		if r.clusterWideMode && strings.HasPrefix(meshRoleBinding.Name, "istiod-") {
 			continue
 		}
 		roleBindingName := meshRoleBinding.GetName()


### PR DESCRIPTION
#1194 was merged, because we weren't sure if upstream Prometheus will be included in 2.4, but since it was, we can revert this fix and simplify roles reconciliation.