### PR TITLE
set Kiali CR cluster_wide_access to false always

### DIFF
--- a/resources/helm/overlays/istio-telemetry/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/overlays/istio-telemetry/kiali/templates/kiali-cr.yaml
@@ -13,6 +13,7 @@ spec:
     strategy: "openshift"
 
   deployment:
+    cluster_wide_access: false
     accessible_namespaces: []
 {{- if and .Values.kiali.hub .Values.kiali.image }}
     image_name: "{{ .Values.kiali.hub }}/{{ .Values.kiali.image }}"

--- a/resources/helm/v2.6/istio-telemetry/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/v2.6/istio-telemetry/kiali/templates/kiali-cr.yaml
@@ -15,6 +15,7 @@ spec:
     strategy: "openshift"
 
   deployment:
+    cluster_wide_access: false
     accessible_namespaces: []
 {{- if and .Values.kiali.hub .Values.kiali.image }}
     image_name: "{{ .Values.kiali.hub }}/{{ .Values.kiali.image }}"


### PR DESCRIPTION
fixes: https://issues.redhat.com/browse/OSSM-11635

The Kiali CRD Schema sets the default for cluster_wide_access to true. We need it always set to false to support multi-tenancy. Since accessible_namespaces is never set to "**" in Maistra/OSSM 2.x, setting this to false always is appropriate.