### PR TITLE
[OSSM-12223] Fix tmp invalid KialiCR after update MultiTenanty to ClusterWide in SMCP

### DIFF
--- a/pkg/controller/servicemesh/memberroll/controller.go
+++ b/pkg/controller/servicemesh/memberroll/controller.go
@@ -711,7 +711,23 @@ func (r *defaultKialiReconciler) reconcileKiali(ctx context.Context, kialiCRName
 		return pkgerrors.Wrapf(err, "cannot set deployment.accessible_namespaces in Kiali CR %s/%s", kialiCRNamespace, kialiCRName)
 	}
 
-	err = updatedKiali.Spec.SetStringSlice("api.namespaces.exclude", excludedNamespacesSet.List())
+	// if the accessible namespaces include "**", set the cluster wide access flag to true
+	// since other combination (like accessible_namespaces="**" and cluster_wide_access=false) are not allowed in Kiali operator and reconsilation fails
+	if accessibleNamespacesSet.Has("**") {
+		reqLogger.Info("Updating Kiali CR deployment.cluster_wide_access to true since accessible namespaces include **", "deployment.cluster_wide_access", true)
+		err = updatedKiali.Spec.SetField("deployment.cluster_wide_access", true)
+		if err != nil {
+			return pkgerrors.Wrapf(err, "cannot set deployment.cluster_wide_access in Kiali CR %s/%s", kialiCRNamespace, kialiCRName)
+		}
+	} else {
+		reqLogger.Info("Setting Kiali CR deployment.cluster_wide_access to false (no ** in accessible namespaces)",
+			"deployment.cluster_wide_access", false)
+		err = updatedKiali.Spec.SetField("deployment.cluster_wide_access", false)
+		if err != nil {
+			return pkgerrors.Wrapf(err, "cannot set deployment.cluster_wide_access in Kiali CR %s/%s", kialiCRNamespace, kialiCRName)
+		}
+	}
+
 	if err != nil {
 		return pkgerrors.Wrapf(err, "cannot set api.namespaces.exclude in Kiali CR %s/%s", kialiCRNamespace, kialiCRName)
 	}

--- a/pkg/controller/servicemesh/memberroll/controller_test.go
+++ b/pkg/controller/servicemesh/memberroll/controller_test.go
@@ -834,6 +834,11 @@ func TestReconcileKialiSetsClusterWideAccessWhenAccessibleNamespacesIsDoubleAste
 			accessibleNamespaces:      []string{"**", "bookinfo"},
 			expectedClusterWideAccess: true,
 		},
+		{
+			name:                      "cluster-wide-access-false-when-no-namespaces",
+			accessibleNamespaces:      []string{},
+			expectedClusterWideAccess: false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/controller/servicemesh/memberroll/controller_test.go
+++ b/pkg/controller/servicemesh/memberroll/controller_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -21,6 +22,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/maistra/istio-operator/pkg/apis/external"
+	kialiv1alpha1 "github.com/maistra/istio-operator/pkg/apis/external/kiali/v1alpha1"
 	"github.com/maistra/istio-operator/pkg/apis/maistra/status"
 	maistrav1 "github.com/maistra/istio-operator/pkg/apis/maistra/v1"
 	maistrav2 "github.com/maistra/istio-operator/pkg/apis/maistra/v2"
@@ -808,6 +811,86 @@ func TestKialiResource(t *testing.T) {
 			kialiReconciler.assertInvokedWith(t, tc.expectedAccessibleNamespaces, tc.expectedExcludedNamespaces)
 		})
 	}
