### PR TITLE
Add test for setting cluster_wide_access

### DIFF
--- a/pkg/controller/servicemesh/controlplane/addons_test.go
+++ b/pkg/controller/servicemesh/controlplane/addons_test.go
@@ -114,7 +114,7 @@ func TestAddonsInstall(t *testing.T) {
 			},
 			create: IntegrationTestValidation{
 				Verifier: Verify("create").On("kialis").Named(kialiName).In(controlPlaneNamespace).
-					Passes(ExpectedKialiCreate(jaegerExistingName, domain, prometheusPasswordExpected)),
+					Passes(ExpectedKialiCreate(jaegerExistingName, domain, prometheusPasswordExpected, false)),
 				Assertions: ActionAssertions{
 					Assert("create").On("kialis").Named(kialiName).In(controlPlaneNamespace).IsSeen(),
 					Assert("create").On("jaegers").Named(jaegerName).In(controlPlaneNamespace).IsNotSeen(),
@@ -139,7 +139,7 @@ func TestAddonsInstall(t *testing.T) {
 			},
 			create: IntegrationTestValidation{
 				Verifier: Verify("patch").On("kialis").Named(kialiName).In(controlPlaneNamespace).
-					Passes(ExpectedKialiPatch(jaegerName, domain, true)),
+					Passes(ExpectedKialiPatch(jaegerName, domain, true, false)),
 				Assertions: ActionAssertions{
 					Assert("create").On("kialis").Named(kialiName).In(controlPlaneNamespace).IsNotSeen(),
 					Assert("create").On("jaegers").Named(jaegerName).In(controlPlaneNamespace).IsSeen(),
@@ -164,7 +164,7 @@ func TestAddonsInstall(t *testing.T) {
 			},
 			create: IntegrationTestValidation{
 				Verifier: Verify("patch").On("kialis").Named(kialiExistingName).In(controlPlaneNamespace).
-					Passes(ExpectedKialiPatch(jaegerExistingName, domain, prometheusPasswordExpected)),
+					Passes(ExpectedKialiPatch(jaegerExistingName, domain, prometheusPasswordExpected, false)),
 				Assertions: ActionAssertions{
 					Assert("create").On("kialis").Named(kialiName).In(controlPlaneNamespace).IsNotSeen(),
 					Assert("create").On("kialis").Named(kialiExistingName).In(controlPlaneNamespace).IsNotSeen(),
@@ -191,7 +191,7 @@ func TestAddonsInstall(t *testing.T) {
 			},
 			create: IntegrationTestValidation{
 				Verifier: Verify("patch").On("kialis").Named(kialiName).In(controlPlaneNamespace).
-					Passes(ExpectedKialiPatch(jaegerExistingName, domain, prometheusPasswordUnexpected)),
+					Passes(ExpectedKialiPatch(jaegerExistingName, domain, prometheusPasswordUnexpected, false)),
 				Assertions: ActionAssertions{
 					Assert("create").On("kialis").Named(kialiName).In(controlPlaneNamespace).IsNotSeen(),
 					Assert("create").On("jaegers").Named(jaegerName).In(controlPlaneNamespace).IsNotSeen(),
@@ -235,6 +235,106 @@ func TestAddonsInstall(t *testing.T) {
 				},
 			},
 			unsupportedVersions: []string{versions.V2_0.String(), versions.V2_1.String(), versions.V2_2.String()},
+		},
+		{
+			name: "kiali.install.cluster_wide",
+			smcp: newSMCPForKialiSMCPModeTest(maistrav2.ClusterWideMode),
+			create: IntegrationTestValidation{
+				Verifier: Verify("create").On("kialis").Named(kialiName).In(controlPlaneNamespace).
+					Passes(ExpectedKialiCreate(jaegerName, domain, prometheusPasswordExpected, true)),
+				Assertions: ActionAssertions{
+					Assert("create").On("kialis").Named(kialiName).In(controlPlaneNamespace).IsSeen(),
+				},
+			},
+			unsupportedVersions: []string{versions.V2_4.String(), versions.V2_5.String()},
+		},
+		{
+			name: "kiali.install.multi_tenant",
+			smcp: newSMCPForKialiSMCPModeTest(maistrav2.MultiTenantMode),
+			create: IntegrationTestValidation{
+				Verifier: Verify("create").On("kialis").Named(kialiName).In(controlPlaneNamespace).
+					Passes(ExpectedKialiCreate(jaegerName, domain, prometheusPasswordExpected, false)),
+				Assertions: ActionAssertions{
+					Assert("create").On("kialis").Named(kialiName).In(controlPlaneNamespace).IsSeen(),
+				},
+			},
+			unsupportedVersions: []string{versions.V2_4.String(), versions.V2_5.String()},
+		},
+		{
+			name: "kiali.existing.multi_tenant.patch.cluster_wide",
+			smcp: newSMCPForKialiSMCPModeTest(maistrav2.ClusterWideMode),
+			resources: []runtime.Object{
+				&kialiv1alpha1.Kiali{Base: external.Base{
+					ObjectMeta: metav1.ObjectMeta{Name: kialiName, Namespace: controlPlaneNamespace},
+					Spec: maistrav1.NewHelmValues(map[string]interface{}{
+						"deployment": map[string]interface{}{
+							"cluster_wide_access": false,
+						},
+					}),
+				}},
+			},
+			create: IntegrationTestValidation{
+				Verifier: Verify("patch").On("kialis").Named(kialiName).In(controlPlaneNamespace).
+					Passes(ExpectedKialiPatch(jaegerName, domain, prometheusPasswordExpected, true)),
+				Assertions: ActionAssertions{
+					Assert("create").On("kialis").Named(kialiName).In(controlPlaneNamespace).IsNotSeen(),
+				},
+			},
+			delete: IntegrationTestValidation{
+				Assertions: ActionAssertions{
+					Assert("delete").On("kialis").Named(kialiName).In(controlPlaneNamespace).IsNotSeen(),
+				},
+			},
+			unsupportedVersions: []string{versions.V2_4.String(), versions.V2_5.String()},
+		},
+		{
+			name: "kiali.existing.cluster_wide.patch.multi_tenant",
+			smcp: newSMCPForKialiSMCPModeTest(maistrav2.MultiTenantMode),
+			resources: []runtime.Object{
+				&kialiv1alpha1.Kiali{Base: external.Base{
+					ObjectMeta: metav1.ObjectMeta{Name: kialiName, Namespace: controlPlaneNamespace},
+					Spec: maistrav1.NewHelmValues(map[string]interface{}{
+						"deployment": map[string]interface{}{
+							"cluster_wide_access": true,
+						},
+					}),
+				}},
+			},
+			create: IntegrationTestValidation{
+				Verifier: Verify("patch").On("kialis").Named(kialiName).In(controlPlaneNamespace).
+					Passes(ExpectedKialiPatch(jaegerName, domain, prometheusPasswordExpected, false)),
+				Assertions: ActionAssertions{
+					Assert("create").On("kialis").Named(kialiName).In(controlPlaneNamespace).IsNotSeen(),
+				},
+			},
+			delete: IntegrationTestValidation{
+				Assertions: ActionAssertions{
+					Assert("delete").On("kialis").Named(kialiName).In(controlPlaneNamespace).IsNotSeen(),
+				},
+			},
+			unsupportedVersions: []string{versions.V2_4.String(), versions.V2_5.String()},
+		},
+		{
+			name: "kiali.existing.no_exist_cluster_wide_access.patch.multi_tenant",
+			smcp: newSMCPForKialiSMCPModeTest(maistrav2.MultiTenantMode),
+			resources: []runtime.Object{
+				&kialiv1alpha1.Kiali{Base: external.Base{
+					ObjectMeta: metav1.ObjectMeta{Name: kialiName, Namespace: controlPlaneNamespace},
+				}},
+			},
+			create: IntegrationTestValidation{
+				Verifier: Verify("patch").On("kialis").Named(kialiName).In(controlPlaneNamespace).
+					Passes(ExpectedKialiPatch(jaegerName, domain, prometheusPasswordExpected, false)),
+				Assertions: ActionAssertions{
+					Assert("create").On("kialis").Named(kialiName).In(controlPlaneNamespace).IsNotSeen(),
+				},
+			},
+			delete: IntegrationTestValidation{
+				Assertions: ActionAssertions{
+					Assert("delete").On("kialis").Named(kialiName).In(controlPlaneNamespace).IsNotSeen(),
+				},
+			},
+			unsupportedVersions: []string{versions.V2_4.String(), versions.V2_5.String()},
 		},
 	}
 
@@ -290,6 +390,12 @@ func newSMCPForKialiJaegerPrometheusDisabledTest(smcpName, kialiName, jaegerName
 	return smcp
 }
 
+func newSMCPForKialiSMCPModeTest(controlPlaneMode maistrav2.ControlPlaneMode) *maistrav2.ServiceMeshControlPlane {
+	smcp := NewSMCPForKialiJaegerTests("testSMCP", "kiali", "jaeger")
+	smcp.Spec.Mode = controlPlaneMode
+	return smcp
+}
+
 func NewSMCPForPrometheusGrafanaTests(smcpName string, grafanaHosts, prometheusHosts []string) *maistrav2.ServiceMeshControlPlane {
 	return NewV2SMCPResource(smcpName, controlPlaneNamespace, &maistrav2.ControlPlaneSpec{
 		Addons: &maistrav2.AddonsConfig{
@@ -322,12 +428,12 @@ func NewSMCPForPrometheusGrafanaTests(smcpName string, grafanaHosts, prometheusH
 	})
 }
 
-func ExpectedKialiCreate(jaegerName, domain string, foundPrometheusPassword bool) VerifierTestFunc {
+func ExpectedKialiCreate(jaegerName, domain string, foundPrometheusPassword bool, clusterWideAccessEnabled bool) VerifierTestFunc {
 	return func(action clienttesting.Action) error {
 		createAction := action.(clienttesting.CreateAction)
 		obj := createAction.GetObject()
 		kiali := obj.(*unstructured.Unstructured)
-		if err := VerifyKialiUpdate(jaegerName, domain, foundPrometheusPassword, maistrav1.NewHelmValues(kiali.Object)); err != nil {
+		if err := VerifyKialiUpdate(jaegerName, domain, foundPrometheusPassword, clusterWideAccessEnabled, maistrav1.NewHelmValues(kiali.Object)); err != nil {
 			fmt.Printf("kiali:\n%v\n", kiali)
 			return err
 		}
@@ -335,7 +441,7 @@ func ExpectedKialiCreate(jaegerName, domain string, foundPrometheusPassword bool
 	}
 }
 
-func ExpectedKialiPatch(jaegerName, domain string, foundPrometheusPassword bool) VerifierTestFunc {
+func ExpectedKialiPatch(jaegerName, domain string, foundPrometheusPassword bool, clusterWideAccessEnabled bool) VerifierTestFunc {
 	return func(action clienttesting.Action) error {
 		patchAction := action.(clienttesting.PatchAction)
 		if patchAction.GetPatchType() != types.MergePatchType {
@@ -346,7 +452,7 @@ func ExpectedKialiPatch(jaegerName, domain string, foundPrometheusPassword bool)
 			return err
 		}
 		patchValues := maistrav1.NewHelmValues(patch)
-		if err := VerifyKialiUpdate(jaegerName, domain, foundPrometheusPassword, patchValues); err != nil {
+		if err := VerifyKialiUpdate(jaegerName, domain, foundPrometheusPassword, clusterWideAccessEnabled, patchValues); err != nil {
 			fmt.Printf("patch:\n%s\n", string(patchAction.GetPatch()))
 			return err
 		}
@@ -354,7 +460,7 @@ func ExpectedKialiPatch(jaegerName, domain string, foundPrometheusPassword bool)
 	}
 }
 
-func VerifyKialiUpdate(jaegerName, domain string, foundPrometheusPassword bool, values *maistrav1.HelmValues) error {
+func VerifyKialiUpdate(jaegerName, domain string, foundPrometheusPassword bool, clusterWideAccessEnabled bool, values *maistrav1.HelmValues) error {
 	var allErrors []error
 	expectedGrafanaURL := "https://grafana." + domain
 	if url, _, _ := values.GetString("spec.external_services.grafana.url"); url != expectedGrafanaURL {
@@ -382,6 +488,9 @@ func VerifyKialiUpdate(jaegerName, domain string, foundPrometheusPassword bool, 
 		} else {
 			allErrors = append(allErrors, fmt.Errorf("expected prometheus password to not be set"))
 		}
+	}
+	if enabled, _, _ := values.GetBool("spec.deployment.cluster_wide_access"); enabled != clusterWideAccessEnabled {
+		allErrors = append(allErrors, fmt.Errorf("expected cluster wide access to be %t, got %t", clusterWideAccessEnabled, enabled))
 	}
 	if len(allErrors) > 0 {
 		return errors.NewAggregate(allErrors)

--- a/pkg/controller/servicemesh/controlplane/addons_test.go
+++ b/pkg/controller/servicemesh/controlplane/addons_test.go
@@ -55,14 +55,16 @@ type installAddonsTestCase struct {
 
 func TestAddonsInstall(t *testing.T) {
 	const (
-		smcpName                     = "test"
-		domain                       = "test.com"
-		kialiName                    = "kiali"
-		kialiExistingName            = "kiali-existing"
-		jaegerName                   = "jaeger"
-		jaegerExistingName           = "jaeger-existing"
-		prometheusPasswordExpected   = true
-		prometheusPasswordUnexpected = false
+		smcpName                        = "test"
+		domain                          = "test.com"
+		kialiName                       = "kiali"
+		kialiExistingName               = "kiali-existing"
+		jaegerName                      = "jaeger"
+		jaegerExistingName              = "jaeger-existing"
+		prometheusPasswordExpected      = true
+		prometheusPasswordUnexpected    = false
+		disabledClusterWideModeExpected = false
+		enabledClusterWideModeExpected  = true
 	)
 
 	if testing.Verbose() {
@@ -114,7 +116,7 @@ func TestAddonsInstall(t *testing.T) {
 			},
 			create: IntegrationTestValidation{
 				Verifier: Verify("create").On("kialis").Named(kialiName).In(controlPlaneNamespace).
-					Passes(ExpectedKialiCreate(jaegerExistingName, domain, prometheusPasswordExpected, false)),
+					Passes(ExpectedKialiCreate(jaegerExistingName, domain, prometheusPasswordExpected, disabledClusterWideModeExpected)),
 				Assertions: ActionAssertions{
 					Assert("create").On("kialis").Named(kialiName).In(controlPlaneNamespace).IsSeen(),
 					Assert("create").On("jaegers").Named(jaegerName).In(controlPlaneNamespace).IsNotSeen(),
@@ -139,7 +141,7 @@ func TestAddonsInstall(t *testing.T) {
 			},
 			create: IntegrationTestValidation{
 				Verifier: Verify("patch").On("kialis").Named(kialiName).In(controlPlaneNamespace).
-					Passes(ExpectedKialiPatch(jaegerName, domain, true, false)),
+					Passes(ExpectedKialiPatch(jaegerName, domain, prometheusPasswordExpected, disabledClusterWideModeExpected)),
 				Assertions: ActionAssertions{
 					Assert("create").On("kialis").Named(kialiName).In(controlPlaneNamespace).IsNotSeen(),
 					Assert("create").On("jaegers").Named(jaegerName).In(controlPlaneNamespace).IsSeen(),
@@ -164,7 +166,7 @@ func TestAddonsInstall(t *testing.T) {
 			},
 			create: IntegrationTestValidation{
 				Verifier: Verify("patch").On("kialis").Named(kialiExistingName).In(controlPlaneNamespace).
-					Passes(ExpectedKialiPatch(jaegerExistingName, domain, prometheusPasswordExpected, false)),
+					Passes(ExpectedKialiPatch(jaegerExistingName, domain, prometheusPasswordExpected, disabledClusterWideModeExpected)),
 				Assertions: ActionAssertions{
 					Assert("create").On("kialis").Named(kialiName).In(controlPlaneNamespace).IsNotSeen(),
 					Assert("create").On("kialis").Named(kialiExistingName).In(controlPlaneNamespace).IsNotSeen(),
@@ -191,7 +193,7 @@ func TestAddonsInstall(t *testing.T) {
 			},
 			create: IntegrationTestValidation{
 				Verifier: Verify("patch").On("kialis").Named(kialiName).In(controlPlaneNamespace).
-					Passes(ExpectedKialiPatch(jaegerExistingName, domain, prometheusPasswordUnexpected, false)),
+					Passes(ExpectedKialiPatch(jaegerExistingName, domain, prometheusPasswordUnexpected, disabledClusterWideModeExpected)),
 				Assertions: ActionAssertions{
 					Assert("create").On("kialis").Named(kialiName).In(controlPlaneNamespace).IsNotSeen(),
 					Assert("create").On("jaegers").Named(jaegerName).In(controlPlaneNamespace).IsNotSeen(),
@@ -241,7 +243,7 @@ func TestAddonsInstall(t *testing.T) {
 			smcp: newSMCPForKialiSMCPModeTest(maistrav2.ClusterWideMode),
 			create: IntegrationTestValidation{
 				Verifier: Verify("create").On("kialis").Named(kialiName).In(controlPlaneNamespace).
-					Passes(ExpectedKialiCreate(jaegerName, domain, prometheusPasswordExpected, true)),
+					Passes(ExpectedKialiCreate(jaegerName, domain, prometheusPasswordExpected, enabledClusterWideModeExpected)),
 				Assertions: ActionAssertions{
 					Assert("create").On("kialis").Named(kialiName).In(controlPlaneNamespace).IsSeen(),
 				},
@@ -253,7 +255,7 @@ func TestAddonsInstall(t *testing.T) {
 			smcp: newSMCPForKialiSMCPModeTest(maistrav2.MultiTenantMode),
 			create: IntegrationTestValidation{
 				Verifier: Verify("create").On("kialis").Named(kialiName).In(controlPlaneNamespace).
-					Passes(ExpectedKialiCreate(jaegerName, domain, prometheusPasswordExpected, false)),
+					Passes(ExpectedKialiCreate(jaegerName, domain, prometheusPasswordExpected, disabledClusterWideModeExpected)),
 				Assertions: ActionAssertions{
 					Assert("create").On("kialis").Named(kialiName).In(controlPlaneNamespace).IsSeen(),
 				},
@@ -275,7 +277,7 @@ func TestAddonsInstall(t *testing.T) {
 			},
 			create: IntegrationTestValidation{
 				Verifier: Verify("patch").On("kialis").Named(kialiName).In(controlPlaneNamespace).
-					Passes(ExpectedKialiPatch(jaegerName, domain, prometheusPasswordExpected, true)),
+					Passes(ExpectedKialiPatch(jaegerName, domain, prometheusPasswordExpected, enabledClusterWideModeExpected)),
 				Assertions: ActionAssertions{
 					Assert("create").On("kialis").Named(kialiName).In(controlPlaneNamespace).IsNotSeen(),
 				},
@@ -302,7 +304,7 @@ func TestAddonsInstall(t *testing.T) {
 			},
 			create: IntegrationTestValidation{
 				Verifier: Verify("patch").On("kialis").Named(kialiName).In(controlPlaneNamespace).
-					Passes(ExpectedKialiPatch(jaegerName, domain, prometheusPasswordExpected, false)),
+					Passes(ExpectedKialiPatch(jaegerName, domain, prometheusPasswordExpected, disabledClusterWideModeExpected)),
 				Assertions: ActionAssertions{
 					Assert("create").On("kialis").Named(kialiName).In(controlPlaneNamespace).IsNotSeen(),
 				},
@@ -324,7 +326,7 @@ func TestAddonsInstall(t *testing.T) {
 			},
 			create: IntegrationTestValidation{
 				Verifier: Verify("patch").On("kialis").Named(kialiName).In(controlPlaneNamespace).
-					Passes(ExpectedKialiPatch(jaegerName, domain, prometheusPasswordExpected, false)),
+					Passes(ExpectedKialiPatch(jaegerName, domain, prometheusPasswordExpected, disabledClusterWideModeExpected)),
 				Assertions: ActionAssertions{
 					Assert("create").On("kialis").Named(kialiName).In(controlPlaneNamespace).IsNotSeen(),
 				},

--- a/pkg/controller/servicemesh/controlplane/hooks.go
+++ b/pkg/controller/servicemesh/controlplane/hooks.go
@@ -171,9 +171,8 @@ func (r *controlPlaneInstanceReconciler) patchKialiConfig(ctx context.Context, o
 	if err != nil {
 		return fmt.Errorf("could not set tracing password in kiali CR: %s", err)
 	}
-	// SMCP mode cluster wide access
-	clusterWideAccess := r.Instance.Spec.Mode == maistrav2.ClusterWideMode
-	err = unstructured.SetNestedField(object.UnstructuredContent(), clusterWideAccess, "spec", "deployment", "cluster_wide_access")
+	smcpClusterWideAccess := r.Instance.Spec.Mode == maistrav2.ClusterWideMode
+	err = unstructured.SetNestedField(object.UnstructuredContent(), smcpClusterWideAccess, "spec", "deployment", "cluster_wide_access")
 	if err != nil {
 		return fmt.Errorf("could not set cluster_wide_access in kiali CR: %s", err)
 	}

--- a/pkg/controller/servicemesh/controlplane/hooks.go
+++ b/pkg/controller/servicemesh/controlplane/hooks.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/maistra/istio-operator/pkg/apis/maistra/status"
+	maistrav2 "github.com/maistra/istio-operator/pkg/apis/maistra/v2"
 	"github.com/maistra/istio-operator/pkg/controller/common"
 )
 
@@ -169,6 +170,12 @@ func (r *controlPlaneInstanceReconciler) patchKialiConfig(ctx context.Context, o
 	err = unstructured.SetNestedField(object.UnstructuredContent(), rawPassword, "spec", "external_services", "tracing", "auth", "password")
 	if err != nil {
 		return fmt.Errorf("could not set tracing password in kiali CR: %s", err)
+	}
+	// SMCP mode cluster wide access
+	clusterWideAccess := r.Instance.Spec.Mode == maistrav2.ClusterWideMode
+	err = unstructured.SetNestedField(object.UnstructuredContent(), clusterWideAccess, "spec", "deployment", "cluster_wide_access")
+	if err != nil {
+		return fmt.Errorf("could not set cluster_wide_access in kiali CR: %s", err)
 	}
 
 	return nil


### PR DESCRIPTION
Added tests after PR https://github.com/maistra/istio-operator/pull/1881 

- Fixed Kiali CR cluster_wide_access field to be correctly set based on SMCP mode during creation
- Added 5 new test cases for addon_test covering:
  - SMCP with ClusterWide mode
    - check that Kiali CR was created with `cluster_wide_access=true`
  - SMCP with MultiTenant mode
    - check that Kiali CR was created with `cluster_wide_access=false`
  - SMCP without any mode (no new test, this is implicitly test by the other tests)
    - check that Kiali CR was created with `cluster_wide_access=false`
  - Create Kiali CR with `cluster_wide_access=true` and than create SMCP with MultiTenant mode
    - check that Kiali CR was patched to  `cluster_wide_access=false`
  - Create Kiali CR with `cluster_wide_access=false` and than create SMCP with ClusterWide mode
    - check that Kiali CR was patched to  `cluster_wide_access=true`
  - Create Kiali CR without any `cluster_wide_access` and than create SMCP with MultiTenant mode
    - check that Kiali CR was patched to  `cluster_wide_access=false` 
