### PR TITLE
Remove the 2.5 SMCP option from the 2.6 SM drop-down

### DIFF
--- a/build/manifest-templates/clusterserviceversion.yaml
+++ b/build/manifest-templates/clusterserviceversion.yaml
@@ -200,7 +200,6 @@ __DEPLOYMENT_SPEC__
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:General'
           - 'urn:alm:descriptor:com.tectonic.ui:select:v2.6'
-          - 'urn:alm:descriptor:com.tectonic.ui:select:v2.5'
       - displayName: Control Plane Mode
         description: 'NOTE: only applies if version is v2.4 or higher'
         path: mode

--- a/manifests-maistra/2.6.11/maistraoperator.v2.6.11.clusterserviceversion.yaml
+++ b/manifests-maistra/2.6.11/maistraoperator.v2.6.11.clusterserviceversion.yaml
@@ -15,7 +15,7 @@ metadata:
       The Maistra Operator enables you to install, configure, and manage an instance of Maistra service mesh. Maistra is based on the open source Istio project.
 
     containerImage: quay.io/maistra/istio-ubi8-operator:2.6.0
-    createdAt: 2025-09-09T13:13:32CEST
+    createdAt: 2025-09-09T13:46:24CEST
     support: Red Hat, Inc. 
     olm.skipRange: ">=1.0.2 <2.6.11-0"
     operators.openshift.io/infrastructure-features: '[]'
@@ -616,7 +616,6 @@ spec:
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:General'
           - 'urn:alm:descriptor:com.tectonic.ui:select:v2.6'
-          - 'urn:alm:descriptor:com.tectonic.ui:select:v2.5'
       - displayName: Control Plane Mode
         description: 'NOTE: only applies if version is v2.4 or higher'
         path: mode

--- a/manifests-servicemesh/2.6.11/servicemeshoperator.v2.6.11.clusterserviceversion.yaml
+++ b/manifests-servicemesh/2.6.11/servicemeshoperator.v2.6.11.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
       The OpenShift Service Mesh 2 Operator enables you to install, configure, and manage an instance of Red Hat OpenShift Service Mesh 2.6 and earlier releases. OpenShift Service Mesh 2 is based on the open source Istio project.
 
     containerImage: ${OSSM_OPERATOR_IMAGE}
-    createdAt: 2025-09-09T13:13:36CEST
+    createdAt: 2025-09-09T13:46:27CEST
     support: Red Hat, Inc. 
     olm.skipRange: ">=1.0.2 <2.6.11-0"
     operators.openshift.io/infrastructure-features: '["Disconnected","fips"]'
@@ -621,7 +621,6 @@ spec:
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:General'
           - 'urn:alm:descriptor:com.tectonic.ui:select:v2.6'
-          - 'urn:alm:descriptor:com.tectonic.ui:select:v2.5'
       - displayName: Control Plane Mode
         description: 'NOTE: only applies if version is v2.4 or higher'
         path: mode


### PR DESCRIPTION
Same as for 2.4 before EOL: https://github.com/maistra/istio-operator/pull/1870