+}
+
+func TestReconcileKialiSetsClusterWideAccessWhenAccessibleNamespacesIsDoubleAsterisk(t *testing.T) {
+	cases := []struct {
+		name                      string
+		accessibleNamespaces      []string
+		expectedClusterWideAccess bool
+	}{
+		{
+			name:                      "cluster-wide-access-true-when-double-asterisk",
+			accessibleNamespaces:      []string{"**"},
+			expectedClusterWideAccess: true,
+		},
+		{
+			name:                      "cluster-wide-access-false-when-regular-namespaces",
+			accessibleNamespaces:      []string{"bookinfo", "foo"},
+			expectedClusterWideAccess: false,
+		},
+		{
+			name:                      "cluster-wide-access-true-when-double-asterisk-with-other-namespaces",
+			accessibleNamespaces:      []string{"**", "bookinfo"},
+			expectedClusterWideAccess: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			kiali := newTestKiali()
+
+			s := scheme.Scheme
+			configureKialiScheme(s)
+
+			cl, _ := test.CreateClient(kiali)
+			kialiReconciler := &defaultKialiReconciler{Client: cl}
+
+			err := kialiReconciler.reconcileKiali(ctx, "kiali", controlPlaneNamespace, tc.accessibleNamespaces, []string{})
+			if err != nil {
+				t.Fatalf("reconcileKiali failed: %v", err)
+			}
+
+			updatedKiali := &kialiv1alpha1.Kiali{}
+			err = cl.Get(ctx, client.ObjectKey{Name: "kiali", Namespace: controlPlaneNamespace}, updatedKiali)
+			if err != nil {
+				t.Fatalf("Failed to get updated Kiali CR: %v", err)
+			}
+
+			clusterWideAccess, found, _ := updatedKiali.Spec.GetBool("deployment.cluster_wide_access")
+			assert.True(found, "Expected deployment.cluster_wide_access to be set", t)
+			assert.Equals(clusterWideAccess, tc.expectedClusterWideAccess, "Unexpected deployment.cluster_wide_access value", t)
+		})
+	}
+}
+
+func newTestKiali() *kialiv1alpha1.Kiali {
+	return &kialiv1alpha1.Kiali{
+		Base: external.Base{
+			ObjectMeta: meta.ObjectMeta{
+				Name:      "kiali",
+				Namespace: controlPlaneNamespace,
+			},
+			Spec: maistrav1.NewHelmValues(map[string]interface{}{
+				"deployment": map[string]interface{}{
+					"accessible_namespaces": []string{"initial"},
+				},
+				"api": map[string]interface{}{
+					"namespaces": map[string]interface{}{
+						"exclude": []string{},
+					},
+				},
+			}),
+		},
+	}
+}
+
+func configureKialiScheme(s *runtime.Scheme) {
+	kialiGroupVersion := schema.GroupVersion{
+		Group:   "kiali.io",
+		Version: "v1alpha1",
+	}
+	s.AddKnownTypes(kialiGroupVersion, &kialiv1alpha1.Kiali{})
 }
 
 func newSMCPClusterWide23() *maistrav2.ServiceMeshControlPlane {


### PR DESCRIPTION
The memberroll controller sets `accessible_namespaces` and `api.namespaces.exclude` according to the SMCP mode here: https://github.com/maistra/istio-operator/blob/maistra-2.6/pkg/controller/servicemesh/memberroll/controller.go#L377-L381 

When a new SMCP is created, there is no issue:
- The Maistra operator generates the Kiali Custom Resource (CR) without `cluster_wide_access` set. (since it is not in kiali cr helm template)
- The memberroll controller populates `accessible_namespaces`.
- The `addons.go` logic then sets the `cluster_wide_access` field explicitly. This sequence does not cause issues.

However, a temporary invalid Kiali CR state can occur when an existing MultiTenant SMCP is updated to ClusterWide mode. In this scenario:
- The Kiali CR already exists with `cluster_wide_access=false`.
- When the memberroll controller updates `accessible_namespaces` to `**`, the Kiali CR becomes temporarily invalid from the Kiali operator's perspective. ( because contains accessible_namespaces=** as well as cluster_wide_access=false )
- This invalid state persists until the `addons.go` logic patches the Kiali CR to set `cluster_wide_access=true`.


**Fix:**
Every time the memberroll controller sets `accessible_namespaces="**"`, it should set explicitly also `cluster_wide_access=true` 