### PR TITLE
[OSSM-11635] Set kiali cluster_wide_access value according to SMCP mode

### DIFF
--- a/pkg/controller/servicemesh/controlplane/addons.go
+++ b/pkg/controller/servicemesh/controlplane/addons.go
@@ -56,6 +56,17 @@ func (r *controlPlaneInstanceReconciler) patchKiali(ctx context.Context, grafana
 		},
 	}
 
+	// SMCP mode cluster wide access
+	if r.Instance.Spec.Mode == maistrav2.ClusterWideMode {
+		if err := updatedKiali.Spec.SetField("deployment.cluster_wide_access", true); err != nil {
+			return common.RequeueWithError(errorOnSettingValueInKialiCR("deployment.cluster_wide_access", err))
+		}
+	} else {
+		if err := updatedKiali.Spec.SetField("deployment.cluster_wide_access", false); err != nil {
+			return common.RequeueWithError(errorOnSettingValueInKialiCR("deployment.cluster_wide_access", err))
+		}
+	}
+
 	// grafana
 	var grafanaURL string
 	if grafanaEnabled {

--- a/resources/helm/overlays/istio-telemetry/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/overlays/istio-telemetry/kiali/templates/kiali-cr.yaml
@@ -13,7 +13,6 @@ spec:
     strategy: "openshift"
 
   deployment:
-    cluster_wide_access: false
     accessible_namespaces: []
 {{- if and .Values.kiali.hub .Values.kiali.image }}
     image_name: "{{ .Values.kiali.hub }}/{{ .Values.kiali.image }}"

--- a/resources/helm/v2.6/istio-telemetry/kiali/templates/kiali-cr.yaml
+++ b/resources/helm/v2.6/istio-telemetry/kiali/templates/kiali-cr.yaml
@@ -15,7 +15,6 @@ spec:
     strategy: "openshift"
 
   deployment:
-    cluster_wide_access: false
     accessible_namespaces: []
 {{- if and .Values.kiali.hub .Values.kiali.image }}
     image_name: "{{ .Values.kiali.hub }}/{{ .Values.kiali.image }}"


### PR DESCRIPTION
Fix regression after https://github.com/maistra/istio-operator/pull/1880 where istio-operator generates invalid Kiali CR
```
  accessible_namespaces:
      **
  cluster_wide_access:  false
```
when SMCP mode is set to `ClusterWide`.
Since istio-operator manages also `accessible_namespaces` here https://github.com/maistra/istio-operator/blob/maistra-2.6/pkg/controller/servicemesh/memberroll/controller.go#L378 , hardcoded `cluster_wide_access:  false` in KialiCR is not possible.

The istio-operator should set `.spec.deployment.cluster_wide_access` in the created/managed KialiCR according to the value in SMCP `.spec.mode`, so:

| SMCP .spec.mode | Kiali .spec.deployment.cluster_wide_access |
| ------------- | ------------- |
| ClusterWide | true  |
| MultiTenant or empty  | false |

==============

Tested (with generated operator image quay.io/mkralik3/istio-operator:kiali) that
- [x] Correct Kiali CR (cluster_wide_access:  false) when SMCP `.spec.mode` is empty or `MultiTenant`
- [x] Correct Kiali CR (cluster_wide_access:  true) when SMCP `.spec.mode` is empty or `ClusterWide`
- [x] That update SMCP `.spec.mode` causes an update of Kiali CR
- [x] That older Kiali operator (`1.17.10`) can work with this as well ( since some customers can be on older Kiali operator ) 
- [x] Standalone Kiali CR is not touched 