### PR TITLE
[maistra-2.4] helm: add `maistra.io/managed: true` label to the validating webhook

### DIFF
--- a/resources/helm/overlays/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
+++ b/resources/helm/overlays/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
@@ -8,6 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     istio: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
+    maistra.io/managed: "true"
 webhooks:
   # Webhook handling per-revision validation. Mostly here so we can determine whether webhooks
   # are rejecting invalid configs on a per-revision basis.

--- a/resources/helm/v2.4/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
+++ b/resources/helm/v2.4/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
@@ -9,6 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     istio: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
+    maistra.io/managed: "true"
 webhooks:
   # Webhook handling per-revision validation. Mostly here so we can determine whether webhooks
   # are rejecting invalid configs on a per-revision basis.


### PR DESCRIPTION
This is a follow-up to #1887.